### PR TITLE
dwarf.c: remove spurious extern void LPUT/WPUT/VPUT declarations

### DIFF
--- a/sys/src/cmd/ld/dwarf.c
+++ b/sys/src/cmd/ld/dwarf.c
@@ -39,13 +39,7 @@ Prog *cursym;
 
 // Linker-core functions/vars not available in lib.h
 extern void cflush(void);
-extern void LPUT(long);
-extern void WPUT(ushort);
-extern void VPUT(vlong);
 extern void lputl(long);
-#ifndef ARCH_HAS_WPUTL
-extern void wputl(ushort);
-#endif
 extern void vlputl(vlong);
 extern vlong cpos(void);
 extern void diag(char*, ...);


### PR DESCRIPTION
LPUT, WPUT, VPUT are macros defined in lib.h. 'extern void WPUT(ushort)' is not a function declaration — after preprocessing it expands to 'extern void wputl(ushort)', producing a type conflict with 7l's wputl(long). Same issue with LPUT/VPUT.

Remove all three. The underlying functions (lputl, wputl, vlputl) are already declared via lib.h (guarded with #ifndef ARCH_HAS_WPUTL for wputl) and arch-specific l.h files.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs