### PR TITLE
network: add ether support; delete sethostent.c

### DIFF
--- a/sys/include/ape/netinet/ether.h
+++ b/sys/include/ape/netinet/ether.h
@@ -1,0 +1,27 @@
+#ifndef _NETINET_ETHER_H
+#define _NETINET_ETHER_H
+
+#include <sys/types.h>
+
+struct ether_addr {
+	unsigned char ether_addr_octet[6];
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ether_addr	*ether_aton(const char *);
+struct ether_addr	*ether_aton_r(const char *, struct ether_addr *);
+char			*ether_ntoa(const struct ether_addr *);
+char			*ether_ntoa_r(const struct ether_addr *, char *);
+
+int	ether_line(const char *, struct ether_addr *, char *);
+int	ether_ntohost(char *, const struct ether_addr *);
+int	ether_hostton(const char *, struct ether_addr *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/sys/src/ape/lib/ap/network/mkfile
+++ b/sys/src/ape/lib/ap/network/mkfile
@@ -12,6 +12,7 @@ OFILES=\
 	dn_skipname.$O\
 	dns_parse.$O\
 	ent.$O\
+	ether.$O\
 	gai_strerror.$O\
 	getaddrinfo.$O\
 	gethostbyaddr.$O\

--- a/sys/src/ape/lib/ap/network/sethostent.c
+++ b/sys/src/ape/lib/ap/network/sethostent.c
@@ -1,5 +1,0 @@
-int
-sethostent(int)
-{
-	return 0;
-}


### PR DESCRIPTION
- netinet/ether.h: new header with struct ether_addr and declarations for ether_aton/ether_ntoa and their _r variants, plus the stub host-lookup functions (ether_line/ether_ntohost/ether_hostton)
- mkfile: add ether.$O — pure string parse/format, no kernel glue needed; the host-lookup stubs in ether.c already return -1 correctly
- sethostent.c: delete old APE stub; ent.c (musl) provides sethostent

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs