### PR TITLE
dwarf: guard AADJSP and pcond usage behind arch capability macros

### DIFF
--- a/sys/src/cmd/1l/l.h
+++ b/sys/src/cmd/1l/l.h
@@ -84,6 +84,7 @@ struct	Prog
 
 #define	stkoff	u0.u0stkoff
 #define	forwd	u0.u0forwd
+#define	PROG_HAS_PCOND
 
 struct	Auto
 {

--- a/sys/src/cmd/6l/l.h
+++ b/sys/src/cmd/6l/l.h
@@ -400,6 +400,7 @@ void	lput(long);
 void	lputl(long);
 #define ARCH_HAS_WPUTL
 #define ARCH_HAS_STRNPUT
+#define PROG_HAS_PCOND
 void	main(int, char*[]);
 void	mkfwd(void);
 void	nuxiinit(void);

--- a/sys/src/cmd/8l/l.h
+++ b/sys/src/cmd/8l/l.h
@@ -366,6 +366,7 @@ void	lput(long);
 void	lputl(long);
 #define ARCH_HAS_WPUTL
 #define ARCH_HAS_STRNPUT
+#define PROG_HAS_PCOND
 void	main(int, char*[]);
 void	mkfwd(void);
 void	nuxiinit(void);

--- a/sys/src/cmd/ld/dwarf.c
+++ b/sys/src/cmd/ld/dwarf.c
@@ -7,12 +7,16 @@
 #include	"dwarf.h"
 #include	"dwarf_defs.h"
 
-/* Calculate stack adjustment from AADJSP instruction */
+/* Calculate stack adjustment from AADJSP instruction (x86 only) */
 static long
 getspadj(Prog *p)
 {
+#ifdef AADJSP
 	if(p->as == AADJSP)
 		return p->from.offset;
+#else
+	USED(p);
+#endif
 	return 0;
 }
 
@@ -719,7 +723,12 @@ writelines(void)
 	currfile = -1;
 	lineo = cpos();
 
+#ifdef PROG_HAS_PCOND
 	for(cursym = textp; cursym != P; cursym = cursym->pcond) {
+#else
+	for(cursym = textp; cursym != P; cursym = cursym->link) {
+		if(cursym->as != ATEXT) continue;
+#endif
 		Sym *s = cursym->from.u1.u1sym;
 		// Look for history stack.  If we find one,
 		// we're entering a new compilation unit
@@ -884,7 +893,12 @@ writeframes(void)
 	}
 	strnput("", pad);
 
+#ifdef PROG_HAS_PCOND
 	for(cursym = textp; cursym != P; cursym = cursym->pcond) {
+#else
+	for(cursym = textp; cursym != P; cursym = cursym->link) {
+		if(cursym->as != ATEXT) continue;
+#endif
 		fdeo = cpos();
 		// Emit a FDE, Section 6.4.1, starting wit a placeholder.
 		LPUT(0);	// length, must be multiple of PtrSize


### PR DESCRIPTION
AADJSP is an x86-only pseudo-instruction (amd64/386). For all other arches, getspadj() now returns 0 unconditionally via #ifdef AADJSP.

pcond is a Prog field used by 6l/8l/1l to build a linked list of text functions. Other arches (ARM, MIPS, PowerPC, SPARC, Alpha) lack this field. The two textp iteration loops in writelines and writeframes now select between:
  - pcond chain (when PROG_HAS_PCOND defined): existing 6l/8l behavior
  - link chain with ATEXT guard (fallback): portable iteration using the ->link field and as == ATEXT to identify function entries

PROG_HAS_PCOND added to: 1l/l.h, 6l/l.h, 8l/l.h

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs