### PR TITLE
cpp: debug tracing to diagnose LZ77Min macro expansion failure

### DIFF
--- a/sys/src/cmd/cpp/macro.c
+++ b/sys/src/cmd/cpp/macro.c
@@ -147,14 +147,24 @@ expandrow(Tokenrow *trp, char *flag)
 		setsource(flag, -1, "");
 	for (i = 0; i < rowlen(trp); ) {
 		Token *tp = &trp->bp[i];
-		if (tp->type!=NAME
-		 || quicklook(tp->t[0], tp->len>1?tp->t[1]:0)==0
-		 || (np = lookup(tp, 0))==NULL
-		 || (np->flag&(ISDEFINED|ISMAC))==0
-		 || tp->hideset && checkhideset(tp->hideset, np)) {
-			i++;
-			continue;
+		if (tp->type!=NAME) { i++; continue; }
+		if (quicklook(tp->t[0], tp->len>1?tp->t[1]:0)==0) {
+			fprintf(stderr, "SKIP ql: %.*s\n", tp->len, tp->t);
+			i++; continue;
 		}
+		if ((np = lookup(tp, 0))==NULL) {
+			fprintf(stderr, "SKIP np: %.*s\n", tp->len, tp->t);
+			i++; continue;
+		}
+		if ((np->flag&(ISDEFINED|ISMAC))==0) {
+			fprintf(stderr, "SKIP def: %.*s\n", tp->len, tp->t);
+			i++; continue;
+		}
+		if (tp->hideset && checkhideset(tp->hideset, np)) {
+			fprintf(stderr, "SKIP hs: %.*s hs=%d\n", tp->len, tp->t, tp->hideset);
+			i++; continue;
+		}
+		fprintf(stderr, "EXPAND: %.*s hs=%d flag=%s\n", tp->len, tp->t, tp->hideset, flag?flag:"(main)");
 		trp->tp = tp;
 		if (np->val==KDEFINED) {
 			tp->type = DEFINED;
@@ -195,6 +205,7 @@ expand(Tokenrow *trp, Nlist *np)
 	Tokenrow ntr;
 	Token *tp;
 
+	fprintf(stderr, "expand(): macro=%.*s hs=%d\n", np->len, np->name, trp->tp->hideset);
 	copytokenrow(&ntr, np->vp);		/* copy macro value */
 	if (np->ap==NULL) {			/* parameterless */
 		ntokc = 1;
@@ -234,6 +245,7 @@ expand(Tokenrow *trp, Nlist *np)
 	hs = newhideset(trp->tp->hideset, np);
 	for (tp=ntr.bp; tp<ntr.lp; tp++) {	/* distribute hidesets */
 		if (tp->type==NAME) {
+			fprintf(stderr, "  hideset: %.*s gets hs=%d (was %d)\n", tp->len, tp->t, hs, tp->hideset);
 			if (tp->hideset==0)
 				tp->hideset = hs;
 			else
@@ -455,6 +467,8 @@ glue(Tokenrow *ntr, Token *tp, Token *tn)
 		}
 		ntr->lp = ntr->bp+1;
 	}
+	fprintf(stderr, "GLUE: '%.*s' ## '%.*s' -> '%.*s'\n",
+		np, tt, nn, tt+np, np+nn, tt);
 	makespace(ntr);	/* makespace copies tp->t before we free tt */
 	dofree(tt);
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `fprintf(stderr)` diagnostic traces to `sys/src/cmd/cpp/macro.c` to pinpoint why `LZ77Min` fails to expand in the `PNG_KNOWN_CHUNKS → PNG_CHUNK(iCCP,14) → CDiCCP → LKMin → LZ77Min` chain
- Traces added to: `expandrow()` (skip reason per token), `expand()` (which macro + hideset), `glue()` (## paste input/output), and the hideset distribution loop

## How to test

1. Rebuild cpp: `cd sys/src/cmd/cpp && mk nuke && mk install`
2. Run on the failing file and capture stderr:
   ```
   pcc -E sys/src/external/libpng/pngrutil.c 2>debug.txt
   grep -E 'LZ77|LKMin|CDiCCP|GLUE.*iCCP' debug.txt | head -50
   ```
3. Or use a minimal repro:
   ```
   echo '#define LZ77Min 11U
   #define LKMin (3U + LZ77Min)
   #define CDiCCP NoCheck, LKMin, hCOL, hIHDR, 0
   #define PNG_CHUNK(cHNK, index) { png_handle_ ## cHNK, CD ## cHNK },
   PNG_CHUNK(iCCP, 14)' | /bin/cpp 2>debug.txt
   cat debug.txt
   ```

Key things to look for:
- Does `GLUE: 'CD' ## 'iCCP' -> 'CDiCCP'` appear?
- Does `expand(): macro=CDiCCP` appear?
- Does `hideset: LKMin gets hs=N` appear?
- Does `expand(): macro=LKMin` → `hideset: LZ77Min gets hs=N` appear?
- Does `SKIP hs: LZ77Min` appear (blocked by hideset)?
- Does `SKIP ql: LZ77Min` or `SKIP np: LZ77Min` appear?

## Note

This PR contains only diagnostic instrumentation — the debug output goes to stderr (not stdout), so preprocessed output is unaffected. Once the bug is identified, a follow-up commit will remove the debug traces and add the actual fix.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs)_