### PR TITLE
dwarf/go/lib: guard Auto.asym and Adr.u1 struct accesses for 9l/ql

### DIFF
--- a/sys/src/cmd/1l/l.h
+++ b/sys/src/cmd/1l/l.h
@@ -85,6 +85,8 @@ struct	Prog
 #define	stkoff	u0.u0stkoff
 #define	forwd	u0.u0forwd
 #define	PROG_HAS_PCOND
+#define AUTO_HAS_ASYM
+#define ADR_HAS_U1
 
 struct	Auto
 {

--- a/sys/src/cmd/5l/l.h
+++ b/sys/src/cmd/5l/l.h
@@ -427,6 +427,8 @@ int	relinv(int);
 long	rnd(long, long);
 void	span(void);
 #define ARCH_HAS_STRNPUT
+#define AUTO_HAS_ASYM
+#define ADR_HAS_U1
 void	strnput(char*, int);
 void	undef(void);
 void	undefsym(Sym*);

--- a/sys/src/cmd/6l/l.h
+++ b/sys/src/cmd/6l/l.h
@@ -402,6 +402,8 @@ void	lputl(long);
 void	wputl(ushort);
 #define ARCH_HAS_STRNPUT
 #define PROG_HAS_PCOND
+#define AUTO_HAS_ASYM
+#define ADR_HAS_U1
 void	main(int, char*[]);
 void	mkfwd(void);
 void	nuxiinit(void);

--- a/sys/src/cmd/7l/l.h
+++ b/sys/src/cmd/7l/l.h
@@ -448,6 +448,9 @@ void	zerosig(char*);
 #pragma	varargck	type	"R"	int
 
 /* for ../ld */
+#define AUTO_HAS_ASYM
+#define ADR_HAS_U1
+
 #define	isbranch(a)	((a) == AB)
 #define	iscall(a)	((a) == ABL)
 #define	isreturn(a)	((a) == ARETURN || (a) == ARET || (a) == AERET)

--- a/sys/src/cmd/8l/l.h
+++ b/sys/src/cmd/8l/l.h
@@ -368,6 +368,8 @@ void	lputl(long);
 void	wputl(ushort);
 #define ARCH_HAS_STRNPUT
 #define PROG_HAS_PCOND
+#define AUTO_HAS_ASYM
+#define ADR_HAS_U1
 void	main(int, char*[]);
 void	mkfwd(void);
 void	nuxiinit(void);

--- a/sys/src/cmd/kl/l.h
+++ b/sys/src/cmd/kl/l.h
@@ -351,3 +351,6 @@ void	undef(void);
 void	xdefine(char*, int, long);
 void	xfol(Prog*);
 
+#define AUTO_HAS_ASYM
+#define ADR_HAS_U1
+

--- a/sys/src/cmd/ld/dwarf.c
+++ b/sys/src/cmd/ld/dwarf.c
@@ -569,7 +569,11 @@ inithist(Auto *a)
 		return 0;
 	}
 
+#ifdef AUTO_HAS_ASYM
 	unitname = decodez(a->asym->name);
+#else
+	unitname = decodez(a->sym->name);
+#endif
 
 	// Clear the history.
 	clearhistfile();
@@ -586,7 +590,11 @@ inithist(Auto *a)
 	// Construct the new one.
 	for (; a; a = a->link) {
 		if (a->type == D_FILE) {  // 'z'
+#ifdef AUTO_HAS_ASYM
 			int f = addhistfile(a->asym->name);
+#else
+			int f = addhistfile(a->sym->name);
+#endif
 			if (f < 0) {	   // pop file
 				includetop--;
 				checknesting();
@@ -725,10 +733,18 @@ writelines(void)
 	for(cursym = textp; cursym != P; cursym = cursym->link) {
 		if(cursym->as != ATEXT) continue;
 #endif
+#ifdef ADR_HAS_U1
 		Sym *s = cursym->from.u1.u1sym;
+#else
+		Sym *s = cursym->from.sym;
+#endif
 		// Look for history stack.  If we find one,
 		// we're entering a new compilation unit
+#ifdef ADR_HAS_U1
 		if((unitname = inithist(cursym->to.u1.u1autom)) != 0) {
+#else
+		if((unitname = inithist(cursym->to.autom)) != 0) {
+#endif
 			Linehist* lh1;
 			flushunit(epc, unitstart);
 			unitstart = cpos();

--- a/sys/src/cmd/ld/go.c
+++ b/sys/src/cmd/ld/go.c
@@ -522,7 +522,7 @@ go_marktext(Sym *s)
 	markdepth++;
 	if(debug['v'] > 1)
 		Bprint(&bso, "%d go_marktext %s\n", markdepth, s->name);
-	for(a=s->autom; a; a=a->link)
+	for(a=s->u1.u1autom; a; a=a->link)
 		go_mark(a->gotype);
 	for(p=s->text; p != P; p=p->link) {
 		if(p->from.sym)
@@ -594,8 +594,8 @@ addz(Sym *s, Auto *z)
 		}
 	}
 	if(last) {
-		last->link = s->autom;
-		s->autom = z;
+		last->link = s->u1.u1autom;
+		s->u1.u1autom = z;
 	}
 }
 
@@ -628,8 +628,8 @@ go_deadcode(void)
 	for(p = textp; p != P; p = p->pcond) {
 		s = p->from.sym;
 		if(s == S || !s->reachable) {
-			if(s != S && isz(s->autom))
-				z = s->autom;
+			if(s != S && isz(s->u1.u1autom))
+				z = s->u1.u1autom;
 			continue;
 		}
 		if(last == P)
@@ -638,7 +638,7 @@ go_deadcode(void)
 			last->pcond = p;
 		last = p;
 		if(z != nil) {
-			if(!isz(s->autom))
+			if(!isz(s->u1.u1autom))
 				addz(s, z);
 			z = nil;
 		}

--- a/sys/src/cmd/ld/lib.c
+++ b/sys/src/cmd/ld/lib.c
@@ -493,7 +493,11 @@ go_addhist(int32 line, int type)
 	s = go_mal(sizeof(Sym));
 	s->name = go_mal(2*(histfrogp+1) + 1);
 
+#ifdef AUTO_HAS_ASYM
 	u->asym = s;
+#else
+	u->sym = s;
+#endif
 	u->type = type;
 	u->aoffset = line;
 	u->link = curhist;

--- a/sys/src/cmd/vl/l.h
+++ b/sys/src/cmd/vl/l.h
@@ -356,6 +356,8 @@ void	sched(Prog*, Prog*);
 void	span(void);
 #define ARCH_HAS_STRNPUT
 void	strnput(char*, int);
+#define AUTO_HAS_ASYM
+#define ADR_HAS_U1
 void	undef(void);
 void	xdefine(char*, int, long);
 void	xfol(Prog*);


### PR DESCRIPTION
9l and ql use Autom.sym (not .asym) and direct Adr.sym/.autom fields (not the u1 union), unlike all other arch linkers.

Add AUTO_HAS_ASYM and ADR_HAS_U1 capability macros to l.h for arches that use the asym/u1 patterns (1l, 5l, 6l, 7l, 8l, kl, vl). Guard the four affected sites in dwarf.c, the Auto init in lib.c, and all Sym.autom accesses in go.c (replaced with explicit s->u1.u1autom which works for all arches since Sym always uses the u1 union).

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs