### PR TITLE
6l,8l: add void wputl(ushort) declaration alongside ARCH_HAS_WPUTL

### DIFF
--- a/sys/src/cmd/6l/l.h
+++ b/sys/src/cmd/6l/l.h
@@ -399,6 +399,7 @@ void	lput(long);
 #define ARCH_HAS_LPUTL
 void	lputl(long);
 #define ARCH_HAS_WPUTL
+void	wputl(ushort);
 #define ARCH_HAS_STRNPUT
 #define PROG_HAS_PCOND
 void	main(int, char*[]);

--- a/sys/src/cmd/8l/l.h
+++ b/sys/src/cmd/8l/l.h
@@ -365,6 +365,7 @@ void	lput(long);
 #define ARCH_HAS_LPUTL
 void	lputl(long);
 #define ARCH_HAS_WPUTL
+void	wputl(ushort);
 #define ARCH_HAS_STRNPUT
 #define PROG_HAS_PCOND
 void	main(int, char*[]);


### PR DESCRIPTION
ARCH_HAS_WPUTL suppresses the wputl(ushort) declaration in lib.h, but 6l/8l were not providing their own replacement declaration. Add void wputl(ushort) in each l.h right after the guard define.

7l already had void wputl(long) in the same position. Now all three arches that define ARCH_HAS_WPUTL also declare the function with the correct parameter type for that arch.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs