### PR TITLE
perl/perlstatic.h: avoid extern const char[] as function arg

### DIFF
--- a/sys/src/external/perl/perlstatic.h
+++ b/sys/src/external/perl/perlstatic.h
@@ -18,7 +18,7 @@
 STATIC void
 Perl_croak_memory_wrap(void)
 {
-    Perl_croak_nocontext("%s",PL_memory_wrap);
+    Perl_croak_nocontext("%s","panic: memory wrap");
 }
 
 


### PR DESCRIPTION
kencc cannot pass extern const char[] (incomplete array PL_memory_wrap) as a function argument — produces "not an l-value" at the addaddr path. Replace with the equivalent string literal to work around this.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs