### PR TITLE
cfront table.c: use signed (long long) guard to also catch negative i…

### DIFF
--- a/sys/src/external/cfront-C4/src/table.c
+++ b/sys/src/external/cfront-C4/src/table.c
@@ -1242,7 +1242,7 @@ Pname look__5tableFPCcUc(register struct table *__0this, const char *__1s, TOK _
             if (__1n == 0)
                 error__FiPCc((int)'i', (const char *)"hashed lookup");
             __1p = __1n->__O2__4expr.string;
-            if (__1p == 0 || (unsigned long long)__1p < 0x10000ULL) goto nxt;
+            if ((long long)__1p < 0x200000) goto nxt;
             __1q = __1s;
             while (((*__1p)) && ((*__1q)))
                 if (((*(__1p++))) != ((*(__1q++))))
@@ -1348,8 +1348,7 @@ Pname insert__5tableFP4nameUc(register struct table *__0this, Pname __1nx, TOK _
         __1n = (__1np[(__1hash[__1i])]);
         if (__1n == 0)
             error__FiPCc((int)'i', (const char *)"hashed lookup");
-        if (__1n->__O2__4expr.string != 0 &&
-                (unsigned long long)__1n->__O2__4expr.string >= 0x10000ULL &&
+        if ((long long)__1n->__O2__4expr.string >= 0x200000 &&
                 strcmp(__1n->__O2__4expr.string, __1s) == 0)
             goto found;
 
@@ -1449,7 +1448,7 @@ void grow__5tableFi(register struct table *__0this, int __1g) {
         int __2firsti;
 
         __2s = (__1np[__1j])->__O2__4expr.string;
-        if (__2s == 0 || (unsigned long long)__2s < 0x10000ULL) continue;    /* skip corrupt null-string entries during rehash */
+        if ((long long)__2s < 0x200000) continue;
 
         __2p = __2s;
         __2i = 0;
@@ -1468,7 +1467,7 @@ void grow__5tableFi(register struct table *__0this, int __1g) {
             if (__1n == 0)
                 error__FiPCc((int)'i', (const char *)"hashed lookup");
             __2p = __1n->__O2__4expr.string;
-            if (__2p == 0 || (unsigned long long)__2p < 0x10000ULL) goto nxt;
+            if ((long long)__2p < 0x200000) goto nxt;
             __2q = __2s;
             while (((*__2p)) && ((*__2q)))
                 if (((*(__2p++))) != ((*(__2q++))))
@@ -1605,7 +1604,7 @@ Pname look__6ktableFPCcUc(register struct ktable *__0this, const char *__1s, TOK
                 __2n = __0this->__O1__6ktable.k_n;
 
                 for (; __2n; __2n = __2n->n_tbl_list__4name) {
-                    if (__2n->__O2__4expr.string == 0 || (unsigned long long)__2n->__O2__4expr.string < 0x10000ULL) continue;
+                    if ((long long)__2n->__O2__4expr.string < 0x200000) continue;
                     if ((((((*__2n->__O2__4expr.string)) == ((*__1s)))
                               ? strcmp(__2n->__O2__4expr.string, __1s)
                               : -1) == 0) &&
@@ -1669,8 +1668,8 @@ Pname insert__6ktableFP4nameUc(register struct ktable *__0this, Pname __1nn, TOK
                     __3n = __0this->__O1__6ktable.k_n;
 
                     for (; __3n; __3n = __3n->n_tbl_list__4name) {
-                        if (__3n->__O2__4expr.string == 0 || (unsigned long long)__3n->__O2__4expr.string < 0x10000ULL ||
-                            __1nn->__O2__4expr.string == 0 || (unsigned long long)__1nn->__O2__4expr.string < 0x10000ULL) continue;
+                        if ((long long)__3n->__O2__4expr.string < 0x200000 ||
+                            (long long)__1nn->__O2__4expr.string < 0x200000) continue;
                         if ((((((*__3n->__O2__4expr.string)) == ((*__1nn->__O2__4expr.string)))
                                   ? strcmp(__3n->__O2__4expr.string, __1nn->__O2__4expr.string)
                                   : -1) == 0) &&


### PR DESCRIPTION
…1 values

The previous unsigned guard (< 0x10000) missed the case where i1 contains a negative integer (e.g. -1 from EOF in default params like overflow(int c=EOF)). As unsigned long long, -1 = 0xFFFFFFFFFFFFFFFF >> 0x10000, bypassing the check.

Switch all five string-pointer guards to: (long long)ptr < 0x200000

This single signed comparison rejects:
  - null (0)
  - small positive integers (enum constants, all <= 16384)
  - values in [0x10000, 0x200000) — unmapped on Plan 9 amd64
  - negative integers (-1, -2, etc. stored as i1)

Plan 9 amd64 text starts at 0x200020, so all real string pointers (static data, heap) are >= 0x200020 and are not rejected.

https://claude.ai/code/session_01X3op4VKV9ZjgjvG4Cyhoev