### PR TITLE
Implement _Alignas layout effect in kencc (struct members + auto vars)

### DIFF
--- a/sys/src/cmd/cc/cc.h
+++ b/sys/src/cmd/cc/cc.h
@@ -127,6 +127,7 @@ struct	Type
 	char	garb;
 	char	vla;		/* 1 = variable-length array */
 	Node*	vlasizevar;	/* hidden auto holding runtime byte count (VLA only) */
+	short	alignas_req;	/* _Alignas() override; 0 = use type's natural alignment */
 };
 
 #define	T	((Type*)0)
@@ -483,6 +484,7 @@ EXTERN	Node*	initlist;
 EXTERN	Term	term[NTERM];
 EXTERN	int	nterm;
 EXTERN	int	packflg;
+EXTERN	int	alignasval;	/* pending _Alignas() requirement; 0 = none */
 EXTERN	int	fproundflg;
 EXTERN	int	profileflg;
 EXTERN	int	ncontin;

--- a/sys/src/cmd/cc/cc.y
+++ b/sys/src/cmd/cc/cc.y
@@ -72,6 +72,7 @@ static Type *auto_deduct_type(Node*, Node*);
 %token	LTYPEOF LTYPEOF_UNQUAL
 %token	LNULLPTR LSTATICASSERT
 %token	LALIGNOF
+%token	LALIGNAS
 %token	LGENERIC
 %%
 prog:
@@ -1493,6 +1494,29 @@ gname:	/* garbage words */
 |	LVOLATILE { $$ = BVOLATILE; }
 |	LRESTRICT { $$ = 0; }
 |	LNORET { $$ = BNORET; }
+|	LALIGNAS '(' cexpr ')'
+	{
+		/* _Alignas(constant-expression) */
+		complex($3);
+		if($3->op != OCONST)
+			diag($3, "_Alignas: not a constant expression");
+		else {
+			long a = $3->vconst;
+			if(a <= 0 || (a & (a-1)) != 0)
+				diag($3, "_Alignas: argument must be a positive power of 2");
+			else
+				alignasval = a;
+		}
+		$$ = 0;
+	}
+|	LALIGNAS '(' tlist abdecor ')'
+	{
+		/* _Alignas(type-name): same alignment as the given type */
+		dodecl(NODECL, CXXX, $3, $4);
+		/* align(1, T, Ael1) is the Alignof formula from com.c OALIGNOF */
+		alignasval = align(1, lastdcl, Ael1);
+		$$ = 0;
+	}
 
 name:
 	LNAME

--- a/sys/src/cmd/cc/dcl.c
+++ b/sys/src/cmd/cc/dcl.c
@@ -837,6 +837,8 @@ sualign(Type *t)
 					else
 						diag(Z, "incomplete structure element");
 				w = align(w, l, Ael1);
+				if(l->alignas_req > 0)
+					w = round(w, l->alignas_req);
 				l->offset = w;
 				w = align(w, l, Ael2);
 			}
@@ -1554,6 +1556,12 @@ adecl(int c, Type *t, Sym *s)
 	switch(c) {
 	case CAUTO:
 		autoffset = align(autoffset, t, Aaut3);
+		/* _Alignas: round the end-of-allocation up so start is aligned.
+		 * Variable starts at base-autoffset; base%req==0 → autoffset%req==0. */
+		if(alignasval > 0) {
+			autoffset = round(autoffset, alignasval);
+			alignasval = 0;
+		}
 		stkoff = maxround(stkoff, autoffset);
 		s->offset = -autoffset;
 		break;
@@ -1567,6 +1575,7 @@ adecl(int c, Type *t, Sym *s)
 		if(s)
 			s->offset = autoffset;
 		autoffset = align(autoffset, t, Aarg2);
+		alignasval = 0;	/* _Alignas on parameters is ignored */
 		break;
 	}
 }
@@ -1646,6 +1655,7 @@ xdecl(int c, Type *t, Sym *s)
 	s->class = c;
 	s->block = 0;
 	s->offset = o;
+	alignasval = 0;	/* _Alignas on globals not yet supported; discard */
 }
 
 void
@@ -1736,6 +1746,10 @@ edecl(int c, Type *t, Sym *s)
 	t = copytyp(t1);
 	t->sym = s;
 	t->down = T;
+	if(alignasval > 0) {
+		t->alignas_req = alignasval;
+		alignasval = 0;
+	}
 	if(lastfield) {
 		t->shift = lastbit - lastfield;
 		t->nbits = lastfield;

--- a/sys/src/cmd/cc/lex.c
+++ b/sys/src/cmd/cc/lex.c
@@ -1586,6 +1586,10 @@ struct
 	"__alignof__",		LALIGNOF,	0,
 	"__alignof",		LALIGNOF,	0,
 
+	/* _Alignas / alignas: C11/C23 alignment specifier.  Layout effect. */
+	"_Alignas",		LALIGNAS,	0,
+	"alignas",		LALIGNAS,	0,
+
 	/*
 	 * GNU visibility / linkage hints.
 	 * These appear as function/variable attributes.  When used as


### PR DESCRIPTION
Parses _Alignas(N) and _Alignas(type-name) as a declaration specifier (via the gname qualifier production in cc.y) and applies the layout effect in two places:

Struct members (sualign in dcl.c):
  After Ael1 natural alignment, round the member offset up to
  l->alignas_req if nonzero. The alignas_req is set by edecl() from
  the global alignasval when the member is parsed.

Auto variables (adecl in dcl.c):
  After Aaut3, round autoffset up to alignasval.  The variable
  start address is base-autoffset; rounding the end makes the start
  alignas-aligned when base is 0 (mod alignas_req) — true for
  properly aligned function frames.

Global variables: alignasval is silently discarded (reset in xdecl).
Function parameters: alignasval is silently discarded.

cc.h:
  - short alignas_req added to Type struct (0 = use natural alignment)
  - EXTERN int alignasval (pending _Alignas value, 0 = none)

lex.c: _Alignas / alignas → LALIGNAS token

cc.y:
  - %token LALIGNAS
  - Two gname alternatives: LALIGNAS '(' cexpr ')' (constant) and LALIGNAS '(' tlist abdecor ')' (_Alignof(type) formula)

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs