### PR TITLE
cc: fix sizeof to return size_t (TUVLONG on 64-bit, TULONG on 32-bit …

### DIFF
--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -718,8 +718,13 @@ tcomo(Node *n, int f)
 		n->op = OCONST;
 		n->left = Z;
 		n->right = Z;
-		n->vconst = convvtox(n->type->width, TINT);
-		n->type = types[TINT];
+		{
+			/* sizeof must return size_t: unsigned 64-bit on LLP64/LP64
+			 * targets (pointer > long), unsigned 32-bit on ILP32 targets */
+			int sztype = ewidth[TIND] > ewidth[TLONG] ? TUVLONG : TULONG;
+			n->vconst = convvtox(n->type->width, sztype);
+			n->type = types[sztype];
+		}
 		break;
 
 	case OTYPEOF:

--- a/sys/src/external/perl/handy.h
+++ b/sys/src/external/perl/handy.h
@@ -408,7 +408,7 @@ Perl_xxx(aTHX_ ...) form for any API calls where it's used.
 =cut
 */
 
-#define STR_WITH_LEN(s)  ASSERT_IS_LITERAL(s), ((size_t)(sizeof(s)-1))
+#define STR_WITH_LEN(s)  ASSERT_IS_LITERAL(s), (sizeof(s)-1)
 
 /* STR_WITH_LEN() shortcuts */
 #define newSVpvs(str) Perl_newSVpvn(aTHX_ STR_WITH_LEN(str))


### PR DESCRIPTION
…targets)

kencc hardcoded sizeof to return TINT (signed 32-bit) on all architectures. The C standard requires sizeof to return size_t, which is unsigned 64-bit on LLP64/LP64 targets (amd64, arm64, power64, sparc64) where pointers are wider than long.

This caused pervasive ABI bugs: any sizeof() result passed as a variadic argument to a function that reads it back as STRLEN/size_t (64-bit) had garbage in the upper 32 bits (observed: 0xFFFFFFFF_0000000A for length 10, triggering 'sv_setpvn_fresh called with negative strlen' in Perl).

Fix: use ewidth[TIND] > ewidth[TLONG] to select TUVLONG (64-bit unsigned) on 64-bit targets, TULONG (32-bit unsigned) on ILP32 targets. Same pattern already used in sub.c:732 and dcl.c:1994.

Also revert the defensive (size_t) cast in STR_WITH_LEN — no longer needed now that sizeof returns the correct type.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs