### PR TITLE
ld: define go_goroot/goarch/goos variables and declare go_Lflag

### DIFF
--- a/sys/src/cmd/ld/lib.c
+++ b/sys/src/cmd/ld/lib.c
@@ -48,6 +48,11 @@ int	go_libraryp;
 go_Library*	go_library;
 int	go_nlibrary;
 
+/* set by go_mywhatsys() */
+char*	go_goroot;
+char*	go_goarch;
+char*	go_goos;
+
 /*
  * These functions bridge the DWARF code to the native linker's output.
  * We use the native cput() and cflush() macros defined in l.h.

--- a/sys/src/cmd/ld/lib.h
+++ b/sys/src/cmd/ld/lib.h
@@ -168,6 +168,7 @@ int	go_pathchar(void);
 void*	go_mal(uint32);
 void	go_unmal(void*, uint32);
 void	go_mywhatsys(void);
+void	go_Lflag(char*);
 void	vlputl(vlong);
 
 /* set by call to mywhatsys() */


### PR DESCRIPTION
go_goroot, go_goarch, go_goos were declared extern in lib.h but had no storage definition anywhere, causing undefined symbol link errors. Add the definitions to lib.c alongside the other global linker state.

Also add the missing go_Lflag declaration to lib.h.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs