### PR TITLE
9l: remove obsolete POSIX seek/create wrappers from cputime.c

### DIFF
--- a/sys/src/cmd/9l/cputime.c
+++ b/sys/src/cmd/9l/cputime.c
@@ -10,21 +10,3 @@ cputime(void)
 		t[0] += t[i];
 	return t[0] / 100.;
 }
-
-long
-seek(int f, long o, int p)
-{
-	long lseek(int, long, int);
-
-	return lseek(f, o, p);
-}
-
-int
-create(char *n, int m, long p)
-{
-	int creat(char*, int);
-
-	if(m != 1)
-		return -1;
-	return creat(n, p);
-}


### PR DESCRIPTION
cputime.c defined seek() returning long (32-bit) calling lseek(), and create() calling creat(). These conflict with Plan9's native vlong seek() signature and cause both type signature mismatches (cputime.6 vs all other .6 files that use Plan9's 64-bit seek) and undefined lseek/creat symbols at link time.

Plan9's native libc provides the correct seek/create; these POSIX compatibility wrappers belong to a pre-9front portability layer that no longer applies.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs