### PR TITLE
perl/mkfile: fix pm_to_blib dependency and drop DynaLoader

### DIFF
--- a/sys/src/ape/cmd/perl/mkfile
+++ b/sys/src/ape/cmd/perl/mkfile
@@ -22,7 +22,7 @@ miniperl: miniperlmain.$O opmini.$O perlmini.$O universalmini.$O
 	$LD $prereq -o $target
 
 opmini.$O: $PERLSRC/op.c
-	$CC $CFLAGS  -DPERL_IS_MINIPERL -DPERL_EXTERNAL_GLOB $PERLSRC/op.c -o $target
+	$CC $CFLAGS -DPERL_IS_MINIPERL -DPERL_EXTERNAL_GLOB $PERLSRC/op.c -o $target
 
 perlmini.$O: $PERLSRC/perl.c
 	$CC $CFLAGS -DPERL_IS_MINIPERL -DPERL_EXTERNAL_GLOB $PERLSRC/perl.c -o $target
@@ -30,6 +30,16 @@ perlmini.$O: $PERLSRC/perl.c
 universalmini.$O: $PERLSRC/universal.c
 	$CC $CFLAGS -DPERL_IS_MINIPERL -DPERL_EXTERNAL_GLOB $PERLSRC/universal.c -o $target
 
+# pm_to_blib is a MakeMaker marker file (records that .pm files were
+# copied to blib/). We skip the MakeMaker step: miniperl finds
+# ExtUtils::Miniperl directly via -I below, so just touch the marker.
+$PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib: miniperl
+	touch $PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib
+
+# Generate perlmain.c via miniperl.
+# No DynaLoader: Plan9 has no dlopen; all extensions are linked statically
+# or omitted. Pass -I to the ExtUtils-Miniperl source directly.
 perlmain.c: miniperl $PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib
-	./miniperl -MExtUtils::Miniperl -e 'writemain(\"perlmain.c", @ARGV)' DynaLoader\
-	$PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib
+	./miniperl -I$PERLSRC/ext/ExtUtils-Miniperl/lib \
+		-MExtUtils::Miniperl \
+		-e 'writemain("perlmain.c")'


### PR DESCRIPTION
pm_to_blib is a MakeMaker marker file created when ExtUtils::Miniperl is installed into blib/. We bypass MakeMaker entirely: add a rule that touches pm_to_blib as a marker, and pass -I directly to the source tree so miniperl can find ExtUtils::Miniperl without blib.

Drop DynaLoader from the writemain() argument list — Plan9 has no dlopen/shared libraries, so DynaLoader is not usable. perlmain.c is generated with an empty xs_init (no statically linked XS extensions).

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs