### PR TITLE
mmap: fix 64-bit address truncation; kencc: rename 'true' parameter i…

### DIFF
--- a/sys/src/ape/lib/ap/plan9/__p9_syscall.c
+++ b/sys/src/ape/lib/ap/plan9/__p9_syscall.c
@@ -159,26 +159,37 @@ p9retl(long r)
  */
 #define SEG_THRESHOLD (1024*1024)   /* 1 MB — use segattach only above this */
 
-static long
-p9_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
+/*
+ * p9_mmap_impl: core anonymous mmap emulation.
+ * Returns the allocated pointer on success, MAP_FAILED on error (sets errno).
+ * Uses void* throughout to preserve 64-bit addresses on amd64.
+ */
+static void *
+p9_mmap_impl(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 {
 	void *p;
 	int is_seg;
 	(void)prot;  /* Plan9 has no per-page protection */
 
 	/* MAP_FIXED to a specific non-NULL address is not supportable */
-	if((flags & MAP_FIXED) && addr != NULL)
-		return -EINVAL;
+	if((flags & MAP_FIXED) && addr != NULL){
+		errno = EINVAL;
+		return MAP_FAILED;
+	}
 
 	is_seg = (len >= SEG_THRESHOLD);
 	if(is_seg){
 		p = _SEGATTACH(0, "memory", 0, len);
-		if(p == (void*)-1)
-			return -ENOMEM;
+		if(p == (void*)-1){
+			errno = ENOMEM;
+			return MAP_FAILED;
+		}
 	} else {
 		p = malloc(len);
-		if(p == NULL)
-			return -ENOMEM;
+		if(p == NULL){
+			errno = ENOMEM;
+			return MAP_FAILED;
+		}
 	}
 	memset(p, 0, len);
 
@@ -191,10 +202,11 @@ p9_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 		if(n < 0){
 			if(is_seg) _SEGDETACH(p);
 			else free(p);
-			return -EIO;
+			errno = EIO;
+			return MAP_FAILED;
 		}
 	}
-	return (long)(uintptr_t)p;
+	return p;
 }
 
 /*
@@ -212,12 +224,17 @@ static struct MmapEntry {
 static int mmap_table_n   = 0;
 static int mmap_table_cap = 0;
 
-static long
+/*
+ * p9_mmap_tracked / p9_munmap: public (non-static) so mman.c can call
+ * them directly without going through __p9_syscall() which uses long
+ * (32-bit on amd64) and would truncate 64-bit heap addresses.
+ */
+void *
 p9_mmap_tracked(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 {
-	long r = p9_mmap(addr, len, prot, flags, fd, off);
-	if(r < 0)
-		return r;
+	void *p = p9_mmap_impl(addr, len, prot, flags, fd, off);
+	if(p == MAP_FAILED)
+		return MAP_FAILED;
 
 	/* grow table if needed */
 	if(mmap_table_n >= mmap_table_cap){
@@ -231,15 +248,15 @@ p9_mmap_tracked(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 		/* if realloc fails we proceed; munmap will fall back to segdetach */
 	}
 	if(mmap_table_n < mmap_table_cap){
-		mmap_table[mmap_table_n].addr   = (void*)r;
+		mmap_table[mmap_table_n].addr   = p;
 		mmap_table[mmap_table_n].len    = len;
 		mmap_table[mmap_table_n].is_seg = (len >= SEG_THRESHOLD);
 		mmap_table_n++;
 	}
-	return r;
+	return p;
 }
 
-static long
+int
 p9_munmap(void *addr, size_t len)
 {
 	int i;
@@ -590,12 +607,14 @@ __p9_syscall(long n, long a1, long a2, long a3, long a4, long a5, long a6)
 	case SYS_brk: /* [EMULATE] */
 		return p9_brk((void*)a1);
 
-	case SYS_mmap: /* [EMULATE] anonymous only */
-		return p9_mmap_tracked((void*)a1, (size_t)a2,
-		                       (int)a3, (int)a4, (int)a5, (off_t)a6);
+	case SYS_mmap: /* [EMULATE] — callers must use mman.c::mmap() directly; */
+		/* routing through __p9_syscall truncates 64-bit addresses via long */
+		errno = ENOSYS;
+		return -1;
 
-	case SYS_munmap: /* [EMULATE] */
-		return p9_munmap((void*)a1, (size_t)a2);
+	case SYS_munmap: /* [EMULATE] — same, use munmap() in mman.c directly */
+		errno = ENOSYS;
+		return -1;
 
 	case SYS_mremap: /* [STUB] not emulable portably */
 		return -ENOSYS;

--- a/sys/src/ape/lib/ap/plan9/mman.c
+++ b/sys/src/ape/lib/ap/plan9/mman.c
@@ -5,14 +5,16 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-#include "../include/syscall.h"
 
 /*
  * mmap/munmap and related wrappers for APExp.
  *
  * The actual emulation (segattach for large allocations, malloc for
  * small ones, read() for file-backed) lives in __p9_syscall.c.
- * These functions expose them as public symbols that programs can link.
+ * We call those functions directly rather than routing through
+ * __p9_syscall(), because __p9_syscall() uses long (32-bit on Plan9 6c
+ * for amd64) for all arguments and return values, which would truncate
+ * 64-bit heap addresses and return corrupt pointers.
  *
  * Limitations:
  *   - MAP_SHARED write-back not supported; writes stay private.
@@ -21,29 +23,21 @@
  *   - shm_open is backed by files in /tmp.
  */
 
+/* Declared non-static in __p9_syscall.c */
+extern void *p9_mmap_tracked(void *addr, size_t len, int prot, int flags,
+                              int fd, off_t off);
+extern int   p9_munmap(void *addr, size_t len);
+
 void *
 mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
 {
-	long r = __p9_syscall(SYS_mmap,
-	                      (long)addr, (long)len, (long)prot,
-	                      (long)flags, (long)fd, (long)off);
-	if(r < 0){
-		errno = (int)-r;
-		return MAP_FAILED;
-	}
-	return (void *)(uintptr_t)r;
+	return p9_mmap_tracked(addr, len, prot, flags, fd, off);
 }
 
 int
 munmap(void *addr, size_t len)
 {
-	long r = __p9_syscall(SYS_munmap, (long)addr, (long)len,
-	                      0L, 0L, 0L, 0L);
-	if(r < 0){
-		errno = (int)-r;
-		return -1;
-	}
-	return 0;
+	return p9_munmap(addr, len);
 }
 
 int

--- a/sys/src/cmd/1c/cgen.c
+++ b/sys/src/cmd/1c/cgen.c
@@ -945,14 +945,14 @@ lcgen(Node *n, int result, Node *nn)
 }
 
 void
-bcgen(Node *n, int true)
+bcgen(Node *n, int cond)
 {
 
-	boolgen(n, true, D_NONE, Z, Z);
+	boolgen(n, cond, D_NONE, Z, Z);
 }
 
 void
-boolgen(Node *n, int true, int result, Node *nn, Node *post)
+boolgen(Node *n, int cond, int result, Node *nn, Node *post)
 {
 	Prog *p1, *p2;
 	Node *l, *r;
@@ -985,7 +985,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 
 	case OCONST:
 		fp = vconst(n);
-		if(!true)
+		if(!cond)
 			fp = !fp;
 		gbranch(OGOTO);
 		if(fp) {
@@ -996,7 +996,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		goto com;
 
 	case ONOT:
-		boolgen(l, !true, result, nn, post);
+		boolgen(l, !cond, result, nn, post);
 		break;
 
 	case OCOND:
@@ -1006,7 +1006,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 
 		inargs++;
 		doinc(r->left, PRE);
-		boolgen(r->left, true, result, nn, r->left);
+		boolgen(r->left, cond, result, nn, r->left);
 		if(result != D_NONE) {
 			doinc(r->left, POST);
 			gbranch(OGOTO);
@@ -1014,7 +1014,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 			p1 = p;
 
 			doinc(r->right, PRE);
-			boolgen(r->right, !true, result, nn, r->right);
+			boolgen(r->right, !cond, result, nn, r->right);
 			doinc(r->right, POST);
 			patch(p1, pc);
 			inargs--;
@@ -1026,7 +1026,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		p1 = p;
 
 		doinc(r->right, PRE);
-		boolgen(r->right, !true, result, nn, r->right);
+		boolgen(r->right, !cond, result, nn, r->right);
 		patch(p2, pc);
 		p2 = p;
 		if(doinc(post, POST|TEST)) {
@@ -1043,16 +1043,16 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		goto com;
 
 	case OANDAND:
-		if(!true)
+		if(!cond)
 			goto caseor;
 
 	caseand:
 		doinc(l, PRE);
-		boolgen(l, true, D_NONE, Z, l);
+		boolgen(l, cond, D_NONE, Z, l);
 		p1 = p;
 		inargs++;
 		doinc(r, PRE);
-		boolgen(r, !true, D_NONE, Z, r);
+		boolgen(r, !cond, D_NONE, Z, r);
 		p2 = p;
 		patch(p1, pc);
 		gbranch(OGOTO);
@@ -1061,16 +1061,16 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		goto com;
 
 	case OOROR:
-		if(!true)
+		if(!cond)
 			goto caseand;
 
 	caseor:
 		doinc(l, PRE);
-		boolgen(l, !true, D_NONE, Z, l);
+		boolgen(l, !cond, D_NONE, Z, l);
 		p1 = p;
 		inargs++;
 		doinc(r, PRE);
-		boolgen(r, !true, D_NONE, Z, r);
+		boolgen(r, !cond, D_NONE, Z, r);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
@@ -1082,10 +1082,10 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 	case ONE:
 		if(vconst(l) == 0) {
 			if(n->op == ONE) {
-				boolgen(r, true, result, nn, post);
+				boolgen(r, cond, result, nn, post);
 				break;
 			}
-			boolgen(r, !true, result, nn, post);
+			boolgen(r, !cond, result, nn, post);
 			break;
 		}
 
@@ -1143,7 +1143,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		regfree(rg);
 
 	genbool:
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(doinc(post, POST|TEST)) {
 			lg = regalloc(types[TSHORT], D_NONE);

--- a/sys/src/cmd/2c/cgen.c
+++ b/sys/src/cmd/2c/cgen.c
@@ -953,14 +953,14 @@ lcgen(Node *n, int result, Node *nn)
 }
 
 void
-bcgen(Node *n, int true)
+bcgen(Node *n, int cond)
 {
 
-	boolgen(n, true, D_NONE, Z, Z);
+	boolgen(n, cond, D_NONE, Z, Z);
 }
 
 void
-boolgen(Node *n, int true, int result, Node *nn, Node *post)
+boolgen(Node *n, int cond, int result, Node *nn, Node *post)
 {
 	Prog *p1, *p2;
 	Node *l, *r;
@@ -993,7 +993,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 
 	case OCONST:
 		fp = vconst(n);
-		if(!true)
+		if(!cond)
 			fp = !fp;
 		gbranch(OGOTO);
 		if(fp) {
@@ -1004,7 +1004,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		goto com;
 
 	case ONOT:
-		boolgen(l, !true, result, nn, post);
+		boolgen(l, !cond, result, nn, post);
 		break;
 
 	case OCOND:
@@ -1014,7 +1014,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 
 		inargs++;
 		doinc(r->left, PRE);
-		boolgen(r->left, true, result, nn, r->left);
+		boolgen(r->left, cond, result, nn, r->left);
 		if(result != D_NONE) {
 			doinc(r->left, POST);
 			gbranch(OGOTO);
@@ -1022,7 +1022,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 			p1 = p;
 
 			doinc(r->right, PRE);
-			boolgen(r->right, !true, result, nn, r->right);
+			boolgen(r->right, !cond, result, nn, r->right);
 			doinc(r->right, POST);
 			patch(p1, pc);
 			inargs--;
@@ -1034,7 +1034,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		p1 = p;
 
 		doinc(r->right, PRE);
-		boolgen(r->right, !true, result, nn, r->right);
+		boolgen(r->right, !cond, result, nn, r->right);
 		patch(p2, pc);
 		p2 = p;
 		if(doinc(post, POST|TEST)) {
@@ -1051,16 +1051,16 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		goto com;
 
 	case OANDAND:
-		if(!true)
+		if(!cond)
 			goto caseor;
 
 	caseand:
 		doinc(l, PRE);
-		boolgen(l, true, D_NONE, Z, l);
+		boolgen(l, cond, D_NONE, Z, l);
 		p1 = p;
 		inargs++;
 		doinc(r, PRE);
-		boolgen(r, !true, D_NONE, Z, r);
+		boolgen(r, !cond, D_NONE, Z, r);
 		p2 = p;
 		patch(p1, pc);
 		gbranch(OGOTO);
@@ -1069,16 +1069,16 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		goto com;
 
 	case OOROR:
-		if(!true)
+		if(!cond)
 			goto caseand;
 
 	caseor:
 		doinc(l, PRE);
-		boolgen(l, !true, D_NONE, Z, l);
+		boolgen(l, !cond, D_NONE, Z, l);
 		p1 = p;
 		inargs++;
 		doinc(r, PRE);
-		boolgen(r, !true, D_NONE, Z, r);
+		boolgen(r, !cond, D_NONE, Z, r);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
@@ -1090,10 +1090,10 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 	case ONE:
 		if(vconst(l) == 0) {
 			if(n->op == ONE) {
-				boolgen(r, true, result, nn, post);
+				boolgen(r, cond, result, nn, post);
 				break;
 			}
-			boolgen(r, !true, result, nn, post);
+			boolgen(r, !cond, result, nn, post);
 			break;
 		}
 
@@ -1151,7 +1151,7 @@ boolgen(Node *n, int true, int result, Node *nn, Node *post)
 		regfree(rg);
 
 	genbool:
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(doinc(post, POST|TEST)) {
 			lg = regalloc(types[TSHORT], D_NONE);

--- a/sys/src/cmd/5c/cgen.c
+++ b/sys/src/cmd/5c/cgen.c
@@ -722,17 +722,17 @@ lcgen(Node *n, Node *nn)
 }
 
 void
-bcgen(Node *n, int true)
+bcgen(Node *n, int cond)
 {
 
 	if(n->type == T)
 		gbranch(OGOTO);
 	else
-		boolgen(n, true, Z);
+		boolgen(n, cond, Z);
 }
 
 void
-boolgen(Node *n, int true, Node *nn)
+boolgen(Node *n, int cond, Node *nn)
 {
 	int o;
 	Prog *p1, *p2;
@@ -752,12 +752,12 @@ boolgen(Node *n, int true, Node *nn)
 		regalloc(&nod, n, nn);
 		cgen(n, &nod);
 		o = ONE;
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(typefd[n->type->etype]){
 			regalloc(&nod1, n, Z);
 			gmove(nodfconst(0.0), &nod1);
-			gopcode(true ? o | BTRUE : o, &nod1, &nod, Z);
+			gopcode(cond ? o | BTRUE : o, &nod1, &nod, Z);
 			regfree(&nod1);
 		}else
 			gopcode(o, nodconst(0), &nod, Z);
@@ -766,7 +766,7 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCONST:
 		o = vconst(n);
-		if(!true)
+		if(!cond)
 			o = !o;
 		gbranch(OGOTO);
 		if(o) {
@@ -778,22 +778,22 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCOMMA:
 		cgen(l, Z);
-		boolgen(r, true, nn);
+		boolgen(r, cond, nn);
 		break;
 
 	case ONOT:
-		boolgen(l, !true, nn);
+		boolgen(l, !cond, nn);
 		break;
 
 	case OCOND:
 		bcgen(l, 1);
 		p1 = p;
-		bcgen(r->left, true);
+		bcgen(r->left, cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
 		p1 = p;
-		bcgen(r->right, !true);
+		bcgen(r->right, !cond);
 		patch(p2, pc);
 		p2 = p;
 		gbranch(OGOTO);
@@ -802,13 +802,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OANDAND:
-		if(!true)
+		if(!cond)
 			goto caseor;
 
 	caseand:
-		bcgen(l, true);
+		bcgen(l, cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		patch(p1, pc);
 		gbranch(OGOTO);
@@ -816,13 +816,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OOROR:
-		if(!true)
+		if(!cond)
 			goto caseand;
 
 	caseor:
-		bcgen(l, !true);
+		bcgen(l, !cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
@@ -840,7 +840,7 @@ boolgen(Node *n, int true, Node *nn)
 	case OLO:
 	case OLS:
 		o = n->op;
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(l->complex >= FNX && r->complex >= FNX) {
 			regret(&nod, r);
@@ -850,21 +850,21 @@ boolgen(Node *n, int true, Node *nn)
 			regfree(&nod);
 			nod = *n;
 			nod.right = &nod1;
-			boolgen(&nod, true, nn);
+			boolgen(&nod, cond, nn);
 			break;
 		}
 		if(sconst(l)) {
 			regalloc(&nod, r, nn);
 			cgenrel(r, &nod, 1);
 			o = invrel[relindex(o)];
-			gopcode(true ? o | BTRUE : o, l, &nod, Z);
+			gopcode(cond ? o | BTRUE : o, l, &nod, Z);
 			regfree(&nod);
 			goto com;
 		}
 		if(sconst(r)) {
 			regalloc(&nod, l, nn);
 			cgenrel(l, &nod, 1);
-			gopcode(true ? o | BTRUE : o, r, &nod, Z);
+			gopcode(cond ? o | BTRUE : o, r, &nod, Z);
 			regfree(&nod);
 			goto com;
 		}
@@ -879,7 +879,7 @@ boolgen(Node *n, int true, Node *nn)
 			regalloc(&nod1, l, Z);
 			cgenrel(l, &nod1, 1);
 		}
-		gopcode(true ? o | BTRUE : o, &nod, &nod1, Z);
+		gopcode(cond ? o | BTRUE : o, &nod, &nod1, Z);
 		regfree(&nod);
 		regfree(&nod1);
 

--- a/sys/src/cmd/7c/cgen.c
+++ b/sys/src/cmd/7c/cgen.c
@@ -738,17 +738,17 @@ lcgen(Node *n, Node *nn)
 }
 
 void
-bcgen(Node *n, int true)
+bcgen(Node *n, int cond)
 {
 
 	if(n->type == T)
 		gbranch(OGOTO);
 	else
-		boolgen(n, true, Z);
+		boolgen(n, cond, Z);
 }
 
 void
-boolgen(Node *n, int true, Node *nn)
+boolgen(Node *n, int cond, Node *nn)
 {
 	int o;
 	Prog *p1, *p2;
@@ -768,12 +768,12 @@ boolgen(Node *n, int true, Node *nn)
 		regalloc(&nod, n, nn);
 		cgen(n, &nod);
 		o = ONE;
-		if(true)
+		if(cond)
 			o = OEQ;
 		if(typefd[n->type->etype]) {
 			regalloc(&nod1, n, Z);
 			gmove(nodfconst(0.0), &nod1);
-			gopcode(true ? o | BTRUE : o, &nod1, &nod, Z);
+			gopcode(cond ? o | BTRUE : o, &nod1, &nod, Z);
 			regfree(&nod1);
 		}else
 			gopcode(o, nodconst(0), &nod, Z);
@@ -782,7 +782,7 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCONST:
 		o = vconst(n);
-		if(!true)
+		if(!cond)
 			o = !o;
 		gbranch(OGOTO);
 		if(o) {
@@ -794,22 +794,22 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCOMMA:
 		cgen(l, Z);
-		boolgen(r, true, nn);
+		boolgen(r, cond, nn);
 		break;
 
 	case ONOT:
-		boolgen(l, !true, nn);
+		boolgen(l, !cond, nn);
 		break;
 
 	case OCOND:
 		bcgen(l, 1);
 		p1 = p;
-		bcgen(r->left, true);
+		bcgen(r->left, cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
 		p1 = p;
-		bcgen(r->right, !true);
+		bcgen(r->right, !cond);
 		patch(p2, pc);
 		p2 = p;
 		gbranch(OGOTO);
@@ -818,13 +818,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OANDAND:
-		if(!true)
+		if(!cond)
 			goto caseor;
 
 	caseand:
-		bcgen(l, true);
+		bcgen(l, cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		patch(p1, pc);
 		gbranch(OGOTO);
@@ -832,13 +832,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OOROR:
-		if(!true)
+		if(!cond)
 			goto caseand;
 
 	caseor:
-		bcgen(l, !true);
+		bcgen(l, !cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
@@ -856,7 +856,7 @@ boolgen(Node *n, int true, Node *nn)
 	case OLO:
 	case OLS:
 		o = n->op;
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(l->complex >= FNX && r->complex >= FNX) {
 			regret(&nod, r);
@@ -866,21 +866,21 @@ boolgen(Node *n, int true, Node *nn)
 			regfree(&nod);
 			nod = *n;
 			nod.right = &nod1;
-			boolgen(&nod, true, nn);
+			boolgen(&nod, cond, nn);
 			break;
 		}
 		if(sconst(l)) {
 			regalloc(&nod, r, nn);
 			cgenrel(r, &nod, 1);
 			o = invrel[relindex(o)];
-			gopcode(true ? o | BTRUE : o, l, &nod, Z);
+			gopcode(cond ? o | BTRUE : o, l, &nod, Z);
 			regfree(&nod);
 			goto com;
 		}
 		if(sconst(r)) {
 			regalloc(&nod, l, nn);
 			cgenrel(l, &nod, 1);
-			gopcode(true ? o | BTRUE : o, r, &nod, Z);
+			gopcode(cond ? o | BTRUE : o, r, &nod, Z);
 			regfree(&nod);
 			goto com;
 		}
@@ -895,7 +895,7 @@ boolgen(Node *n, int true, Node *nn)
 			regalloc(&nod1, l, Z);
 			cgenrel(l, &nod1, 1);
 		}
-		gopcode(true ? o | BTRUE : o, &nod, &nod1, Z);
+		gopcode(cond ? o | BTRUE : o, &nod, &nod1, Z);
 		regfree(&nod);
 		regfree(&nod1);
 

--- a/sys/src/cmd/8c/cgen.c
+++ b/sys/src/cmd/8c/cgen.c
@@ -1229,17 +1229,17 @@ lcgen(Node *n, Node *nn)
 }
 
 void
-bcgen(Node *n, int true)
+bcgen(Node *n, int cond)
 {
 
 	if(n->type == T)
 		gbranch(OGOTO);
 	else
-		boolgen(n, true, Z);
+		boolgen(n, cond, Z);
 }
 
 void
-boolgen(Node *n, int true, Node *nn)
+boolgen(Node *n, int cond, Node *nn)
 {
 	int o;
 	Prog *p1, *p2;
@@ -1257,11 +1257,11 @@ boolgen(Node *n, int true, Node *nn)
 
 	default:
 		if(typev[n->type->etype]) {
-			testv(n, true);
+			testv(n, cond);
 			goto com;
 		}
 		o = ONE;
-		if(true)
+		if(cond)
 			o = OEQ;
 		if(typefd[n->type->etype]) {
 			if(n->addable < INDEXED) {
@@ -1287,7 +1287,7 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCONST:
 		o = vconst(n);
-		if(!true)
+		if(!cond)
 			o = !o;
 		gbranch(OGOTO);
 		if(o) {
@@ -1299,22 +1299,22 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCOMMA:
 		cgen(l, Z);
-		boolgen(r, true, nn);
+		boolgen(r, cond, nn);
 		break;
 
 	case ONOT:
-		boolgen(l, !true, nn);
+		boolgen(l, !cond, nn);
 		break;
 
 	case OCOND:
 		bcgen(l, 1);
 		p1 = p;
-		bcgen(r->left, true);
+		bcgen(r->left, cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
 		p1 = p;
-		bcgen(r->right, !true);
+		bcgen(r->right, !cond);
 		patch(p2, pc);
 		p2 = p;
 		gbranch(OGOTO);
@@ -1323,13 +1323,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OANDAND:
-		if(!true)
+		if(!cond)
 			goto caseor;
 
 	caseand:
-		bcgen(l, true);
+		bcgen(l, cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		patch(p1, pc);
 		gbranch(OGOTO);
@@ -1337,13 +1337,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OOROR:
-		if(!true)
+		if(!cond)
 			goto caseand;
 
 	caseor:
-		bcgen(l, !true);
+		bcgen(l, !cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
@@ -1362,12 +1362,12 @@ boolgen(Node *n, int true, Node *nn)
 	case OLS:
 		o = n->op;
 		if(typev[l->type->etype]) {
-			if(!true)
+			if(!cond)
 				n->op = comrel[relindex(o)];
 			cgen64(n, Z);
 			goto com;
 		}
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(l->complex >= FNX && r->complex >= FNX) {
 			regret(&nod, r);
@@ -1377,7 +1377,7 @@ boolgen(Node *n, int true, Node *nn)
 			regfree(&nod);
 			nod = *n;
 			nod.right = &nod1;
-			boolgen(&nod, true, nn);
+			boolgen(&nod, cond, nn);
 			break;
 		}
 		if(typefd[l->type->etype]) {

--- a/sys/src/cmd/8c/cgen64.c
+++ b/sys/src/cmd/8c/cgen64.c
@@ -411,13 +411,13 @@ enum
 /*
  * _testv:
  * 	CMPL	lo,$0
- * 	JNE	true
+ * 	JNE	cond
  * 	CMPL	hi,$0
- * 	JNE	true
+ * 	JNE	cond
  * 	GOTO	false
  * false:
  * 	GOTO	code
- * true:
+ * cond:
  * 	GOTO	patchme
  * code:
  */
@@ -1187,7 +1187,7 @@ static uchar	HSargs[]	= { OHI, OHS };
 
 /* Big Generator */
 static void
-biggen(Node *l, Node *r, Node *t, int true, uchar code[][VLEN], uchar *a)
+biggen(Node *l, Node *r, Node *t, int cond, uchar code[][VLEN], uchar *a)
 {
 	int i, j, g, oc, op, lo, ro, to, xo, *xp;
 	Type *lt;
@@ -1432,11 +1432,11 @@ biggen(Node *l, Node *r, Node *t, int true, uchar code[][VLEN], uchar *a)
 				break;
 
 			case VT:
-				g = true;
+				g = cond;
 				i++;
 				break;
 			case VF:
-				g = !true;
+				g = !cond;
 				i++;
 				break;
 
@@ -1564,7 +1564,7 @@ cgen64(Node *n, Node *nn)
 {
 	Type *dt;
 	uchar *args, (*cp)[VLEN], (**optab)[VLEN];
-	int li, ri, lri, dr, si, m, op, sh, cmp, true;
+	int li, ri, lri, dr, si, m, op, sh, cmp, cond;
 	Node *c, *d, *l, *r, *t, *s, nod1, nod2, nod3, nod4, nod5;
 
 	if(debug['g']) {
@@ -2093,40 +2093,40 @@ twoop:
 			break;
 		}
 
-		true = 1;
+		cond = 1;
 		optab = cmptab;
 		switch(op) {
 		case OEQ:
 			optab = NEtab;
-			true = 0;
+			cond = 0;
 			break;
 		case ONE:
 			optab = NEtab;
 			break;
 		case OLE:
 			args = GTargs;
-			true = 0;
+			cond = 0;
 			break;
 		case OGT:
 			args = GTargs;
 			break;
 		case OLS:
 			args = HIargs;
-			true = 0;
+			cond = 0;
 			break;
 		case OHI:
 			args = HIargs;
 			break;
 		case OLT:
 			args = GEargs;
-			true = 0;
+			cond = 0;
 			break;
 		case OGE:
 			args = GEargs;
 			break;
 		case OLO:
 			args = HSargs;
-			true = 0;
+			cond = 0;
 			break;
 		case OHS:
 			args = HSargs;
@@ -2138,7 +2138,7 @@ twoop:
 
 		switch(lri) {
 		case IMM(0, 0):
-			biggen(l, r, Z, true, optab[T0i], args);
+			biggen(l, r, Z, cond, optab[T0i], args);
 			break;
 		case IMM(0, 1):
 		case IMM(1, 0):
@@ -2147,14 +2147,14 @@ twoop:
 				diag(l, "bad whatof\n");
 				break;
 			case WCONST:
-				biggen(l, r, Z, true, optab[T0i], args);
+				biggen(l, r, Z, cond, optab[T0i], args);
 				break;
 			case WHARD:
 				reglcgen(&nod2, r, Z);
 				r = &nod2;
 				/* fall thru */
 			case WADDR:
-				biggen(l, r, Z, true, optab[T0i], args);
+				biggen(l, r, Z, cond, optab[T0i], args);
 				if(ri == WHARD)
 					regfree(r);
 				break;
@@ -2169,7 +2169,7 @@ twoop:
 				reglcgen(&nod2, r, Z);
 				r = &nod2;
 			}
-			biggen(l, r, Z, true, optab[Tii], args);
+			biggen(l, r, Z, cond, optab[Tii], args);
 			if(li == WHARD)
 				regfree(l);
 			if(ri == WHARD)
@@ -2616,14 +2616,14 @@ finished:
 }
 
 void
-testv(Node *n, int true)
+testv(Node *n, int cond)
 {
 	Type *t;
 	Node *nn, nod, *b;
 
 	if(machcap(Z)) {
 		b = &nod;
-		b->op = true ? ONE : OEQ;
+		b->op = cond ? ONE : OEQ;
 		b->left = n;
 		b->right = new(0, Z, Z);
 		*b->right = *nodconst(0);
@@ -2636,7 +2636,7 @@ testv(Node *n, int true)
 	switch(n->op) {
 	case OINDREG:
 	case ONAME:
-		biggen(n, Z, Z, true, testi, nil);
+		biggen(n, Z, Z, cond, testi, nil);
 		break;
 
 	default:
@@ -2647,14 +2647,14 @@ testv(Node *n, int true)
 			reglcgen(&nod, n, Z);
 			n->type = t;
 			n = &nod;
-			biggen(n, Z, Z, true, testi, nil);
+			biggen(n, Z, Z, cond, testi, nil);
 			if(n == &nod)
 				regfree(n);
 		}
 		else {
 			nn = regpair(Z, n);
 			sugen(n, nn, 8);
-			biggen(nn, Z, Z, true, testi, nil);
+			biggen(nn, Z, Z, cond, testi, nil);
 			freepair(nn);
 		}
 	}

--- a/sys/src/cmd/kc/cgen.c
+++ b/sys/src/cmd/kc/cgen.c
@@ -648,17 +648,17 @@ lcgen(Node *n, Node *nn)
 }
 
 void
-bcgen(Node *n, int true)
+bcgen(Node *n, int cond)
 {
 
 	if(n->type == T)
 		gbranch(OGOTO);
 	else
-		boolgen(n, true, Z);
+		boolgen(n, cond, Z);
 }
 
 void
-boolgen(Node *n, int true, Node *nn)
+boolgen(Node *n, int cond, Node *nn)
 {
 	int o;
 	Prog *p1, *p2;
@@ -677,7 +677,7 @@ boolgen(Node *n, int true, Node *nn)
 	default:
 		if(n->op == OCONST) {
 			o = vconst(n);
-			if(!true)
+			if(!cond)
 				o = !o;
 			gbranch(OGOTO);
 			if(o) {
@@ -690,7 +690,7 @@ boolgen(Node *n, int true, Node *nn)
 		regalloc(&nod, n, nn);
 		cgen(n, &nod);
 		o = ONE;
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(typefd[n->type->etype]) {
 			nodreg(&nod1, n, NREG+FREGZERO);
@@ -702,22 +702,22 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCOMMA:
 		cgen(l, Z);
-		boolgen(r, true, nn);
+		boolgen(r, cond, nn);
 		break;
 
 	case ONOT:
-		boolgen(l, !true, nn);
+		boolgen(l, !cond, nn);
 		break;
 
 	case OCOND:
 		bcgen(l, 1);
 		p1 = p;
-		bcgen(r->left, true);
+		bcgen(r->left, cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
 		p1 = p;
-		bcgen(r->right, !true);
+		bcgen(r->right, !cond);
 		patch(p2, pc);
 		p2 = p;
 		gbranch(OGOTO);
@@ -726,13 +726,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OANDAND:
-		if(!true)
+		if(!cond)
 			goto caseor;
 
 	caseand:
-		bcgen(l, true);
+		bcgen(l, cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		patch(p1, pc);
 		gbranch(OGOTO);
@@ -740,13 +740,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OOROR:
-		if(!true)
+		if(!cond)
 			goto caseand;
 
 	caseor:
-		bcgen(l, !true);
+		bcgen(l, !cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
@@ -764,7 +764,7 @@ boolgen(Node *n, int true, Node *nn)
 	case OLO:
 	case OLS:
 		o = n->op;
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(l->complex >= FNX && r->complex >= FNX) {
 			regret(&nod, r);
@@ -774,7 +774,7 @@ boolgen(Node *n, int true, Node *nn)
 			regfree(&nod);
 			nod = *n;
 			nod.right = &nod1;
-			boolgen(&nod, true, nn);
+			boolgen(&nod, cond, nn);
 			break;
 		}
 		if(sconst(r)) {

--- a/sys/src/cmd/qc/cgen.c
+++ b/sys/src/cmd/qc/cgen.c
@@ -686,17 +686,17 @@ lcgen(Node *n, Node *nn)
 }
 
 void
-bcgen(Node *n, int true)
+bcgen(Node *n, int cond)
 {
 
 	if(n->type == T)
 		gbranch(OGOTO);
 	else
-		boolgen(n, true, Z);
+		boolgen(n, cond, Z);
 }
 
 void
-boolgen(Node *n, int true, Node *nn)
+boolgen(Node *n, int cond, Node *nn)
 {
 	int o, uns;
 	Prog *p1, *p2;
@@ -716,7 +716,7 @@ boolgen(Node *n, int true, Node *nn)
 	default:
 		if(n->op == OCONST) {
 			o = vconst(n);
-			if(!true)
+			if(!cond)
 				o = !o;
 			gbranch(OGOTO);
 			if(o) {
@@ -727,13 +727,13 @@ boolgen(Node *n, int true, Node *nn)
 			goto com;
 		}
 		if(typev[n->type->etype]) {
-			testv(n, true);
+			testv(n, cond);
 			goto com;
 		}
 		regalloc(&nod, n, nn);
 		cgen(n, &nod);
 		o = ONE;
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(typefd[n->type->etype]) {
 			nodreg(&nod1, n, NREG+FREGZERO);
@@ -745,22 +745,22 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCOMMA:
 		cgen(l, Z);
-		boolgen(r, true, nn);
+		boolgen(r, cond, nn);
 		break;
 
 	case ONOT:
-		boolgen(l, !true, nn);
+		boolgen(l, !cond, nn);
 		break;
 
 	case OCOND:
 		bcgen(l, 1);
 		p1 = p;
-		bcgen(r->left, true);
+		bcgen(r->left, cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
 		p1 = p;
-		bcgen(r->right, !true);
+		bcgen(r->right, !cond);
 		patch(p2, pc);
 		p2 = p;
 		gbranch(OGOTO);
@@ -769,13 +769,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OANDAND:
-		if(!true)
+		if(!cond)
 			goto caseor;
 
 	caseand:
-		bcgen(l, true);
+		bcgen(l, cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		patch(p1, pc);
 		gbranch(OGOTO);
@@ -783,13 +783,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OOROR:
-		if(!true)
+		if(!cond)
 			goto caseand;
 
 	caseor:
-		bcgen(l, !true);
+		bcgen(l, !cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
@@ -809,11 +809,11 @@ boolgen(Node *n, int true, Node *nn)
 	case OGE:
 	case OGT:
 		if(typev[l->type->etype]){
-			cmpv(n, true, Z);
+			cmpv(n, cond, Z);
 			goto com;
 		}
 		o = n->op;
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(l->complex >= FNX && r->complex >= FNX) {
 			regret(&nod, r);
@@ -823,7 +823,7 @@ boolgen(Node *n, int true, Node *nn)
 			regfree(&nod);
 			nod = *n;
 			nod.right = &nod1;
-			boolgen(&nod, true, nn);
+			boolgen(&nod, cond, nn);
 			break;
 		}
 		if(!uns && sconst(r) || (uns || o == OEQ || o == ONE) && uconst(r)) {
@@ -1281,7 +1281,7 @@ brcondv(Node *l, Node *r, int chi, int clo)
 }
 
 static void
-testv(Node *n, int true)
+testv(Node *n, int cond)
 {
 	Node nod;
 
@@ -1292,7 +1292,7 @@ testv(Node *n, int true)
 	*nod.right = *nodconst(0);
 	nod.right->type = n->type;
 	nod.type = types[TLONG];
-	cmpv(&nod, true, Z);
+	cmpv(&nod, cond, Z);
 }
 
 /*
@@ -1300,7 +1300,7 @@ testv(Node *n, int true)
  * which saves loading the latter if the high order comparison suffices
  */
 static void
-cmpv(Node *n, int true, Node *nn)
+cmpv(Node *n, int cond, Node *nn)
 {
 	Node *l, *r, nod, nod1;
 	int o, f1, f2;
@@ -1320,7 +1320,7 @@ cmpv(Node *n, int true, Node *nn)
 		cgen(r, &nod1);
 		nod = *n;
 		nod.right = &nod1;
-		cmpv(&nod, true, nn);
+		cmpv(&nod, cond, nn);
 		cursafe = curs;
 		return;
 	}
@@ -1334,7 +1334,7 @@ cmpv(Node *n, int true, Node *nn)
 	nod.type = types[TLONG];
 	nod1.type = types[TLONG];
 	o = n->op;
-	if(true)
+	if(cond)
 		o = comrel[relindex(o)];
 	switch(o){
 	case OEQ:

--- a/sys/src/cmd/vc/cgen.c
+++ b/sys/src/cmd/vc/cgen.c
@@ -648,17 +648,17 @@ lcgen(Node *n, Node *nn)
 }
 
 void
-bcgen(Node *n, int true)
+bcgen(Node *n, int cond)
 {
 
 	if(n->type == T)
 		gbranch(OGOTO);
 	else
-		boolgen(n, true, Z);
+		boolgen(n, cond, Z);
 }
 
 void
-boolgen(Node *n, int true, Node *nn)
+boolgen(Node *n, int cond, Node *nn)
 {
 	int o;
 	Prog *p1, *p2;
@@ -679,7 +679,7 @@ boolgen(Node *n, int true, Node *nn)
 		cgen(n, &nod);
 		if(nn == Z || typefd[n->type->etype]) {
 			o = ONE;
-			if(true)
+			if(cond)
 				o = comrel[relindex(o)];
 			if(typefd[n->type->etype]) {
 				nodreg(&nod1, n, NREG+FREGZERO);
@@ -689,7 +689,7 @@ boolgen(Node *n, int true, Node *nn)
 			regfree(&nod);
 			goto com;
 		}
-		if(true)
+		if(cond)
 			gopcode(OCOND, &nod, nodconst(0), &nod);
 		else
 			gopcode(OCOND, nodconst(1), &nod, &nod);
@@ -699,7 +699,7 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCONST:
 		o = vconst(n);
-		if(!true)
+		if(!cond)
 			o = !o;
 		gbranch(OGOTO);
 		if(o) {
@@ -711,22 +711,22 @@ boolgen(Node *n, int true, Node *nn)
 
 	case OCOMMA:
 		cgen(l, Z);
-		boolgen(r, true, nn);
+		boolgen(r, cond, nn);
 		break;
 
 	case ONOT:
-		boolgen(l, !true, nn);
+		boolgen(l, !cond, nn);
 		break;
 
 	case OCOND:
 		bcgen(l, 1);
 		p1 = p;
-		bcgen(r->left, true);
+		bcgen(r->left, cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
 		p1 = p;
-		bcgen(r->right, !true);
+		bcgen(r->right, !cond);
 		patch(p2, pc);
 		p2 = p;
 		gbranch(OGOTO);
@@ -735,13 +735,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OANDAND:
-		if(!true)
+		if(!cond)
 			goto caseor;
 
 	caseand:
-		bcgen(l, true);
+		bcgen(l, cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		patch(p1, pc);
 		gbranch(OGOTO);
@@ -749,13 +749,13 @@ boolgen(Node *n, int true, Node *nn)
 		goto com;
 
 	case OOROR:
-		if(!true)
+		if(!cond)
 			goto caseand;
 
 	caseor:
-		bcgen(l, !true);
+		bcgen(l, !cond);
 		p1 = p;
-		bcgen(r, !true);
+		bcgen(r, !cond);
 		p2 = p;
 		gbranch(OGOTO);
 		patch(p1, pc);
@@ -773,7 +773,7 @@ boolgen(Node *n, int true, Node *nn)
 	case OLO:
 	case OLS:
 		o = n->op;
-		if(true)
+		if(cond)
 			o = comrel[relindex(o)];
 		if(l->complex >= FNX && r->complex >= FNX) {
 			regret(&nod, r);
@@ -783,7 +783,7 @@ boolgen(Node *n, int true, Node *nn)
 			regfree(&nod);
 			nod = *n;
 			nod.right = &nod1;
-			boolgen(&nod, true, nn);
+			boolgen(&nod, cond, nn);
 			break;
 		}
 		if(nn != Z && !typefd[l->type->etype]) {


### PR DESCRIPTION
…n bcgen/boolgen

mmap/mman.c + __p9_syscall.c:
  CRITICAL BUG FIX: p9_mmap() and p9_mmap_tracked() returned 'long'
  (32-bit on Plan9 6c for amd64), truncating 64-bit heap addresses.
  For allocations < 1MB that use malloc(), the malloc pointer is a
  high amd64 address; casting to long silently discarded the upper
  32 bits.  The caller in mman.c stored this in 'long r' and returned
  (void*)(uintptr_t)r — a completely wrong address.  Programs calling
  mmap() for small buffers received garbage pointers and then wrote
  to random memory, causing the observed binary freeze/hang with
  memory going up.

  Fix: make p9_mmap_impl() return void*, make p9_mmap_tracked() and
  p9_munmap() non-static returning void*/int, and have mman.c call
  them directly (bypassing __p9_syscall() which uses long throughout).
  SYS_mmap/SYS_munmap cases in __p9_syscall() now return ENOSYS since
  they cannot safely carry 64-bit addresses through long parameters.

kencc *c/cgen.c (1c 2c 5c 7c 8c 8c/cgen64 kc qc vc):
  Rename the 'true' parameter in bcgen()/boolgen()/biggen()/testv()
  to 'cond'.  When these arch compilers are rebuilt in an APE context,
  <stdbool.h> or transitively included Plan9 headers define
  '#define true 1', turning 'int true' into 'int 1' and causing
  "syntax error, last name: true" from kencc.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs