### PR TITLE
perl: fix OpMAYBESIB_set bitfield-expression-value bug on Plan9 kencc

### DIFF
--- a/sys/src/external/perl/op.c
+++ b/sys/src/external/perl/op.c
@@ -1622,6 +1622,24 @@ Perl_op_sibling_splice(pTHX_ OP *parent, OP *start, int del_count, OP* insert)
         while (OpHAS_SIBLING(last_ins))
             last_ins = OpSIBLING(last_ins);
         OpMAYBESIB_set(last_ins, rest, NULL);
+        /* SPLDIAG: verify OpMAYBESIB_set for OP_ENTER */
+        if (last_ins->op_type == OP_ENTER && rest != NULL) {
+            char _lb[80]; int _li=0;
+            const char *_hx="0123456789abcdef";
+            unsigned long long _ra=(unsigned long long)(void*)rest;
+            unsigned long long _sp=(unsigned long long)(void*)last_ins->op_sibparent;
+            unsigned int _m=(unsigned int)last_ins->op_moresib;
+            int _i;
+            _lb[_li++]='S'; _lb[_li++]='P'; _lb[_li++]='L'; _lb[_li++]='D';
+            _lb[_li++]='I'; _lb[_li++]='A'; _lb[_li++]='G'; _lb[_li++]=' ';
+            _lb[_li++]='r'; _lb[_li++]='=';
+            for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_ra>>_i)&0xf];
+            _lb[_li++]=' '; _lb[_li++]='m'; _lb[_li++]='=';
+            _lb[_li++]=_hx[_m&0xf];
+            _lb[_li++]=' '; _lb[_li++]='s'; _lb[_li++]='p'; _lb[_li++]='=';
+            for(_i=60;_i>=0;_i-=4) _lb[_li++]=_hx[(_sp>>_i)&0xf];
+            _lb[_li++]='\n'; write(2,_lb,_li);
+        }
     }
     else
         insert = rest;

--- a/sys/src/external/perl/op.h
+++ b/sys/src/external/perl/op.h
@@ -1098,8 +1098,11 @@ C<sib> is non-null. For a higher-level interface, see C<L</op_sibling_splice>>.
 #define OpMORESIB_set(o, sib) ((o)->op_moresib = 1, (o)->op_sibparent = (sib))
 #define OpLASTSIB_set(o, parent) \
     ((o)->op_moresib = 0, (o)->op_sibparent = (parent))
+/* Plan9 kencc: bitfield-assign expression value is unreliable; use comma
+ * operator so (sib) is tested directly, not via the bitfield result. */
 #define OpMAYBESIB_set(o, sib, parent) \
-    ((o)->op_sibparent = ((o)->op_moresib = cBOOL(sib)) ? (sib) : (parent))
+    ((o)->op_moresib = cBOOL(sib),     \
+     (o)->op_sibparent = (sib) ? (sib) : (parent))
 
 #if !defined(PERL_CORE) && !defined(PERL_EXT)
 /* for backwards compatibility only */


### PR DESCRIPTION
The diagnostic output showed SCOPEDIAG: L=84a920 E=84bb48 m=0 sp=0000... meaning OP_ENTER's sibparent is NULL right out of op_scope, before any constant folding or peephole optimization.

Root cause: OpMAYBESIB_set relied on the expression value of a bitfield assignment to drive a ternary:
  ((o)->op_sibparent = ((o)->op_moresib = cBOOL(sib)) ? (sib) : (parent))

Plan9's kencc uses tfield=types[TINT] (32-bit container) for all bitfields regardless of the declared type (U16 for PERL_BITFIELD16). The bitfield WRITE works correctly, but the bitfield assignment EXPRESSION VALUE appears to evaluate to 0 in kencc's code generator, causing the ternary to always pick 'parent' (which is NULL in all op_sibling_splice call sites).

Fix: use comma operator so (sib) is evaluated directly in the ternary, not via the bitfield assignment result:
  ((o)->op_moresib = cBOOL(sib),
   (o)->op_sibparent = (sib) ? (sib) : (parent))

All callers pass simple variable expressions for sib so double evaluation is safe.

Also add SPLDIAG in op_sibling_splice to verify the fix: prints rest, moresib, and sibparent after OpMAYBESIB_set when inserting OP_ENTER with a non-NULL rest (sibling).

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs