### PR TITLE
cc/dcl.c: restrict GNORET check in rsametype() to TFUNC nodes

### DIFF
--- a/sys/src/cmd/cc/dcl.c
+++ b/sys/src/cmd/cc/dcl.c
@@ -1261,9 +1261,10 @@ rsametype(Type *t1, Type *t2, int n, int f)
 		et = t1->etype;
 		if(et != t2->etype)
 			return 0;
-		if((t1->garb & GNORET) != (t2->garb & GNORET))
-			return 0;
 		if(et == TFUNC) {
+			/* _Noreturn is part of a function type's identity */
+			if((t1->garb & GNORET) != (t2->garb & GNORET))
+				return 0;
 			if(!rsametype(t1->link, t2->link, n, 0))
 				return 0;
 			t1 = t1->down;


### PR DESCRIPTION
GNORET is the garb bit set by _Noreturn.  It is semantically meaningful only on TFUNC types (a _Noreturn void f() is genuinely different from void f() when comparing function-pointer types).  Checking GNORET on TIND (pointer) nodes caused false prototype-mismatch errors: callers passing pthread_mutex_t* (IND STRUCT pthread_mutex) were rejected because the prototype's TIND node had GNORET set, printed as "NORET IND STRUCT pthread_mutex".  Pointers and structs have no "noreturn" attribute, so the mismatch check was incorrect.

Fix: move the GNORET check inside the et==TFUNC branch so it is only applied when comparing function types.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs