### PR TITLE
fix cpp: struct fsm ch[4]->ch[8] prevents overread corrupting bigfsm …

### DIFF
--- a/sys/src/cmd/cpp/lex.c
+++ b/sys/src/cmd/cpp/lex.c
@@ -283,8 +283,6 @@ expandlex(void)
 		if (bigfsm[EOFC][i]>=0)
 			bigfsm[EOFC][i] = ~S_EOF;
 	}
-	fprintf(stderr, "bigfsm['+'][NUM1]=%d bigfsm['+'][NUM2]=%d bigfsm['U'][NUM1]=%d (NUM1=%d NUM2=%d S_SELF=%d)\n",
-		(int)bigfsm['+'][NUM1], (int)bigfsm['+'][NUM2], (int)bigfsm['U'][NUM1], NUM1, NUM2, S_SELF);
 }
 
 /*
@@ -326,10 +324,6 @@ gettokens(Tokenrow *trp, int reset)
 		for (;;) {
 			oldstate = state;
 			c = *ip;
-			if (c == '+' || c == '-')
-				fprintf(stderr, "TRACE: char='%c'(%d) oldstate=%d bigfsm=%d tok_so_far='%.*s'\n",
-					c, c, oldstate, (int)bigfsm[(uchar)c][oldstate],
-					(int)(ip - tp->t), tp->t);
 			if ((state = bigfsm[c][state]) >= 0) {
 				ip += runelen;
 				runelen = 1;
@@ -344,9 +338,6 @@ gettokens(Tokenrow *trp, int reset)
 			case S_SELFB:
 				tp->type = GETACT(state);
 				tp->len = ip - tp->t;
-				if (tp->type == NUMBER && tp->len > 2)
-					fprintf(stderr, "LEX NUMBER len=%d '%.*s' next='%c'(%d)\n",
-						tp->len, tp->len, tp->t, (int)*ip, (int)*ip);
 				tp++;
 				goto continue2;
 

--- a/sys/src/cmd/cpp/macro.c
+++ b/sys/src/cmd/cpp/macro.c
@@ -73,13 +73,6 @@ dodefine(Tokenrow *trp)
 	trp->tp = tp;
 	if (((trp->lp)-1)->type==NL)
 		trp->lp -= 1;
-	{
-		Token *dtp;
-		fprintf(stderr, "dodefine: %.*s body=%d toks:", np->len, np->name, (int)(trp->lp - trp->tp));
-		for (dtp = trp->tp; dtp < trp->lp; dtp++)
-			fprintf(stderr, " [type=%d len=%d '%.*s']", dtp->type, dtp->len, dtp->len, dtp->t);
-		fprintf(stderr, "\n");
-	}
 	def = normtokenrow(trp);
 	if (np->flag&ISDEFINED) {
 		if (comparetokens(def, np->vp)


### PR DESCRIPTION
…table

expandlex() iterates `for (i=0; fp->ch[i]; i++)` to find the null terminator. With `uchar ch[4]`, an entry like `NUM1, {'E','e','P','p'}, NUM2` fills all 4 slots leaving no null. The loop reads ch[4], which overlaps with the first byte of `nextstate`. On little-endian systems nextstate=NUM2=2=C_ALPH, so the loop runs a spurious 5th iteration hitting `case C_ALPH:` and overwriting ALL letter entries in bigfsm[][NUM1] to NUM2.

Result: integer suffixes U/u/L/l and others cause NUM1→NUM2 transition, so the +/- that follows them continues the pp-number rather than ending it. `3U+LZ77Min` tokenises as a single NUMBER token instead of `3U` + `+` + `LZ77Min`, breaking macro expansion for chains like PNG_KNOWN_CHUNKS→CDiCCP→LKMin→LZ77Min.

Fix: enlarge ch to uchar ch[8]; C zero-initialises the extra bytes so all existing 4-char initialisers gain a proper null terminator.

Also remove debug instrumentation added during diagnosis (from lex.c and macro.c).

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs