### PR TITLE
perl: add very fine-grained checkpoints in perly.c main parse loop

### DIFF
--- a/sys/src/external/perl/perly.c
+++ b/sys/src/external/perl/perly.c
@@ -332,6 +332,7 @@ Perl_yyparse (pTHX_ int gramtype)
              * element to make this check faster */
 
             if (ps >= parser->stack_max1) {
+                write(2, "YY: growing stack\n", 18);
                 Size_t pos = ps - parser->stack;
                 Size_t newsize = 2 * (parser->stack_max1 + 2 - parser->stack);
                 /* this will croak on insufficient memory */
@@ -352,6 +353,7 @@ Perl_yyparse (pTHX_ int gramtype)
              * lookahead token. */
 
             yyn = yypact[yystate];
+            write(2, "YY: yypact\n", 11);
             if (yyn == YYPACT_NINF)
                 goto yydefault;
 
@@ -399,6 +401,7 @@ Perl_yyparse (pTHX_ int gramtype)
             }
 
             yyn = yytable[yyn];
+            write(2, "YY: yytable\n", 12);
             if (yyn <= 0) {
                 if (yyn == 0 || yyn == YYTABLE_NINF)
                     goto yyerrlab;
@@ -416,6 +419,7 @@ Perl_yyparse (pTHX_ int gramtype)
             if (parser->yychar != YYEOF)
                 parser->yychar = YYEMPTY;
 
+            write(2, "YY: shift\n", 10);
             YYPUSHSTACK;
             ps->state   = yyn;
             ps->val     = parser->yylval;
@@ -450,6 +454,7 @@ Perl_yyparse (pTHX_ int gramtype)
         YY_STACK_PRINT(parser);
         YY_REDUCE_PRINT (yyn);
 
+        write(2, "YY: reduce\n", 11);
         switch (yyn) {
 
     /* contains all the rule actions; auto-generated from perly.y */


### PR DESCRIPTION
The crash now happens immediately after 'entering main loop' before any yylex call. Add checkpoints after yypact lookup, yytable lookup, shift action, and reduce action to pinpoint the exact crash location.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs