### PR TITLE
2l: add AUTO_HAS_ASYM, ADR_HAS_U1, PROG_HAS_PCOND macros

### DIFF
--- a/sys/src/cmd/2l/l.h
+++ b/sys/src/cmd/2l/l.h
@@ -291,3 +291,6 @@ void	xdefine(char*, int, long);
 void	xfol(Prog*);
 int	zaddr(uchar*, Adr*, Sym*[]);
 
+#define PROG_HAS_PCOND
+#define AUTO_HAS_ASYM
+#define ADR_HAS_U1


### PR DESCRIPTION
2l (68020 linker) uses asym in Auto and the u1 union in Adr, same as 1l. Was missed in the previous round.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs