### PR TITLE
linker: add fallback strnput/wputl for arches missing them in DWARF

### DIFF
--- a/sys/src/cmd/5l/l.h
+++ b/sys/src/cmd/5l/l.h
@@ -427,6 +427,7 @@ long	regoff(Adr*);
 int	relinv(int);
 long	rnd(long, long);
 void	span(void);
+#define ARCH_HAS_STRNPUT
 void	strnput(char*, int);
 void	undef(void);
 void	undefsym(Sym*);

--- a/sys/src/cmd/6l/l.h
+++ b/sys/src/cmd/6l/l.h
@@ -398,6 +398,8 @@ Sym*	lookup(char*, int);
 void	lput(long);
 #define ARCH_HAS_LPUTL
 void	lputl(long);
+#define ARCH_HAS_WPUTL
+#define ARCH_HAS_STRNPUT
 void	main(int, char*[]);
 void	mkfwd(void);
 void	nuxiinit(void);

--- a/sys/src/cmd/7l/l.h
+++ b/sys/src/cmd/7l/l.h
@@ -437,6 +437,7 @@ vlong	rnd(vlong, long);
 void	span(void);
 void	undef(void);
 void	wput(long);
+#define ARCH_HAS_WPUTL
 void	wputl(long);
 void	noops(void);
 Mask*	findmask(uvlong);

--- a/sys/src/cmd/8l/l.h
+++ b/sys/src/cmd/8l/l.h
@@ -364,6 +364,8 @@ Sym*	lookup(char*, int);
 void	lput(long);
 #define ARCH_HAS_LPUTL
 void	lputl(long);
+#define ARCH_HAS_WPUTL
+#define ARCH_HAS_STRNPUT
 void	main(int, char*[]);
 void	mkfwd(void);
 void	nuxiinit(void);

--- a/sys/src/cmd/9l/l.h
+++ b/sys/src/cmd/9l/l.h
@@ -362,6 +362,7 @@ long	regoff(Adr*);
 int	relinv(int);
 vlong	rnd(vlong, long);
 void	sched(Prog*, Prog*);
+#define ARCH_HAS_STRNPUT
 void	span(void);
 void	undef(void);
 void	undefsym(Sym*);

--- a/sys/src/cmd/ld/lib.c
+++ b/sys/src/cmd/ld/lib.c
@@ -70,6 +70,32 @@ lputl(long l)
 }
 #endif
 
+/* Arches that define wputl in their own asm.c set ARCH_HAS_WPUTL in l.h */
+#ifndef ARCH_HAS_WPUTL
+void
+wputl(ushort w)
+{
+	cput(w);
+	cput(w>>8);
+}
+#endif
+
+/* Arches that define strnput in their own asm.c set ARCH_HAS_STRNPUT in l.h */
+#ifndef ARCH_HAS_STRNPUT
+void
+strnput(char *s, int n)
+{
+	for(; *s && n > 0; s++){
+		cput(*s);
+		n--;
+	}
+	while(n > 0){
+		cput(0);
+		n--;
+	}
+}
+#endif
+
 void
 vlputl(vlong v)
 {

--- a/sys/src/cmd/ld/lib.h
+++ b/sys/src/cmd/ld/lib.h
@@ -165,6 +165,7 @@ void	go_mywhatsys(void);
 void	go_Lflag(char*);
 void	lputl(long);
 void	vlputl(vlong);
+void	wputl(ushort);
 
 /* set by call to mywhatsys() */
 extern	char*	go_goroot;

--- a/sys/src/cmd/ql/l.h
+++ b/sys/src/cmd/ql/l.h
@@ -349,6 +349,7 @@ long	regoff(Adr*);
 int	relinv(int);
 long	rnd(long, long);
 void	sched(Prog*, Prog*);
+#define ARCH_HAS_STRNPUT
 void	span(void);
 void	undef(void);
 void	undefsym(Sym*);

--- a/sys/src/cmd/vl/l.h
+++ b/sys/src/cmd/vl/l.h
@@ -354,6 +354,7 @@ int	relinv(int);
 long	rnd(long, long);
 void	sched(Prog*, Prog*);
 void	span(void);
+#define ARCH_HAS_STRNPUT
 void	strnput(char*, int);
 void	undef(void);
 void	xdefine(char*, int, long);


### PR DESCRIPTION
Same pattern as the lputl fix: add guarded fallback definitions in lib.c for wputl and strnput, with ARCH_HAS_* macros in arch l.h files that already supply their own asm.c implementations.

strnput missing from: 1l, 7l, kl  → now provided by lib.c fallback
wputl missing from: 1l, 5l, 9l, kl, ql, vl → now provided by lib.c fallback

Guards added:
  ARCH_HAS_STRNPUT: 5l, 6l, 8l, 9l, ql, vl
  ARCH_HAS_WPUTL:   6l, 7l, 8l

Also add void wputl(ushort) declaration to lib.h so all arches see the prototype without relying on the dwarf.c extern.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs