### PR TITLE
ld: guard wputl(ushort) declaration behind #ifndef ARCH_HAS_WPUTL

### DIFF
--- a/sys/src/cmd/ld/dwarf.c
+++ b/sys/src/cmd/ld/dwarf.c
@@ -43,7 +43,9 @@ extern void LPUT(long);
 extern void WPUT(ushort);
 extern void VPUT(vlong);
 extern void lputl(long);
+#ifndef ARCH_HAS_WPUTL
 extern void wputl(ushort);
+#endif
 extern void vlputl(vlong);
 extern vlong cpos(void);
 extern void diag(char*, ...);

--- a/sys/src/cmd/ld/lib.h
+++ b/sys/src/cmd/ld/lib.h
@@ -165,7 +165,9 @@ void	go_mywhatsys(void);
 void	go_Lflag(char*);
 void	lputl(long);
 void	vlputl(vlong);
+#ifndef ARCH_HAS_WPUTL
 void	wputl(ushort);
+#endif
 
 /* set by call to mywhatsys() */
 extern	char*	go_goroot;


### PR DESCRIPTION
7l (Alpha) defines wputl(long) — a different signature from the ushort version used by 6l/8l. Having both lib.h and dwarf.c declare void wputl(ushort) unconditionally causes an 'inconsistently declared' error when compiling for 7l, which already has its own declaration via ARCH_HAS_WPUTL in l.h.

Guard both declarations with #ifndef ARCH_HAS_WPUTL so arches that supply their own wputl declaration suppress the shared one.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs