### PR TITLE
kencc: fix BNORET overflow and char-type promotion after TBOOL insertion

### DIFF
--- a/sys/src/cmd/cc/cc.h
+++ b/sys/src/cmd/cc/cc.h
@@ -341,8 +341,8 @@ enum
 	TCONSTNT,
 	TVOLATILE,
 	TUNSIGNED,
+	TNORET,		/* moved before TSIGNED so BNORET=1L<<30 fits in 32-bit long */
 	TSIGNED,
-	TNORET,
 	TOLD,
 	NALLTYPES,
 

--- a/sys/src/cmd/cc/sub.c
+++ b/sys/src/cmd/cc/sub.c
@@ -707,9 +707,17 @@ arith(Node *n, int f)
 			n->type = t2;
 	} else {
 		/* convert up to at least int */
-		if(f == 1)
-		while(k < TINT)
-			k += 2;
+		if(f == 1) {
+			/* TBOOL at position 3 broke the k+=2 signed/unsigned pairing.
+			 * Handle TCHAR/TUCHAR/TBOOL explicitly; k+=2 still works for
+			 * TSHORT(4)→TINT(6) and TUSHORT(5)→TUINT(7). */
+			if(k == TCHAR || k == TBOOL)
+				k = TINT;
+			else if(k == TUCHAR)
+				k = TUINT;
+			else while(k < TINT)
+				k += 2;
+		}
 		n->type = types[k];
 	}
 	if(n->op == OSUB)


### PR DESCRIPTION
Two bugs introduced when TBOOL was inserted at enum position 3:

1. BNORET overflow (cc.h): TBOOL insertion shifted TNORET from 31 to 32, making BNORET = 1L<<32 = 0 on 32-bit Plan9 long. _Noreturn was silently dropped (BNORET OR'd nothing into the type bitmask). Fixed by moving TNORET before TSIGNED in the qualifier enum (TNORET=30, BNORET=1L<<30=0x40000000, which fits in 32-bit and is non-zero). TOLD becomes 32 (BOLD=1L<<32=0 but BOLD is unused).

2. k+=2 promotion loop (sub.c): The arith() function promotes small types to at least int using "while(k < TINT) k += 2". This relied on signed/unsigned pairs being at consecutive even/odd enum positions (TCHAR=1/TUCHAR=2, TSHORT=3/TUSHORT=4, TINT=5/TUINT=6). TBOOL=3 broke the pairing: now TSHORT=4/TUSHORT=5 and TINT=6/TUINT=7, but TCHAR(1)+2=3(TBOOL), TBOOL(3)+2=5(TUSHORT), TUSHORT(5)+2=7(TUINT) — so char+char promoted to TUINT (unsigned) instead of TINT (signed), and uchar+uchar promoted to TINT instead of TUINT.

   Fix: handle TCHAR, TUCHAR, TBOOL directly before the k+=2 loop:
   - TCHAR/TBOOL → TINT  (signed small types promote to signed int)
   - TUCHAR → TUINT       (unsigned char promotes to unsigned int)
   The k+=2 loop still handles TSHORT(4)→TINT(6) and TUSHORT(5)→TUINT(7)
   correctly after TBOOL insertion.

Both bugs affect all programs compiled with the TBOOL-patched kencc. The wrong char promotion (bug 2) changed signed comparisons to unsigned for char arithmetic, potentially causing incorrect comparison results for negative signed char values.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs