### PR TITLE
cfront table.c: extend string guards to reject small/invalid pointer …

### DIFF
--- a/sys/src/external/cfront-C4/src/table.c
+++ b/sys/src/external/cfront-C4/src/table.c
@@ -1242,7 +1242,7 @@ Pname look__5tableFPCcUc(register struct table *__0this, const char *__1s, TOK _
             if (__1n == 0)
                 error__FiPCc((int)'i', (const char *)"hashed lookup");
             __1p = __1n->__O2__4expr.string;
-            if (__1p == 0) goto nxt;    /* skip corrupt null-string entry */
+            if (__1p == 0 || (unsigned long long)__1p < 0x10000ULL) goto nxt;
             __1q = __1s;
             while (((*__1p)) && ((*__1q)))
                 if (((*(__1p++))) != ((*(__1q++))))
@@ -1349,6 +1349,7 @@ Pname insert__5tableFP4nameUc(register struct table *__0this, Pname __1nx, TOK _
         if (__1n == 0)
             error__FiPCc((int)'i', (const char *)"hashed lookup");
         if (__1n->__O2__4expr.string != 0 &&
+                (unsigned long long)__1n->__O2__4expr.string >= 0x10000ULL &&
                 strcmp(__1n->__O2__4expr.string, __1s) == 0)
             goto found;
 
@@ -1448,7 +1449,7 @@ void grow__5tableFi(register struct table *__0this, int __1g) {
         int __2firsti;
 
         __2s = (__1np[__1j])->__O2__4expr.string;
-        if (__2s == 0) continue;    /* skip corrupt null-string entries during rehash */
+        if (__2s == 0 || (unsigned long long)__2s < 0x10000ULL) continue;    /* skip corrupt null-string entries during rehash */
 
         __2p = __2s;
         __2i = 0;
@@ -1467,7 +1468,7 @@ void grow__5tableFi(register struct table *__0this, int __1g) {
             if (__1n == 0)
                 error__FiPCc((int)'i', (const char *)"hashed lookup");
             __2p = __1n->__O2__4expr.string;
-            if (__2p == 0) goto nxt;    /* skip corrupt null-string entry */
+            if (__2p == 0 || (unsigned long long)__2p < 0x10000ULL) goto nxt;
             __2q = __2s;
             while (((*__2p)) && ((*__2q)))
                 if (((*(__2p++))) != ((*(__2q++))))
@@ -1604,7 +1605,7 @@ Pname look__6ktableFPCcUc(register struct ktable *__0this, const char *__1s, TOK
                 __2n = __0this->__O1__6ktable.k_n;
 
                 for (; __2n; __2n = __2n->n_tbl_list__4name) {
-                    if (__2n->__O2__4expr.string == 0) continue; /* skip null-string entries */
+                    if (__2n->__O2__4expr.string == 0 || (unsigned long long)__2n->__O2__4expr.string < 0x10000ULL) continue;
                     if ((((((*__2n->__O2__4expr.string)) == ((*__1s)))
                               ? strcmp(__2n->__O2__4expr.string, __1s)
                               : -1) == 0) &&
@@ -1668,8 +1669,8 @@ Pname insert__6ktableFP4nameUc(register struct ktable *__0this, Pname __1nn, TOK
                     __3n = __0this->__O1__6ktable.k_n;
 
                     for (; __3n; __3n = __3n->n_tbl_list__4name) {
-                        if (__3n->__O2__4expr.string == 0 ||
-                            __1nn->__O2__4expr.string == 0) continue; /* skip null-string entries */
+                        if (__3n->__O2__4expr.string == 0 || (unsigned long long)__3n->__O2__4expr.string < 0x10000ULL ||
+                            __1nn->__O2__4expr.string == 0 || (unsigned long long)__1nn->__O2__4expr.string < 0x10000ULL) continue;
                         if ((((((*__3n->__O2__4expr.string)) == ((*__1nn->__O2__4expr.string)))
                                   ? strcmp(__3n->__O2__4expr.string, __1nn->__O2__4expr.string)
                                   : -1) == 0) &&


### PR DESCRIPTION
…values

The union __Q2_4expr4__C2 stores either a string pointer or an integer (i1) in the same 8 bytes. When an enum constant (e.g. eofbit=1, failbit=2, badbit=4) is stored as i1, reading it as .string gives a non-null but unmapped address, causing a GPF in the string comparison loops.

Extend all five null-string guards from `== 0` to
`== 0 || (unsigned long long)ptr < 0x10000ULL` so small integer values (all enum constants in iostream.h are < 0x10000) are also skipped.

Sites updated:
- look__5tableFPCcUc probe loop
- insert__5tableFP4nameUc collision loop
- grow__5tableFi: outer entry loop + inner probe loop
- look__6ktableFPCcUc tiny-list loop
- insert__6ktableFP4nameUc tiny-list loop

https://claude.ai/code/session_01X3op4VKV9ZjgjvG4Cyhoev