### PR TITLE
malloc: fix aligned_alloc/posix_memalign to be free()-safe; mmap: red…

### DIFF
--- a/sys/src/ape/lib/ap/malloc/aligned_alloc.c
+++ b/sys/src/ape/lib/ap/malloc/aligned_alloc.c
@@ -1,97 +1,79 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <stdint.h>
+#include "malloc_align.h"
 
 /*
- * aligned_alloc(alignment, size) — allocate size bytes aligned to alignment.
+ * aligned_alloc(alignment, size) — C11 §7.22.3.1
  *
- * C11 §7.22.3.1: alignment must be a power of two and a valid alignment
- * supported by the implementation.  size must be a multiple of alignment
- * (though many callers omit this; we relax it here for compatibility).
+ * APE malloc guarantees 16-byte alignment (datoff = 16).
  *
- * APE malloc alignment constraints
- * ---------------------------------
- * APE's malloc returns pointers at exactly datoff=16 bytes past a Bucket
- * header, so it guarantees 16-byte alignment.  free() recomputes the
- * header as (ptr - datoff) and checks the MAGIC field — meaning free()
- * is only safe on a pointer that is the exact value returned by malloc().
+ * Strategy for alignment > 16:
  *
- * Strategy:
- *   alignment <= 16: malloc already satisfies it; return directly.
- *   alignment >  16: over-allocate by (alignment - 16) bytes so that
- *                    among the returned block there is always at least
- *                    one address that is alignment-aligned AND is exactly
- *                    datoff bytes past a correctly-placed Bucket header.
+ * 1. Retry loop (MAX_TRIES attempts): allocate a block large enough
+ *    for size bytes and return it only if malloc happened to return
+ *    an alignment-aligned pointer.  Since APE uses power-of-two
+ *    bucket sizes, common SIMD alignments (32, 64) succeed within
+ *    1-2 tries.
  *
- *                    We achieve this by allocating the block such that
- *                    the malloc return value itself satisfies alignment:
- *                    keep retrying with fresh malloc calls until we get
- *                    a suitably aligned pointer.  In practice this takes
- *                    at most 2 attempts for power-of-two alignments up to
- *                    the sbrk page size.
+ * 2. Safe fallback: over-allocate, find the aligned address within
+ *    the block, and write an ALIGN_MAGIC sentinel at (aligned - DATOFF).
+ *    free() in free.c detects ALIGN_MAGIC and redirects to the
+ *    original malloc pointer, so free() works correctly on the result.
  *
- *                    If after MAX_TRIES the pointer is still not aligned,
- *                    fall back to the over-allocate-and-adjust approach;
- *                    in that case the returned pointer cannot be passed
- *                    directly to free() — callers must use the original
- *                    malloc pointer.  This is noted for transparency;
- *                    the common Plan9 use case (SIMD alignment ≤ 32) is
- *                    handled by the retry loop in the vast majority of
- *                    real allocations.
+ * The fallback adds DATOFF (16) + alignment - 1 bytes of overhead.
  */
 
-#define MALLOC_ALIGN    16      /* APE malloc return alignment */
-#define MAX_TRIES       8       /* retry attempts before fallback */
+#define MALLOC_ALIGN  16
+#define MAX_TRIES     16
 
 void *
 aligned_alloc(size_t alignment, size_t size)
 {
-	void *p;
-	int i;
+	void *raw, *aligned;
+	size_t i, total;
 
-	/* alignment must be a power of two */
 	if(alignment == 0 || (alignment & (alignment - 1)) != 0) {
 		errno = EINVAL;
 		return 0;
 	}
-
 	if(size == 0)
-		return malloc(1);  /* implementation-defined; return non-NULL */
+		return malloc(1);
 
-	/* Fast path: malloc already satisfies small alignments */
 	if(alignment <= MALLOC_ALIGN)
 		return malloc(size);
 
-	/*
-	 * For larger alignments, try to get a naturally-aligned block
-	 * by retrying malloc.  Since APE's malloc uses a power-of-two
-	 * bucket allocator with sbrk, consecutive calls often return
-	 * sequentially addressed blocks, so alignment is achieved quickly.
-	 *
-	 * We allocate (size + alignment - MALLOC_ALIGN) to ensure the
-	 * block is large enough regardless of which aligned offset we use.
-	 * But we only return it if the pointer itself is aligned, so free()
-	 * works correctly (ptr == original malloc return == bp->data).
-	 */
+	/* retry loop: fast path for common alignments */
 	for(i = 0; i < MAX_TRIES; i++) {
-		p = malloc(size + alignment - MALLOC_ALIGN);
-		if(p == 0)
+		raw = malloc(size + alignment - MALLOC_ALIGN);
+		if(raw == 0)
 			return 0;
-		if(((uintptr_t)p & (alignment - 1)) == 0)
-			return p;  /* aligned and free()-safe */
-		free(p);
+		if(((uintptr_t)raw & (alignment - 1)) == 0)
+			return raw;   /* aligned; free() works directly */
+		free(raw);
 	}
 
 	/*
-	 * Fallback: over-allocate and adjust.  The returned pointer is
-	 * alignment-aligned but is NOT the original malloc return value,
-	 * so free() on it will abort.  Callers that need free()-safe
-	 * aligned memory for alignment > MALLOC_ALIGN should use
-	 * posix_memalign() which documents this limitation explicitly,
-	 * or use a slab/pool allocator.
+	 * Safe fallback: allocate DATOFF + alignment - 1 extra bytes so we
+	 * can always find an aligned address with room for the sentinel.
+	 *
+	 * Layout (raw = malloc return):
+	 *   raw ... [DATOFF bytes of sentinel] [aligned] ... [size bytes]
+	 *
+	 * We need: aligned >= raw + DATOFF  (room for sentinel before it)
+	 *          aligned % alignment == 0
+	 *          aligned + size <= raw + total
 	 */
-	p = malloc(size + alignment);
-	if(p == 0)
+	total = size + DATOFF + alignment - 1;
+	raw = malloc(total);
+	if(raw == 0)
 		return 0;
-	return (void *)(((uintptr_t)p + alignment - 1) & ~(uintptr_t)(alignment - 1));
+
+	/* first alignment-aligned address at or after (raw + DATOFF) */
+	aligned = (void *)(((uintptr_t)raw + DATOFF + alignment - 1)
+	                   & ~(uintptr_t)(alignment - 1));
+
+	/* write the sentinel so free() can find raw */
+	malign_place(aligned, raw);
+	return aligned;
 }

--- a/sys/src/ape/lib/ap/malloc/free.c
+++ b/sys/src/ape/lib/ap/malloc/free.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include <lock.h>
+#include "malloc_align.h"
 
 enum
 {
@@ -55,8 +56,14 @@ free(void *ptr)
 	/* Find the start of the structure */
 	bp = (Bucket*)((uintptr_t)ptr - datoff);
 
-	if(bp->magic != MAGIC)
+	if(bp->magic != MAGIC) {
+		/* aligned-fallback block: header written by aligned_alloc/posix_memalign */
+		if(malign_check(bp)) {
+			free(malign_orig(bp));
+			return;
+		}
 		abort();
+	}
 	if(bp->size <= 0 || bp->size >= MAX2SIZE)
 		abort();
 

--- a/sys/src/ape/lib/ap/malloc/malloc_align.h
+++ b/sys/src/ape/lib/ap/malloc/malloc_align.h
@@ -1,0 +1,53 @@
+/*
+ * malloc_align.h — shared definitions for aligned allocation
+ *
+ * APE's free() computes bp = (Bucket*)(ptr - datoff) and checks
+ * bp->magic == MAGIC.  datoff is always 16 (the Bucket header
+ * is padded to 16 bytes on all APE targets).
+ *
+ * For over-allocated aligned blocks, we place an AlignHdr at
+ * (aligned_ptr - DATOFF) — exactly where free() looks.  free()
+ * detects ALIGN_MAGIC there and recurses with the original
+ * malloc return value instead of aborting.
+ *
+ * AlignHdr layout (16 bytes = DATOFF, offsets are byte-level):
+ *   [0..3]  int  magic   — ALIGN_MAGIC
+ *   [4..7]  int  _pad
+ *   [8..15] void *orig   — original malloc() return value
+ *
+ * The .orig field starts at byte 8 on all targets:
+ *   - 64-bit: int(4)+int(4)+void*(8) = 16 bytes ✓
+ *   - 32-bit: int(4)+int(4)+void*(4) = 12 bytes, but we only use
+ *             bytes 8..11 so 16-byte extent is still safe ✓
+ */
+
+#ifndef _MALLOC_ALIGN_H
+#define _MALLOC_ALIGN_H
+
+#include <stdint.h>
+
+#define DATOFF       16                 /* must match datoff in malloc.c/free.c */
+#define ALIGN_MAGIC  0xA11900CC        /* sentinel for aligned-fallback blocks  */
+
+static inline void
+malign_place(void *aligned, void *orig)
+{
+	char *hdr = (char*)aligned - DATOFF;
+	*(int*)(hdr + 0) = (int)ALIGN_MAGIC;
+	*(int*)(hdr + 4) = 0;
+	*(void**)(hdr + 8) = orig;
+}
+
+static inline int
+malign_check(void *bp_ptr)
+{
+	return *(int*)bp_ptr == (int)ALIGN_MAGIC;
+}
+
+static inline void*
+malign_orig(void *bp_ptr)
+{
+	return *(void**)((char*)bp_ptr + 8);
+}
+
+#endif /* _MALLOC_ALIGN_H */

--- a/sys/src/ape/lib/ap/malloc/posix_memalign.c
+++ b/sys/src/ape/lib/ap/malloc/posix_memalign.c
@@ -1,89 +1,64 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <stdint.h>
-#include <string.h>
+#include "malloc_align.h"
 
 /*
- * posix_memalign - allocate aligned memory
+ * posix_memalign — POSIX aligned allocation, freeable with free().
  *
- * POSIX requires that the returned pointer be freeable with free().
- * APE's malloc uses a fixed header offset (datoff) to find the block
- * header from the returned pointer, so we cannot return an adjusted
- * pointer — free() would compute the wrong header address and abort.
- *
- * The correct approach: over-allocate by (alignment - 1) bytes, then
- * find the first aligned address within the allocation that is also
- * exactly a valid malloc return value (i.e. at offset 0 from what
- * malloc returned). This is only possible if malloc itself returns
- * at least (alignment)-aligned memory.
- *
- * Since APE's malloc aligns to 16 bytes (the Bucket pad size), we
- * satisfy any alignment <= 16 directly. For larger alignments we
- * over-allocate and return the original malloc pointer only when it
- * happens to be aligned, retrying with a fresh allocation — but this
- * is unreliable.
- *
- * The honest solution: for alignment <= 16, just malloc(size) since
- * APE malloc already guarantees 16-byte alignment. For alignment > 16
- * (rare in practice on Plan9 targets), we over-allocate and accept
- * that only programs that don't call free() on the result are safe —
- * or use a wrapper free that searches back for the real header.
- *
- * For APExp's purposes (satisfying configure probes and common use),
- * alignment <= 16 covers virtually all real callers.
+ * Uses the same retry-then-safe-fallback strategy as aligned_alloc.c.
+ * See malloc_align.h for the ALIGN_MAGIC sentinel mechanism that
+ * makes the fallback pointer correctly handled by free().
  */
 
-/* APE malloc guarantees at least this alignment */
 #define MALLOC_ALIGN 16
+#define MAX_TRIES    16
 
 int
 posix_memalign(void **memptr, size_t alignment, size_t size)
 {
-	void *p;
+	void *raw, *aligned;
+	size_t i, total;
 
 	if(memptr == NULL)
 		return EINVAL;
-
-	/* alignment must be power of two and >= sizeof(void*) */
 	if(alignment < sizeof(void*) || (alignment & (alignment - 1)) != 0)
 		return EINVAL;
 
-	if(size == 0){
+	if(size == 0) {
 		*memptr = NULL;
 		return 0;
 	}
 
-	/*
-	 * For alignments <= MALLOC_ALIGN, malloc already satisfies the
-	 * requirement. Return the malloc pointer directly so free() works.
-	 */
-	if(alignment <= MALLOC_ALIGN){
-		p = malloc(size);
-		if(p == NULL)
+	if(alignment <= MALLOC_ALIGN) {
+		raw = malloc(size);
+		if(raw == NULL)
 			return ENOMEM;
-		*memptr = p;
+		*memptr = raw;
 		return 0;
 	}
 
-	/*
-	 * For larger alignments: over-allocate so we can find an aligned
-	 * address, but note this pointer cannot be passed to free() safely.
-	 * Allocate size + alignment so that an aligned address exists within.
-	 * This satisfies link-time and configure probes; programs that use
-	 * large-alignment posix_memalign AND call free() on the result will
-	 * need a proper aligned allocator.
-	 */
-	p = malloc(size + alignment);
-	if(p == NULL)
+	/* retry loop: fast path for common alignments */
+	for(i = 0; i < MAX_TRIES; i++) {
+		raw = malloc(size + alignment - MALLOC_ALIGN);
+		if(raw == NULL)
+			return ENOMEM;
+		if(((uintptr_t)raw & (alignment - 1)) == 0) {
+			*memptr = raw;
+			return 0;
+		}
+		free(raw);
+	}
+
+	/* safe fallback via ALIGN_MAGIC sentinel */
+	total = size + DATOFF + alignment - 1;
+	raw = malloc(total);
+	if(raw == NULL)
 		return ENOMEM;
 
-	/* round up to alignment */
-	*memptr = (void*)(((uintptr_t)p + alignment - 1) & ~(uintptr_t)(alignment - 1));
-
-	/*
-	 * If the aligned pointer equals p, free() will work correctly.
-	 * If not, the caller must not call free() on *memptr for
-	 * alignment > MALLOC_ALIGN. This is noted here for transparency.
-	 */
+	aligned = (void *)(((uintptr_t)raw + DATOFF + alignment - 1)
+	                   & ~(uintptr_t)(alignment - 1));
+	malign_place(aligned, raw);
+	*memptr = aligned;
 	return 0;
 }

--- a/sys/src/ape/lib/ap/plan9/__p9_syscall.c
+++ b/sys/src/ape/lib/ap/plan9/__p9_syscall.c
@@ -143,18 +143,35 @@ p9retl(long r)
 #define O_CLOEXEC OCEXEC
 #endif
 
+/*
+ * Plan9 allows only ~8 segments per process (NSEG in the kernel).
+ * Using segattach for every mmap quickly exhausts this limit, causing
+ * "insufficient physical memory" errors.  Strategy:
+ *
+ *   anonymous, len < SEG_THRESHOLD: use malloc() (no new segment, sbrk-backed)
+ *   anonymous, len >= SEG_THRESHOLD: use segattach() (page-aligned, zeroed)
+ *   file-backed: always read into malloc'd buffer (MAP_SHARED write-back
+ *                is not supported — changes are private)
+ *
+ * Lowering SEG_THRESHOLD from 65536 to 1MB dramatically reduces the
+ * number of segattach calls for programs like bash that use mmap as
+ * a general allocator for medium-sized chunks.
+ */
+#define SEG_THRESHOLD (1024*1024)   /* 1 MB — use segattach only above this */
+
 static long
 p9_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 {
 	void *p;
+	int is_seg;
 	(void)prot;  /* Plan9 has no per-page protection */
 
-	/* MAP_FIXED at a specific address is not supportable in userland */
+	/* MAP_FIXED to a specific non-NULL address is not supportable */
 	if((flags & MAP_FIXED) && addr != NULL)
 		return -EINVAL;
 
-	/* allocate backing memory */
-	if(len >= 65536){
+	is_seg = (len >= SEG_THRESHOLD);
+	if(is_seg){
 		p = _SEGATTACH(0, "memory", 0, len);
 		if(p == (void*)-1)
 			return -ENOMEM;
@@ -165,15 +182,14 @@ p9_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 	}
 	memset(p, 0, len);
 
-	/* file-backed mapping: read file contents into the buffer.
-	 * Write-back (MAP_SHARED) is not supported; changes are private. */
+	/* file-backed mapping: read file contents into buffer */
 	if(!(flags & (MAP_ANONYMOUS|MAP_ANON)) && fd != -1){
 		ssize_t n;
 		if(off != 0)
 			lseek(fd, off, SEEK_SET);
 		n = read(fd, p, len);
 		if(n < 0){
-			if(len >= 65536) _SEGDETACH(p);
+			if(is_seg) _SEGDETACH(p);
 			else free(p);
 			return -EIO;
 		}
@@ -181,15 +197,20 @@ p9_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 	return (long)(uintptr_t)p;
 }
 
-/* We can't reliably know whether an address came from segattach or
- * malloc, so we track segattach regions in a small table. */
-#define MMAP_TABLE_SIZE 256
-static struct {
-	void *addr;
+/*
+ * mmap tracking table.
+ *
+ * Tracks (addr, is_seg) so munmap can call the correct release function.
+ * Uses a dynamically grown array so it never silently overflows — a full
+ * fixed table would cause munmap to not find entries and leak memory/segments.
+ */
+static struct MmapEntry {
+	void  *addr;
 	size_t len;
-	int   is_seg;   /* 1 = segattach, 0 = malloc */
-} mmap_table[MMAP_TABLE_SIZE];
-static int mmap_table_n = 0;
+	int    is_seg;
+} *mmap_table;
+static int mmap_table_n   = 0;
+static int mmap_table_cap = 0;
 
 static long
 p9_mmap_tracked(void *addr, size_t len, int prot, int flags, int fd, off_t off)
@@ -197,10 +218,22 @@ p9_mmap_tracked(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 	long r = p9_mmap(addr, len, prot, flags, fd, off);
 	if(r < 0)
 		return r;
-	if(mmap_table_n < MMAP_TABLE_SIZE){
+
+	/* grow table if needed */
+	if(mmap_table_n >= mmap_table_cap){
+		int newcap = mmap_table_cap ? mmap_table_cap * 2 : 64;
+		struct MmapEntry *t = realloc(mmap_table,
+		                              newcap * sizeof(*mmap_table));
+		if(t != NULL){
+			mmap_table     = t;
+			mmap_table_cap = newcap;
+		}
+		/* if realloc fails we proceed; munmap will fall back to segdetach */
+	}
+	if(mmap_table_n < mmap_table_cap){
 		mmap_table[mmap_table_n].addr   = (void*)r;
 		mmap_table[mmap_table_n].len    = len;
-		mmap_table[mmap_table_n].is_seg = (len >= 65536);
+		mmap_table[mmap_table_n].is_seg = (len >= SEG_THRESHOLD);
 		mmap_table_n++;
 	}
 	return r;
@@ -217,13 +250,14 @@ p9_munmap(void *addr, size_t len)
 				_SEGDETACH(addr);
 			else
 				free(addr);
-			/* remove from table */
 			mmap_table[i] = mmap_table[--mmap_table_n];
 			return 0;
 		}
 	}
-	/* not found in table - attempt free anyway */
-	free(addr);
+	/* addr not in table — could be a segattach we couldn't record.
+	 * Attempt segdetach; if it fails this is an unknown address and
+	 * we return 0 rather than crash or corrupt the malloc heap. */
+	_SEGDETACH(addr);
 	return 0;
 }
 

--- a/sys/src/cmd/6l/asm.c
+++ b/sys/src/cmd/6l/asm.c
@@ -3,22 +3,24 @@
 
 #define	Dbufslop	100
 
-/* Write one 40-byte ELF32 section header (little-endian). */
+/* Write one 40-byte ELF32 section header (little-endian).
+ * Parameter named 'foff' (file offset) to avoid collision with
+ * l.h's #define offset u0.u0offset. */
 static void
-elf32shdr(long name, long type, long flags, long addr,
-          long offset, long size, long link, long info,
-          long align, long entsize)
+elf32shdr(long sh_name, long sh_type, long sh_flags, long sh_addr,
+          long foff, long sh_size, long sh_link, long sh_info,
+          long sh_align, long sh_entsize)
 {
-	lputl(name);
-	lputl(type);
-	lputl(flags);
-	lputl(addr);
-	lputl(offset);
-	lputl(size);
-	lputl(link);
-	lputl(info);
-	lputl(align);
-	lputl(entsize);
+	lputl(sh_name);
+	lputl(sh_type);
+	lputl(sh_flags);
+	lputl(sh_addr);
+	lputl(foff);
+	lputl(sh_size);
+	lputl(sh_link);
+	lputl(sh_info);
+	lputl(sh_align);
+	lputl(sh_entsize);
 }
 
 #define PADDR(a)	((a) & ~0xfffffffff0000000ull)


### PR DESCRIPTION
…uce segattach pressure; 6l: fix elf32shdr parameter collision with l.h macros

malloc/free.c + malloc_align.h:
  Introduce ALIGN_MAGIC sentinel mechanism.  When the retry loop in
  aligned_alloc or posix_memalign can't get a naturally-aligned
  malloc() pointer, the safe fallback over-allocates by DATOFF+alignment-1
  bytes, finds the first alignment-aligned address within the block that
  has at least DATOFF bytes before it, and writes an ALIGN_MAGIC header
  at (aligned - DATOFF).  free() now detects ALIGN_MAGIC before the
  abort() and redirects to the original malloc() pointer.  Previously
  the fallback returned a pointer that caused free() to abort() on the
  magic mismatch — silent heap corruption.

mmap (__p9_syscall.c):
  - Raise the segattach threshold from 64 KB to 1 MB.  Plan9 allows only ~8 segments per process (kernel NSEG); using segattach for every medium-sized mmap quickly exhausts this limit and causes "insufficient physical memory" errors in programs like bash that use mmap as a general allocator.  Allocations < 1 MB now use malloc() (sbrk-backed, no new segment) instead.
  - Replace fixed 256-entry mmap_table with a dynamically grown array (realloc, starting at 64 entries).  The old fixed table silently dropped entries when full, causing munmap() to not find the region and call free() on an unknown address, which aborts.
  - Fix munmap() fallback: when addr is not in the table, attempt segdetach() rather than free() to avoid heap corruption.

6l/asm.c:
  Rename elf32shdr() parameters to sh_name, sh_type, … foff, sh_size, …
  l.h defines "#define offset u0.u0offset" which was macro-expanding
  the 'offset' parameter in elf32shdr's declaration to "u0.u0offset",
  producing "asm.c:9 syntax error, last name: u0".

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs