### PR TITLE
perl: bracket init_predump/postdump, dump ptr on sv_setpvn_fresh panic

### DIFF
--- a/sys/src/external/perl/perl.c
+++ b/sys/src/external/perl/perl.c
@@ -2638,12 +2638,17 @@ S_parse_body(pTHX_ char **env, XSINIT_t xsinit)
 #   endif
 #endif
 
+    write(2, "PB: before init_predump_symbols\n", 32);
     init_predump_symbols();
+    write(2, "PB: after init_predump_symbols\n", 31);
     /* init_postdump_symbols not currently designed to be called */
     /* more than once (ENV isn't cleared first, for example)	 */
     /* But running with -u leaves %ENV & @ARGV undefined!    XXX */
-    if (!PL_do_undump)
+    if (!PL_do_undump) {
+        write(2, "PB: before init_postdump_symbols\n", 33);
         init_postdump_symbols(argc,argv,env);
+        write(2, "PB: after init_postdump_symbols\n", 32);
+    }
 
     /* PL_unicode is turned on by -C, or by $ENV{PERL_UNICODE},
      * or explicitly in some platforms.

--- a/sys/src/external/perl/sv.c
+++ b/sys/src/external/perl/sv.c
@@ -5110,9 +5110,22 @@ Perl_sv_setpvn_fresh(pTHX_ SV *const sv, const char *const ptr, const STRLEN len
     if (ptr) {
         const IV iv = len;
         /* len is STRLEN which is unsigned, need to copy to signed */
-        if (iv < 0)
+        if (iv < 0) {
+            /* Dump first 32 bytes of ptr for debugging */
+            char dbgbuf[80];
+            int i, n;
+            write(2, "SVFRESH bad len, ptr=", 21);
+            n = 0;
+            for (i = 0; i < 32 && ptr[i] && n < 60; i++) {
+                if (ptr[i] >= 32 && ptr[i] < 127)
+                    dbgbuf[n++] = ptr[i];
+                else { dbgbuf[n++] = '\\'; dbgbuf[n++] = 'x'; }
+            }
+            dbgbuf[n++] = '\n';
+            write(2, dbgbuf, n);
             croak("panic: sv_setpvn_fresh called with negative strlen %"
                        IVdf, iv);
+        }
 
         dptr = sv_grow_fresh(sv, len + 1);
         Move(ptr,dptr,len,char);


### PR DESCRIPTION
Crash localized to between 'after xsinit' and a 'negative strlen' panic in sv_setpvn_fresh. Add checkpoints around init_predump_symbols and init_postdump_symbols so we know which one triggers the panic, and dump the first 32 bytes of the offending ptr inside sv_setpvn_fresh.

The bad length is 0xFFFFFFFF_0000000A (= -4294967286 signed) — lower 32 bits = real strlen 10, upper 32 = 0xFFFFFFFF. Suggests an ABI mismatch where a 32-bit length result has its upper word polluted.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs