### PR TITLE
perl: fix stack smash in parse_LC_ALL_string due to wrong LC_* positi…

### DIFF
--- a/sys/src/external/perl/config.h
+++ b/sys/src/external/perl/config.h
@@ -3662,7 +3662,11 @@
  */
 /*#define PERL_LC_ALL_USES_NAME_VALUE_PAIRS  	/ **/
 #define  PERL_LC_ALL_SEPARATOR ";"	/**/
-#define  PERL_LC_ALL_CATEGORY_POSITIONS_INIT  { 0, 1, 2, 3, 4, 5 }	/**/
+/* Plan9 APE locale.h: LC_CTYPE=2, LC_NUMERIC=4, LC_COLLATE=1, LC_TIME=5,
+ * LC_MESSAGES=1729, LC_MONETARY=3. These are in Perl's internal index order
+ * (CTYPE=0, NUMERIC=1, COLLATE=2, TIME=3, MESSAGES=4, MONETARY=5) so that
+ * get_category_index(INIT[i]) == i for all positions. */
+#define  PERL_LC_ALL_CATEGORY_POSITIONS_INIT  { 2, 4, 1, 5, 1729, 3 }	/**/
 
 /* USE_DYNAMIC_LOADING:
  *	This symbol, if defined, indicates that dynamic loading of


### PR DESCRIPTION
…onal init

PERL_LC_ALL_CATEGORY_POSITIONS_INIT was { 0,1,2,3,4,5 } (glibc LC_* values). On Plan9 APE, LC_ALL=0, so get_category_index(0) returned LC_ALL_INDEX_=6, causing an out-of-bounds write to individ_locales[6] (array size 6) that overwrote the return address on S_new_LC_ALL's stack frame.

Fix: use APE's actual LC_* values in Perl's internal index order:
  CTYPE(idx=0)=2, NUMERIC(idx=1)=4, COLLATE(idx=2)=1,
  TIME(idx=3)=5, MESSAGES(idx=4)=1729, MONETARY(idx=5)=3.