### PR TITLE
cfront-C4: fix libc++ build pipeline (pcc .cpp extension, c++ driver, szal, munch)

### DIFF
--- a/sys/src/cmd/pcc.c
+++ b/sys/src/cmd/pcc.c
@@ -133,7 +133,11 @@ main(int argc, char *argv[])
 			suf = utfrrune(s, '.');
 			if(suf) {
 				suf++;
-				if(strcmp(suf, "c") == 0) {
+				if(strcmp(suf, "c") == 0 ||
+					   strcmp(suf, "cpp") == 0 ||
+					   strcmp(suf, "cxx") == 0 ||
+					   strcmp(suf, "cc") == 0 ||
+					   strcmp(suf, "C") == 0) {
 					append(&srcs, s);
 					append(&objs, changeext(s, ot->o));
 				} else if(strcmp(suf, ot->o) == 0 ||

--- a/sys/src/external/cfront-C4/tools/CC-driver/c++
+++ b/sys/src/external/cfront-C4/tools/CC-driver/c++
@@ -161,9 +161,14 @@ if(~ $#sources 0 && ~ $#cfiles 0 && ~ $#objects 0) usage
 # ---- -E: preprocess only ----
 if(! ~ $eflag '') {
 	for(src in $sources) {
+		base = `{basename $src | sed 's/\.\(cpp\|cxx\|cc\|C\)$//'}
+		# pcc only accepts .c extension; copy source to a temp .c file
+		tmpc = /tmp/cxx.$pid.$base.c
+		cp $src $tmpc
 		if(! ~ $vflag '')
 			echo $CC -E -I$CXXINCL $iflags $dflags '-D__cplusplus=1' '-Dc_plusplus=1' $src >/fd/2
-		$CC -E -I$CXXINCL $iflags $dflags '-D__cplusplus=1' '-Dc_plusplus=1' $src
+		$CC -E -I$CXXINCL $iflags $dflags '-D__cplusplus=1' '-Dc_plusplus=1' $tmpc
+		rm -f $tmpc
 		if(! ~ $status 0) exit $status
 	}
 	exit 0
@@ -200,9 +205,12 @@ for(src in $sources) {
 	}
 
 	# 1. Preprocess
+	# pcc only accepts .c extension; copy source to a temp .c file
+	csrc = $tmpdir/$base.src.c
+	cp $src $csrc
 	if(! ~ $vflag '')
 		echo $CC -E -I$CXXINCL $iflags $dflags '-D__cplusplus=1' '-Dc_plusplus=1' $src >/fd/2
-	$CC -E -I$CXXINCL $iflags $dflags '-D__cplusplus=1' '-Dc_plusplus=1' $src > $pp
+	$CC -E -I$CXXINCL $iflags $dflags '-D__cplusplus=1' '-Dc_plusplus=1' $csrc > $pp
 	if(! ~ $status 0) { cleanup; exit $status }
 
 	# 2. ns_strip (namespace preprocessor)

--- a/sys/src/external/cfront-C4/tools/szal/szal.c
+++ b/sys/src/external/cfront-C4/tools/szal/szal.c
@@ -113,9 +113,16 @@ int main()
 		long i = 1;
 		while (i) { i<<=1; i&=~1; i2++; }
 	}
+	else if (sizeof(struct st5) == sizeof(long long)) {
+		/* Plan 9 kencc on amd64: int :0 aligns to pointer size (8 bytes),
+		   not sizeof(int) (4 bytes), so sizeof(st5)==8 falls through above */
+		unsigned long long li = 1;
+		while (li) { li<<=1; li&=~1ULL; i2++; }
+	}
 	else {
 		fprintf(stderr,"Warning: Your C compiler probably handles 0 lengths fields wrong\n");
-		i = sizeof(int);
+		/* fall back to int-sized word so DBI_IN_WORD is non-zero */
+		{ int fi = 1; while (fi) { fi<<=1; fi&=~1; i2++; } }
 	}
 
 	out("#define DBI_IN_WORD",i2);


### PR DESCRIPTION
## Summary

- **Root cause fix (`sys/src/cmd/pcc.c`):** `pcc -E` silently discarded `.cpp`/`.cxx`/`.cc`/`.C` files (only `.c` was accepted), producing 0-byte preprocessed output, which caused cfront to emit 0-byte generated C files. Extended the suffix check to accept all C++ extensions.

- **`c++` driver script:** Replace `>[1=2]` with `>/fd/2` (rc stderr redirect syntax that works on all Plan 9 builds); quote `-D__cplusplus=1`/`-Dc_plusplus=1`; add `cp $src $csrc` workaround (renames `.cpp` to `.src.c` in tmpdir) so preprocessing works even with the pre-fix `pcc` binary. Temp file names use distinct suffixes (`.src.c`, `.pp.c`, `.ns.c`, `.cf.c`) to avoid collisions.

- **`CC-driver/mkfile`:** Fix `APEXPROOT` path depth (`../../../../..` → `../../../../../..`; was resolving to `sys/` instead of repo root).

- **`szal.c`:** (1) kencc cannot `sizeof` structs containing only anonymous bitfields — add dummy named members (`_x`, `_y`). (2) On Plan 9 amd64, `int :0` aligns to pointer size (8 bytes), so `sizeof(struct { char a; int :0; })` = 8, falling through all detection cases and leaving `DBI_IN_WORD 0`. Add `sizeof(long long)` case and a fallback that always sets a non-zero value.

- **`munch/init.c` (new):** `_main.c` and `dtors.c` reference `_ctors[]`/`_dtors[]` as `extern` but neither defines them; munch-generated `_ctdt.c` provides these for user programs but not for the munch binary itself. Add empty stub definitions so munch links.

- **`tools/mkfile`:** Remove `patch` from `DIRS`; it depends on SVr4 COFF headers (`<filehdr.h>`, `<ldfcn.h>`, etc.) and rewrites COFF `__link` chains — completely inapplicable to Plan 9 a.out. Mark as `broken=patch`.

- **`lib/mkfile`:** Add `static` and `string` to the build dirs list.

- **`lib/complex/mkfile`:** Remove `/complex` suffix artifact left by a previous sed pass on CFLAGS.

- **`lib/new/mkfile`:** Remove `_main.$O` from `OFILES` (no `_main.cpp` exists in `lib/new/`).

## Test plan

- [ ] `cd sys/src/cmd && mk install` — rebuilds `pcc` with `.cpp` extension support
- [ ] `cd sys/src/external/cfront-C4/tools && mk install` — builds cfront tools (szal, munch, demangler, pt, CC-driver)
- [ ] `cd sys/src/external/cfront-C4/lib && mk install` — generated `.c` files should now be non-empty; libc++ library should build successfully
- [ ] Verify `szal` output includes a non-zero `DBI_IN_WORD` value

https://claude.ai/code/session_01X3op4VKV9ZjgjvG4Cyhoev

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3op4VKV9ZjgjvG4Cyhoev)_