### PR TITLE
perl: diagnose crash in S_new_logop; fix S_croak_overflow forward decl

### DIFF
--- a/sys/src/external/perl/op.c
+++ b/sys/src/external/perl/op.c
@@ -9069,6 +9069,24 @@ S_new_logop(pTHX_ I32 type, I32 flags, OP** firstp, OP** otherp)
     first = *firstp;
     other = *otherp;
 
+    {
+        char _lb[80]; int _li=0;
+        const char *_hx="0123456789abcdef";
+        int _i;
+        unsigned long long _f=(unsigned long long)(void*)first;
+        unsigned long long _o=(unsigned long long)(void*)other;
+        unsigned int _ft=first?(unsigned int)first->op_type:0xDEAD;
+        _lb[_li++]='L'; _lb[_li++]='G'; _lb[_li++]='P'; _lb[_li++]=' ';
+        _lb[_li++]='f'; _lb[_li++]='=';
+        for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_f>>_i)&0xf];
+        _lb[_li++]=' '; _lb[_li++]='o'; _lb[_li++]='=';
+        for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_o>>_i)&0xf];
+        _lb[_li++]=' '; _lb[_li++]='f'; _lb[_li++]='t'; _lb[_li++]='=';
+        for(_i=12;_i>=0;_i-=4) _lb[_li++]=_hx[(_ft>>_i)&0xf];
+        _lb[_li++]='\n';
+        write(2,_lb,_li);
+    }
+
     if (type == OP_XOR)		/* Not short circuit, but here by precedence. */
         return newBINOP(type, flags, scalar(first), scalar(other));
 

--- a/sys/src/external/perl/sv.c
+++ b/sys/src/external/perl/sv.c
@@ -11459,6 +11459,8 @@ S_warn_vcatpvfn_missing_argument(pTHX) {
               PL_op ? OP_DESC(PL_op) : "sv_vcatpvfn()");
 }
 
+static void S_croak_overflow(void);
+
 
 static void
 S_croak_overflow()


### PR DESCRIPTION
1. op.c (S_new_logop): add diagnostic write() to print first/other OP pointer values and first->op_type before any code runs. This will pinpoint which pointer causes the addr=0x24 crash (which is a NULL OP dereference at op_first, offset 36 in LOGOP/UNOP/BINOP on Plan9 amd64 where kencc uses 4-byte struct alignment for all types). PL_curcop is confirmed non-NULL throughout — the problem is something else inside new_logop (rule 148: expr ANDOP expr).

2. sv.c: add forward declaration for S_croak_overflow() before its first use-site to silence the "undeclared" warning from pcc/kencc. All calls are after the definition but pcc may still warn without a prototype visible when it first processes those call sites.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs