### PR TITLE
cpp/macro.c: add debug tracing to expandrow to diagnose LZ77Min skip

### DIFF
--- a/sys/src/cmd/cpp/macro.c
+++ b/sys/src/cmd/cpp/macro.c
@@ -147,14 +147,24 @@ expandrow(Tokenrow *trp, char *flag)
 		setsource(flag, -1, "");
 	for (i = 0; i < rowlen(trp); ) {
 		Token *tp = &trp->bp[i];
-		if (tp->type!=NAME
-		 || quicklook(tp->t[0], tp->len>1?tp->t[1]:0)==0
-		 || (np = lookup(tp, 0))==NULL
-		 || (np->flag&(ISDEFINED|ISMAC))==0
-		 || tp->hideset && checkhideset(tp->hideset, np)) {
-			i++;
-			continue;
+		if (tp->type!=NAME) { i++; continue; }
+		if (quicklook(tp->t[0], tp->len>1?tp->t[1]:0)==0) {
+			fprintf(stderr, "SKIP quicklook fail: %.*s\n", tp->len, tp->t);
+			i++; continue;
 		}
+		if ((np = lookup(tp, 0))==NULL) {
+			fprintf(stderr, "SKIP lookup fail: %.*s\n", tp->len, tp->t);
+			i++; continue;
+		}
+		if ((np->flag&(ISDEFINED|ISMAC))==0) {
+			fprintf(stderr, "SKIP notdef: %.*s\n", tp->len, tp->t);
+			i++; continue;
+		}
+		if (tp->hideset && checkhideset(tp->hideset, np)) {
+			fprintf(stderr, "SKIP hideset: %.*s\n", tp->len, tp->t);
+			i++; continue;
+		}
+		fprintf(stderr, "EXPAND: %.*s\n", tp->len, tp->t);
 		trp->tp = tp;
 		if (np->val==KDEFINED) {
 			tp->type = DEFINED;


### PR DESCRIPTION
Temporary diagnostic: print which condition causes each NAME token to be skipped in expandrow. To be reverted once the bug is identified.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs