### PR TITLE
cc/dcl.c, perl/config.h: fix GLOBL function redeclaration errors for …

### DIFF
--- a/sys/src/cmd/cc/dcl.c
+++ b/sys/src/cmd/cc/dcl.c
@@ -1647,13 +1647,16 @@ xdecl(int c, Type *t, Sym *s)
 	if(s->type != T)
 		if(s->class != c || !sametype(t, s->type) || t->etype == TENUM) {
 			/*
-			 * Allow static-to-static redeclaration (forward decl + definition).
-			 * kencc mismatches typedef chains vs resolved types for static
-			 * inline functions (e.g. proto.h forward decl vs inline.h definition).
-			 * Demote to warning so compilation continues with the new type.
+			 * Demote function redeclaration type mismatches to warnings.
+			 * kencc's sametype() mismatches typedef chains vs direct types,
+			 * so proto.h forward decls and .c definitions of the same function
+			 * (both static and global) fail the check even when semantically
+			 * identical. The definition's type wins via tmerge() below.
 			 */
-			if(s->class == CSTATIC && c == CSTATIC && t->etype == TFUNC)
-				warn(Z, "static redeclaration of: %s", s->name);
+			if(t->etype == TFUNC &&
+			   ((s->class == CSTATIC && c == CSTATIC) ||
+			    (s->class == CGLOBL  && c == CGLOBL)))
+				warn(Z, "redeclaration of: %s", s->name);
 			else {
 				diag(Z, "external redeclaration of: %s", s->name);
 				Bprint(&diagbuf, "	%s %T %L\n", cnames[c], t, nearln);

--- a/sys/src/external/perl/config.h
+++ b/sys/src/external/perl/config.h
@@ -1215,7 +1215,7 @@
  *	to get any typedef'ed information.
  *	We will pick a type such that sizeof(SSize_t) == sizeof(Size_t).
  */
-#define SSize_t ssize_t	/* signed count of bytes */
+#define SSize_t long long	/* Plan9: ssize_t=long(32-bit); use long long for 64-bit signed size */
 
 /* EBCDIC:
  *	This symbol, if defined, indicates that this system uses
@@ -5383,7 +5383,7 @@
  *	unsigned long, int, etc.  It may be necessary to include
  *	<sys/types.h> to get any typedef'ed information.
  */
-#define Size_t size_t	 /* length parameter for string functions */
+#define Size_t unsigned long long	/* Plan9: size_t alias; use concrete 64-bit type */
 
 /* Uid_t_f:
  *	This symbol defines the format string used for printing a Uid_t.


### PR DESCRIPTION
…Perl

Two fixes for Perl compilation on Plan9:

1. cc/dcl.c: extend the TFUNC redeclaration demotion to cover CGLOBL→CGLOBL in addition to CSTATIC→CSTATIC. proto.h global function declarations and the corresponding .c file definitions trigger sametype() mismatches due to kencc representing typedef chains differently from direct types. The definition's type wins via tmerge(), so demoting to a warning is safe.

2. perl/config.h: change SSize_t from 'ssize_t' (typedef alias, 32-bit long on Plan9) to concrete 'long long', and Size_t from 'size_t' to concrete 'unsigned long long'. This eliminates the typedef chain that causes kencc to display SSize_t as ULONG (unsigned long) vs VLONG (long long) in different compilation contexts.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs