### PR TITLE
cpp: add dodefine body dump and NUMBER token trace in gettokens

### DIFF
--- a/sys/src/cmd/cpp/lex.c
+++ b/sys/src/cmd/cpp/lex.c
@@ -338,6 +338,9 @@ gettokens(Tokenrow *trp, int reset)
 			case S_SELFB:
 				tp->type = GETACT(state);
 				tp->len = ip - tp->t;
+				if (tp->type == NUMBER && tp->len > 2)
+					fprintf(stderr, "LEX NUMBER len=%d '%.*s' next='%c'(%d)\n",
+						tp->len, tp->len, tp->t, (int)*ip, (int)*ip);
 				tp++;
 				goto continue2;
 

--- a/sys/src/cmd/cpp/macro.c
+++ b/sys/src/cmd/cpp/macro.c
@@ -73,6 +73,13 @@ dodefine(Tokenrow *trp)
 	trp->tp = tp;
 	if (((trp->lp)-1)->type==NL)
 		trp->lp -= 1;
+	{
+		Token *dtp;
+		fprintf(stderr, "dodefine: %.*s body=%d toks:", np->len, np->name, (int)(trp->lp - trp->tp));
+		for (dtp = trp->tp; dtp < trp->lp; dtp++)
+			fprintf(stderr, " [type=%d len=%d '%.*s']", dtp->type, dtp->len, dtp->len, dtp->t);
+		fprintf(stderr, "\n");
+	}
 	def = normtokenrow(trp);
 	if (np->flag&ISDEFINED) {
 		if (comparetokens(def, np->vp)


### PR DESCRIPTION
Shows exact tokens stored for each #define body, and prints any NUMBER token longer than 2 chars with the char that follows it.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs