### PR TITLE
perl: fix peep.c NULL sibparent crash; add SCOPEDIAG/CFDIAG/LLDIAG di…

### DIFF
--- a/sys/src/external/perl/op.c
+++ b/sys/src/external/perl/op.c
@@ -4570,6 +4570,31 @@ Perl_op_scope(pTHX_ OP *o)
             o = op_prepend_elem(OP_LINESEQ,
                     newOP(OP_ENTER, (o->op_flags & OPf_WANT)), o);
             OpTYPE_set(o, OP_LEAVE);
+            /* SCOPEDIAG: print OP_ENTER sibparent right after op_scope wraps */
+            if (o->op_flags & OPf_KIDS) {
+                OP *_en = cLISTOPo->op_first;
+                if (_en && _en->op_type == OP_ENTER) {
+                    char _lb[128]; int _li=0;
+                    const char *_hx="0123456789abcdef";
+                    unsigned long long _oa=(unsigned long long)(void*)o;
+                    unsigned long long _ea=(unsigned long long)(void*)_en;
+                    unsigned int _em=(unsigned int)_en->op_moresib;
+                    unsigned long long _esp=(unsigned long long)(void*)_en->op_sibparent;
+                    int _i;
+                    _lb[_li++]='S'; _lb[_li++]='C'; _lb[_li++]='O'; _lb[_li++]='P';
+                    _lb[_li++]='E'; _lb[_li++]='D'; _lb[_li++]='I'; _lb[_li++]='A';
+                    _lb[_li++]='G'; _lb[_li++]=' ';
+                    _lb[_li++]='L'; _lb[_li++]='=';
+                    for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_oa>>_i)&0xf];
+                    _lb[_li++]=' '; _lb[_li++]='E'; _lb[_li++]='=';
+                    for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_ea>>_i)&0xf];
+                    _lb[_li++]=' '; _lb[_li++]='m'; _lb[_li++]='=';
+                    _lb[_li++]=_hx[_em&0xf];
+                    _lb[_li++]=' '; _lb[_li++]='s'; _lb[_li++]='p'; _lb[_li++]='=';
+                    for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_esp>>_i)&0xf];
+                    _lb[_li++]='\n'; write(2,_lb,_li);
+                }
+            }
         }
         else if (o->op_type == OP_LINESEQ) {
             OP *kid;
@@ -9143,6 +9168,34 @@ S_new_logop(pTHX_ I32 type, I32 flags, OP** firstp, OP** otherp)
             op_free(first);
             if (other->op_type == OP_LEAVE)
                 other = newUNOP(OP_NULL, OPf_SPECIAL, other);
+            /* CFDIAG: print OP_NULL subtree after constant-fold wrap */
+            if (other->op_type == OP_NULL) {
+                OP *_lv = (other->op_flags & OPf_KIDS) ? cUNOPx(other)->op_first : NULL;
+                if (_lv && _lv->op_type == OP_LEAVE) {
+                    OP *_en = (_lv->op_flags & OPf_KIDS) ? cLISTOPx(_lv)->op_first : NULL;
+                    char _lb[128]; int _li=0;
+                    const char *_hx="0123456789abcdef";
+                    unsigned long long _na=(unsigned long long)(void*)other;
+                    unsigned long long _la=(unsigned long long)(void*)_lv;
+                    unsigned long long _ea=_en?(unsigned long long)(void*)_en:0;
+                    unsigned int _em=_en?(unsigned int)_en->op_moresib:0xFF;
+                    unsigned long long _esp=_en?(unsigned long long)(void*)_en->op_sibparent:0;
+                    int _i;
+                    _lb[_li++]='C'; _lb[_li++]='F'; _lb[_li++]='D'; _lb[_li++]='I';
+                    _lb[_li++]='A'; _lb[_li++]='G'; _lb[_li++]=' ';
+                    _lb[_li++]='N'; _lb[_li++]='=';
+                    for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_na>>_i)&0xf];
+                    _lb[_li++]=' '; _lb[_li++]='L'; _lb[_li++]='=';
+                    for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_la>>_i)&0xf];
+                    _lb[_li++]=' '; _lb[_li++]='E'; _lb[_li++]='=';
+                    for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_ea>>_i)&0xf];
+                    _lb[_li++]=' '; _lb[_li++]='m'; _lb[_li++]='=';
+                    _lb[_li++]=_hx[_em&0xf];
+                    _lb[_li++]=' '; _lb[_li++]='s'; _lb[_li++]='p'; _lb[_li++]='=';
+                    for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_esp>>_i)&0xf];
+                    _lb[_li++]='\n'; write(2,_lb,_li);
+                }
+            }
             else if (other->op_type == OP_MATCH
                   || other->op_type == OP_SUBST
                   || other->op_type == OP_TRANSR
@@ -9248,6 +9301,36 @@ S_new_logop(pTHX_ I32 type, I32 flags, OP** firstp, OP** otherp)
     logop->op_private = (U8)(1 | (flags >> 8));
 
     /* establish postfix order */
+    /* LLDIAG: if first is OP_NULL->OP_LEAVE->OP_ENTER, check OP_ENTER sibparent */
+    if (first->op_type == OP_NULL && (first->op_flags & OPf_KIDS)) {
+        OP *_lv = cUNOPx(first)->op_first;
+        if (_lv && _lv->op_type == OP_LEAVE && (_lv->op_flags & OPf_KIDS)) {
+            OP *_en = cLISTOPx(_lv)->op_first;
+            if (_en && _en->op_type == OP_ENTER) {
+                char _lb[128]; int _li=0;
+                const char *_hx="0123456789abcdef";
+                unsigned long long _na=(unsigned long long)(void*)first;
+                unsigned long long _la=(unsigned long long)(void*)_lv;
+                unsigned long long _ea=(unsigned long long)(void*)_en;
+                unsigned int _em=(unsigned int)_en->op_moresib;
+                unsigned long long _esp=(unsigned long long)(void*)_en->op_sibparent;
+                int _i;
+                _lb[_li++]='L'; _lb[_li++]='L'; _lb[_li++]='D'; _lb[_li++]='I';
+                _lb[_li++]='A'; _lb[_li++]='G'; _lb[_li++]=' ';
+                _lb[_li++]='N'; _lb[_li++]='=';
+                for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_na>>_i)&0xf];
+                _lb[_li++]=' '; _lb[_li++]='L'; _lb[_li++]='=';
+                for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_la>>_i)&0xf];
+                _lb[_li++]=' '; _lb[_li++]='E'; _lb[_li++]='=';
+                for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_ea>>_i)&0xf];
+                _lb[_li++]=' '; _lb[_li++]='m'; _lb[_li++]='=';
+                _lb[_li++]=_hx[_em&0xf];
+                _lb[_li++]=' '; _lb[_li++]='s'; _lb[_li++]='p'; _lb[_li++]='=';
+                for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_esp>>_i)&0xf];
+                _lb[_li++]='\n'; write(2,_lb,_li);
+            }
+        }
+    }
     logop->op_next = LINKLIST(first);
     first->op_next = (OP*)logop;
     assert(!OpHAS_SIBLING(first));

--- a/sys/src/external/perl/peep.c
+++ b/sys/src/external/perl/peep.c
@@ -1160,8 +1160,12 @@ S_optimize_op(pTHX_ OP* o)
                 return; /* at top; no parents/siblings to try */
             if (OpHAS_SIBLING(o))
                 next_kid = o->op_sibparent;
-            else
-                o = o->op_sibparent; /*try parent's next sibling */
+            else {
+                OP *_par = o->op_sibparent;
+                if (!_par)
+                    return; /* detached/partially-built subtree; skip */
+                o = _par; /*try parent's next sibling */
+            }
         }
 
       /* this label not yet used. Goto here if any code above sets


### PR DESCRIPTION
…agnostics

Fix crash in rpeep() at peep.c:1161: when o->op_sibparent is NULL (OP_ENTER with unset sibparent), the loop tries OpHAS_SIBLING(NULL) which faults. Guard: when climbing to parent and sibparent==NULL, return early just like op_linklist's LLNULL guard.

Add three diagnostic prints to track the origin of the NULL sibparent:
- SCOPEDIAG: printed by op_scope right after OP_ENTER is created and prepended to OP_LEAVE; shows OP_ENTER's initial moresib and sibparent.
- CFDIAG: printed by S_new_logop constant-fold path right after wrapping OP_LEAVE in OP_NULL; shows OP_ENTER's state at that moment.
- LLDIAG: printed by S_new_logop just before LINKLIST(first) when first is OP_NULL->OP_LEAVE->OP_ENTER; shows OP_ENTER's state immediately before the linklist traversal that triggers LLNULL.

Comparing SCOPEDIAG vs CFDIAG vs LLDIAG will reveal when/where sibparent is set to NULL.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs