### PR TITLE
perl: cast STR_WITH_LEN sizeof result to size_t for 64-bit varargs sa…

### DIFF
--- a/sys/src/external/perl/handy.h
+++ b/sys/src/external/perl/handy.h
@@ -408,7 +408,7 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
 =cut
 */
 
-#define STR_WITH_LEN(s)  ASSERT_IS_LITERAL(s), (sizeof(s)-1)
+#define STR_WITH_LEN(s)  ASSERT_IS_LITERAL(s), ((size_t)(sizeof(s)-1))
 
 /* STR_WITH_LEN() shortcuts */
 #define newSVpvs(str) Perl_newSVpvn(aTHX_ STR_WITH_LEN(str))


### PR DESCRIPTION
…fety

kencc sizeof() returns ulong (32-bit) on amd64. When passed as a variadic argument to functions like Perl_populate_isa() that call va_arg(args, size_t), only 4 bytes are written into the 8-byte vararg slot, leaving the upper 4 bytes as stack garbage (observed: 0xFFFFFFFF_0000000A for string length 10).

Fix: cast sizeof(s)-1 to (size_t) in STR_WITH_LEN so the value pushed in variadic calls is a proper 64-bit unsigned quantity.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs