### PR TITLE
9l: fix missing closing brace for struct Prog in l.h

### DIFF
--- a/sys/src/cmd/9l/l.h
+++ b/sys/src/cmd/9l/l.h
@@ -71,6 +71,7 @@ struct	Prog
 	short	as;
 	char	reg;
 
+};
 
 struct	Sym
 {


### PR DESCRIPTION
struct Prog opened at line 58 but was never closed — struct Sym started immediately inside it at line 75, making Sym appear as an unnamed struct member inside Prog. This caused cascading errors:
  'unnamed structure element must be struct/union' (Sym inside Prog)
  'illegal combination of class 4: EXTERN' (everything after, still
  parsed as struct members)

Added the missing '};\n' to close struct Prog before struct Sym. This was a pre-existing latent bug, only surfaced when 9l started being compiled (previously missing from the build).

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs