### PR TITLE
perl: diagnose PL_curcop=NULL crash; guard yylex with recovery

### DIFF
--- a/sys/src/external/perl/op.c
+++ b/sys/src/external/perl/op.c
@@ -1399,8 +1399,10 @@ S_cop_free(pTHX_ COP* cop)
         cop->cop_warnings = rcpv_free(cop->cop_warnings);
 
     cophh_free(CopHINTHASH_get(cop));
-    if (PL_curcop == cop)
+    if (PL_curcop == cop) {
+       write(2, "S_cop_free: PL_curcop=cop -> NULL\n", 34);
        PL_curcop = NULL;
+    }
 }
 
 STATIC void

--- a/sys/src/external/perl/perly.c
+++ b/sys/src/external/perl/perly.c
@@ -361,9 +361,7 @@ Perl_yyparse (pTHX_ int gramtype)
 
             if (parser->yychar == YYEMPTY) {
                 YYDPRINTF ((Perl_debug_log, "Reading a token:\n"));
-                write(2, "YY: before yylex\n", 17);
                 parser->yychar = yylex();
-                write(2, "YY: after yylex\n", 16);
                 assert(parser->yychar >= 0);
                 if (parser->yychar == YYEOF) {
                     YYDPRINTF ((Perl_debug_log, "Now at end of input.\n"));

--- a/sys/src/external/perl/toke.c
+++ b/sys/src/external/perl/toke.c
@@ -9639,6 +9639,11 @@ int
 Perl_yylex(pTHX)
 {
     char *s = PL_bufptr;
+    if (!PL_curcop) {
+        write(2, "yylex: PL_curcop is NULL!\n", 26);
+        /* force a visible crash rather than silent wrong-address fault */
+        PL_curcop = &PL_compiling;
+    }
 
     if (UNLIKELY(PL_parser->recheck_charset_validity)) {
         const U8* first_bad_char_loc;


### PR DESCRIPTION
The crash addr=0x24 pc=0x20d3d5 is CopLINE(PL_curcop) where PL_curcop=NULL. COP struct: BASEOP (36 bytes) + cop_line at offset 0x24.

PL_curcop is set to NULL by S_cop_free (op.c:1402) when a COP is freed while still being the current COP.

Diagnostics added:
- S_cop_free: print when PL_curcop is about to become NULL
- yylex entry: detect NULL PL_curcop, print message, and fall back to &PL_compiling to convert crash to visible diagnostic

Also remove the noisy before/after yylex checkpoints from perly.c.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs