### PR TITLE
ld/go.c: guard pcond-based dead-text pruning with PROG_HAS_PCOND

### DIFF
--- a/sys/src/cmd/ld/go.c
+++ b/sys/src/cmd/ld/go.c
@@ -620,7 +620,9 @@ go_deadcode(void)
 	/*
 	 * Remove dead text but keep file information (z symbols).
 	 * textp is Prog* in Plan9 6l; iterate via pcond which chains TEXT progs.
+	 * Only available on arches whose Prog struct has the pcond field.
 	 */
+#ifdef PROG_HAS_PCOND
 	last = P;
 	z = nil;
 	for(p = textp; p != P; p = p->pcond) {
@@ -645,4 +647,5 @@ go_deadcode(void)
 		textp = P;
 	else
 		last->pcond = P;
+#endif
 }


### PR DESCRIPTION
The go_deadcode() function rebuilds the textp pcond chain to remove unreachable text symbols. This requires both reading and writing the pcond field, which only exists in 1l/6l/8l Prog structs.

Wrap the entire pruning block in #ifdef PROG_HAS_PCOND so arches without pcond (5l, 7l, 9l, kl, ql, vl) skip it. For those arches the Go dead-code elimination is a no-op, which is acceptable since they do not link Go programs.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs