### PR TITLE
cc/com.c: add OFUNC/addaddr diagnostics to identify tlvalue call site

### DIFF
--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -799,6 +799,10 @@ tcomo(Node *n, int f)
 		if(o | tcoma(l, r, l->type->down, 1))
 			goto bad;
 		n->type = l->type->link;
+		fprint(2, "OFUNC: callee=%s callee_etype=%d result_etype=%d\n",
+			l->sym ? l->sym->name : "(indirect)",
+			l->type ? (int)l->type->etype : -1,
+			n->type ? (int)n->type->etype : -1);
 		if(!debug['B']){
 			if(l->type->down == T){
 				if(!debug['T'])
@@ -879,6 +883,8 @@ tcomo(Node *n, int f)
 	case OADDR:
 		if(tcomo(l, ADDROP))
 			goto bad;
+		fprint(2, "OADDR: l->op=%d l->type_etype=%d l->addable=%d\n",
+			l->op, l->type ? (int)l->type->etype : -1, l->addable);
 		if(l->op != ONAME && l->op != OIND && l->op != ODOT && l->op != OBIT)
 		if(tlvalue(l))
 			goto bad;
@@ -930,6 +936,8 @@ tcomo(Node *n, int f)
 	return 0;
 
 addaddr:
+	fprint(2, "addaddr: n->op=%d n->type_etype=%d n->addable=%d\n",
+		n->op, n->type ? (int)n->type->etype : -1, n->addable);
 	if(n->op != ONAME && n->op != OIND && n->op != ODOT && n->op != OBIT)
 	if(tlvalue(n))
 		goto bad;


### PR DESCRIPTION
Adds:
- OFUNC case: print callee name, callee_etype, result_etype after setting n->type
- addaddr label: print n->op/etype/addable before the tlvalue guard
- OADDR case: print l->op/etype/addable before the tlvalue guard

This reveals which code path triggers "not an l-value" for op=39 (OFUNC).

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs