### PR TITLE
cc/lex.c: add __func__/__FUNCTION__ as predefined string literal

### DIFF
--- a/sys/src/cmd/cc/lex.c
+++ b/sys/src/cmd/cc/lex.c
@@ -886,6 +886,30 @@ talph:
 		goto l0;	/* fetch next real token */
 	}
 	/*
+	 * C99 __func__ and GCC __FUNCTION__: predefined string literal
+	 * containing the current function name. kencc has no tracking of the
+	 * current function name at the lex level, so we return an empty string.
+	 * This satisfies type-checking (const char[]) without the expense of
+	 * tracking function names through the lexer.
+	 */
+	if(s->lexical == LNAME && (
+	    strcmp(s->name, "__func__")     == 0 ||
+	    strcmp(s->name, "__FUNCTION__") == 0 ||
+	    strcmp(s->name, "__PRETTY_FUNCTION__") == 0)) {
+		char *cp;
+		int c1;
+		cp = alloc(0);
+		c1 = 0;
+		yylval.sval.l = c1;
+		do {
+			cp = allocn(cp, c1, 1);
+			cp[c1++] = 0;
+		} while(c1 & MAXALIGN);
+		yylval.sval.s = cp;
+		strcpy(symb, "\"\"");
+		return LSTRING;
+	}
+	/*
 	 * GCC __builtin_* functions: swallow the entire call and
 	 * substitute a zero constant.  This handles the common cases:
 	 *   __builtin_expect(x, v)         -> 0  (branch prediction hint)

--- a/sys/src/external/perl/config.h
+++ b/sys/src/external/perl/config.h
@@ -2196,10 +2196,7 @@
 /* kencc: PERL_MALLOC_WRAP disabled — complex comma exprs in Newx fail */
 /*#define PERL_MALLOC_WRAP*/
 
-/* kencc has no __func__/__FUNCTION__ predefined identifier */
-#ifndef __FUNCTION__
-#define __FUNCTION__ ""
-#endif
+/* kencc handles __func__/__FUNCTION__ at the compiler level (lex.c) */
 
 /* MYMALLOC:
  *	This symbol, if defined, indicates that we're using our own malloc.

--- a/sys/src/external/perl/inline.h
+++ b/sys/src/external/perl/inline.h
@@ -141,8 +141,10 @@ Perl_av_fetch_simple(pTHX_ AV *av, SSize_t key, I32 lval)
 
     arr = AvARRAY(av);
     if (key > AvFILLp(av) || !arr[key]) {
-        if (lval)
-            return av_store_simple(av, key, newSV_type(SVt_NULL));
+        if (lval) {
+            SV *newsv = newSV_type(SVt_NULL);
+            return av_store_simple(av, key, newsv);
+        }
         return NULL;
     }
     return arr + key;  /* &arr[key] — avoid & on macro expr (kencc) */


### PR DESCRIPTION
kencc had no support for __func__ (C99) or __FUNCTION__ (GCC extension). These appeared as undeclared identifiers causing compilation failures. Fix: in lex.c, when __func__, __FUNCTION__, or __PRETTY_FUNCTION__ is encountered as an identifier, return an empty LSTRING token. This satisfies type-checking (const char[]) without tracking function names through the lexer.

Also: perl/inline.h: split av_fetch_simple lval branch into two statements to avoid any kencc issue with nested function-call expressions in return.

Also: perl/config.h: remove the __FUNCTION__ macro workaround (now handled at the compiler level).

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs