### PR TITLE
perl: fix rule# printer bug, add PL_curcop dump, guard newSTATEOP

### DIFF
--- a/sys/src/external/perl/op.c
+++ b/sys/src/external/perl/op.c
@@ -8909,6 +8909,11 @@ Perl_newSTATEOP(pTHX_ I32 flags, char *label, OP *o)
 
     flags &= ~SVf_UTF8;
 
+    if (!PL_curcop) {
+        write(2, "newSTATEOP: PL_curcop is NULL, using PL_compiling\n", 50);
+        PL_curcop = &PL_compiling;
+    }
+
     NewOp(1101, cop, 1, COP);
     if (PERLDB_LINE && CopLINE(PL_curcop) && PL_curstash != PL_debstash) {
         OpTYPE_set(cop, OP_DBSTATE);

--- a/sys/src/external/perl/perly.c
+++ b/sys/src/external/perl/perly.c
@@ -451,14 +451,19 @@ Perl_yyparse (pTHX_ int gramtype)
         YY_REDUCE_PRINT (yyn);
 
         {
-            /* print rule number as decimal */
-            char _rdbuf[16]; int _rdi=0; int _ryn=yyn;
+            /* print rule number and PL_curcop as hex */
+            char _rdbuf[48]; int _rdi=0; int _ryn=yyn;
+            unsigned long long _cop=(unsigned long long)(void*)PL_curcop;
+            const char *_hx="0123456789abcdef";
+            int _i;
             _rdbuf[_rdi++]='R'; _rdbuf[_rdi++]=':';
             if(_ryn==0){_rdbuf[_rdi++]='0';}else{
                 char _tmp[12]; int _ti=0;
                 while(_ryn>0){_tmp[_ti++]='0'+(_ryn%10);_ryn/=10;}
-                while(_ti-->0)_rdbuf[_rdi++]=_tmp[_ti+1];
+                while(_ti-->0)_rdbuf[_rdi++]=_tmp[_ti];
             }
+            _rdbuf[_rdi++]=' '; _rdbuf[_rdi++]='c'; _rdbuf[_rdi++]='=';
+            for(_i=60;_i>=0;_i-=4) _rdbuf[_rdi++]=_hx[(_cop>>_i)&0xf];
             _rdbuf[_rdi++]='\n';
             write(2,_rdbuf,_rdi);
         }


### PR DESCRIPTION
Three changes to diagnose/fix the yyparse crash at addr=0x24:

1. perly.c rule number printer: `_tmp[_ti+1]` → `_tmp[_ti]` in the digit-reversal loop. The old code skipped the most-significant digit and printed an uninitialized byte in its place, making all rule numbers unreadable (wrong and garbage-prefixed).

2. perly.c: extend the per-reduction diagnostic to also print PL_curcop as a 16-char hex value, so we can see exactly which reduction first leaves PL_curcop==NULL (the root cause of the crash at addr=0x24 which is COP.cop_line at offset 36 from a NULL PL_curcop).

3. op.c (→ opmini.c via symlink): add NULL guard at the top of Perl_newSTATEOP. The function is documented to accept PL_curcop or PL_compiling; when PL_curcop is NULL it falls back to &PL_compiling and prints a diagnostic so we can see how often this path is taken.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs