### PR TITLE
cpp/macro.c: fix substargs to use standard C preprocessor rescanning

### DIFF
--- a/sys/src/cmd/cpp/macro.c
+++ b/sys/src/cmd/cpp/macro.c
@@ -368,7 +368,7 @@ substargs(Nlist *np, Tokenrow *rtr, Tokenrow **atr, int hideset)
 {
 	Tokenrow ttr, rp, rn;
 	Token *tp, *ap, *an, *pp, *pn;
-	int ntok, argno, hs;
+	int ntok, argno;
 
 	for (rtr->tp=rtr->bp; rtr->tp<rtr->lp; ) {
 		if(rtr->tp->hideset && checkhideset(hideset, np)) {
@@ -416,21 +416,7 @@ substargs(Nlist *np, Tokenrow *rtr, Tokenrow **atr, int hideset)
 				insertrow(rtr, 1, &ttr);
 				free(ttr.bp);
 			} else {
-				maketokenrow(1, &ttr);
-				ttr.lp = ttr.tp + 1;
-				*ttr.tp = *rtr->tp;
-
-				hs = newhideset(rtr->tp->hideset, np);
-				if(hideset == 0)
-					ttr.tp->hideset = hs;
-				else
-					ttr.tp->hideset = unionhideset(hideset, hs);
-				expandrow(&ttr, (char*)np->name);
-				for(tp = ttr.bp; tp != ttr.lp; tp++)
-					if(tp->type == COMMA)
-						tp->type = XCOMMA;
-				insertrow(rtr, 1, &ttr);
-				dofree(ttr.bp);
+				rtr->tp++;
 			}
 		} else {
 			rtr->tp++;


### PR DESCRIPTION
The non-param NAME else branch in substargs was pre-expanding tokens inside substargs via a nested expandrow call. This caused the expansion chain CDiCCP -> LKMin -> LZ77Min to fail: CDiCCP was added to LZ77Min's hideset during premature expansion inside substargs, then the outer expandrow couldn't expand LZ77Min because it appeared already-visited.

Standard C preprocessor behavior (ISO C §6.10.3.4): non-param tokens in the replacement list are passed through substargs unchanged; the outer expandrow rescanning loop handles all further macro expansion. Replace the non-standard nested expandrow call with rtr->tp++ so that CDiCCP correctly rescans to LKMin, then LZ77Min, then its definition.

Fixes: repro_macro.c:8 name not declared: LZ77Min

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs