### PR TITLE
fix ## token pasting in macexpand: strip whitespace before paste point

### DIFF
--- a/sys/src/cmd/cc/macbody
+++ b/sys/src/cmd/cc/macbody
@@ -515,9 +515,13 @@ macexpand(Sym *s, char *b, int blen)
 		if(c == '#') {
 			/*
 			 * #### in macro definition means ## in source.
-			 * We skip it to join tokens.
+			 * Strip trailing whitespace from b before joining,
+			 * so that "CD ## a" with arg a="iCCP" produces
+			 * "CDiCCP" rather than "CD iCCP".
 			 */
 			if(*cp == '#') {
+				while(b > ob && b[-1] == ' ')
+					b--;
 				cp++;
 				continue;
 			}


### PR DESCRIPTION
macdef() stores the space preceding ## literally in the macro body. macexpand() was writing that space to the output buffer before detecting the #### (## encoded as 4 hashes) sequence, so "CD ## a" with arg a="iCCP" produced "CD iCCP" (two tokens) instead of "CDiCCP" (one token).

Fix: strip trailing whitespace from the output buffer before joining, matching the C99 requirement that ## discards surrounding whitespace.

This fixes the libpng build failure where PNG_CHUNK(iCCP, 14) failed to produce CDiCCP and thus could not be further expanded via the CDiCCP macro.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs