### PR TITLE
cfront-C4: fix three libc++ build issues

### DIFF
--- a/sys/src/external/cfront-C4/README.md
+++ b/sys/src/external/cfront-C4/README.md
@@ -173,10 +173,18 @@ gcc -E -I$SRC -I$INCL -D__HAVE_SIZE_T -D__cfront__ -D__cplusplus=1 \
 
 3. **FILE\* globals initialised to NULL** — `lex.c` has `void *out_file = 0`
    because cfront could not evaluate `stdout` at translation time. Fixed in
-   `cfront_stubs.c`: `_main()` (called by cfront's generated startup code
-   before user `main()`) calls `early_init()` which sets `out_file = stdout`
+   `cfront_stubs.c`: `__cfront_pre_main()` (called by cfront's generated startup
+   code before user `main()`) calls `early_init()` which sets `out_file = stdout`
    and `in_file = stdin`. Note: `__attribute__((constructor))` is NOT used
    because Plan 9's pcc does not support GCC constructor attributes.
+
+   **Important:** The function was originally named `_main()` but was renamed to
+   `__cfront_pre_main()` because on Plan 9/APE, `TEXT _main(SB)` in `main9.s`
+   (libap.a) is the **process entry point** — not a C function. Linking a C
+   `_main()` object causes it to override the APE assembly startup, leaving
+   the runtime uninitialised (signal tables, stdio, etc.), so any library call
+   crashes immediately (fault at addr 0x1/0x2). The rename affects four files:
+   `cfront_stubs.c`, `main.c`, `print2.c`, and `tools/munch/_main.c`.
 
 4. **`setbuf` crash in `error_init`** — the old `incl/stdio.h` defined `FILE`
    as `void`, so the struct layout differed from the 64-bit system FILE.
@@ -209,7 +217,7 @@ stdin → lex (lalex.c/lex.c) → parse (y.tab.c / gram.y)
 
 | File | Role |
 |------|------|
-| `cfront_stubs.c` | Runtime shims: `_main`, `__vec_new/delete`, early init. Compile WITHOUT `-I../incl`. |
+| `cfront_stubs.c` | Runtime shims: `__cfront_pre_main`, `__vec_new/delete`, early init. Compile WITHOUT `-I../incl`. |
 | `_stdio.c` | `_get_stdin/stdout/stderr()`. Compile WITHOUT `-I../incl`. |
 | `main.c` | Entry point: `error_init → otbl_init → lex_init → syn_init → typ_init → simpl_init → run`. |
 | `y.tab.c` | Parser (yacc output from `gram.y`). Grammar is the entry point for new features. |

--- a/sys/src/external/cfront-C4/lib/complex/mkfile
+++ b/sys/src/external/cfront-C4/lib/complex/mkfile
@@ -8,7 +8,7 @@ OFILES=abs.$O arg.$O cos.$O error.$O exp.$O io.$O \
 </sys/src/cmd/mksyslib
 
 CXXINCL=/sys/include/ape/c++
-CFLAGS=-FV -I./complex
+CFLAGS=-c -B -D_POSIX_SOURCE -D_BSD_EXTENSION
 CC=pcc
 
 %.c: complex/%.cpp

--- a/sys/src/external/cfront-C4/lib/generic/mkfile
+++ b/sys/src/external/cfront-C4/lib/generic/mkfile
@@ -7,7 +7,7 @@ OFILES=generic.$O
 </sys/src/cmd/mksyslib
 
 CXXINCL=/sys/include/ape/c++
-CFLAGS=-FV -I.
+CFLAGS=-c -B -D_POSIX_SOURCE -D_BSD_EXTENSION
 CC=pcc
 
 %.c: %.cpp

--- a/sys/src/external/cfront-C4/lib/new/mkfile
+++ b/sys/src/external/cfront-C4/lib/new/mkfile
@@ -2,13 +2,13 @@
 
 LIB=/$objtype/lib/ape/libc++.a
 
-OFILES=_arr_map.$O _delete.$O _handler.$O _main.$O \
+OFILES=_arr_map.$O _delete.$O _handler.$O \
 	_new.$O _vec.$O placenew.$O
 
 </sys/src/cmd/mksyslib
 
 CXXINCL=/sys/include/ape/c++
-CFLAGS=-FV -I.
+CFLAGS=-c -B -D_POSIX_SOURCE -D_BSD_EXTENSION
 CC=pcc
 
 %.c: %.cpp

--- a/sys/src/external/cfront-C4/lib/static/mkfile
+++ b/sys/src/external/cfront-C4/lib/static/mkfile
@@ -7,7 +7,7 @@ OFILES=_ctor.$O _dtor.$O pure.$O
 </sys/src/cmd/mksyslib
 
 CXXINCL=/sys/include/ape/c++
-CFLAGS=-FV -I.
+CFLAGS=-c -B -D_POSIX_SOURCE -D_BSD_EXTENSION
 CC=pcc
 
 %.c: %.cpp

--- a/sys/src/external/cfront-C4/lib/stream/mkfile
+++ b/sys/src/external/cfront-C4/lib/stream/mkfile
@@ -10,7 +10,7 @@ OFILES=cstreams.$O filebuf.$O flt.$O fstream.$O in.$O \
 </sys/src/cmd/mksyslib
 
 CXXINCL=/sys/include/ape/c++
-CFLAGS=-FV -I.
+CFLAGS=-c -B -D_POSIX_SOURCE -D_BSD_EXTENSION
 CC=pcc
 
 # stream sources include local headers from this directory

--- a/sys/src/external/cfront-C4/lib/string/mkfile
+++ b/sys/src/external/cfront-C4/lib/string/mkfile
@@ -10,7 +10,7 @@ OFILES=string.$O
 </sys/src/cmd/mksyslib
 
 CXXINCL=/sys/include/ape/c++
-CFLAGS=-FV -I.
+CFLAGS=-c -B -D_POSIX_SOURCE -D_BSD_EXTENSION
 CC=pcc
 
 # string.cpp is plain C++ that includes h/string.h — compile with driver

--- a/sys/src/external/cfront-C4/src/cfront_stubs.c
+++ b/sys/src/external/cfront-C4/src/cfront_stubs.c
@@ -32,7 +32,7 @@ static void early_init(void) {
     in_file = stdin;
 }
 
-void _main(void) { early_init(); }
+void __cfront_pre_main(void) { early_init(); }
 
 /* ------------------------------------------------------------------ */
 /* EH runtime: setjmp/longjmp exception handling for cfront            */

--- a/sys/src/external/cfront-C4/src/main.c
+++ b/sys/src/external/cfront-C4/src/main.c
@@ -3120,8 +3120,8 @@ extern void simpl_init__Fv(void);
 extern int error__FPCc(const char *);
 
 int main(int __1argc, char **__1argv) {
-    extern void _main();
-    _main();
+    extern void __cfront_pre_main(void);
+    __cfront_pre_main();
     {
         char *__1cp;
         const char *__1afile;

--- a/sys/src/external/cfront-C4/src/print2.c
+++ b/sys/src/external/cfront-C4/src/print2.c
@@ -4059,7 +4059,7 @@ void print_body__FP3fct(Pfct __1f) {
         }
 
         if (MAIN) {
-            fputs((const char *)"{ extern void _main(); _main(); ", out_file);
+            fputs((const char *)"{ extern void __cfront_pre_main(); __cfront_pre_main(); ", out_file);
             print__4stmtFv((struct stmt *)__1f->body__3fct);
             puttok__FUc((unsigned char)74);
         } else

--- a/sys/src/external/cfront-C4/tools/munch/_main.c
+++ b/sys/src/external/cfront-C4/tools/munch/_main.c
@@ -7,10 +7,10 @@ extern int atexit(void*);
 extern PFV _ctors[];
 extern void __dtors();
 
-void _main()
+void __cfront_pre_main()
 {
     atexit((PFV)__dtors);
-    
+
     PFV* pf=_ctors;
     for (; *pf; pf++) (**pf)();
 }


### PR DESCRIPTION
1. Rename _main → __cfront_pre_main (cfront_stubs.c, main.c, print2.c, tools/munch/_main.c): on Plan 9/APE, TEXT _main(SB) in main9.s is the process entry point. A C _main() object overrides it, leaving the APE runtime uninitialised; any library call crashes immediately (fault at addr 0x1/0x2). Renamed in all four locations including the string emitted by print2.c for every generated C++ main() wrapper.

2. Fix CFLAGS in all six lib/ mkfiles: replace non-existent -FV flag with -c -B -D_POSIX_SOURCE -D_BSD_EXTENSION. Without -c, pcc tries to link each generated .c file and fails with "no main()".

3. Remove _main.$O from lib/new/mkfile OFILES: no _main.cpp source exists in lib/new/; the constructor-calling _main for user programs lives in tools/munch/_main.c (now renamed to __cfront_pre_main).

https://claude.ai/code/session_01X3op4VKV9ZjgjvG4Cyhoev