### PR TITLE
8c/cgen64.c: rename local var cond→vcond to unshadow cond() function

### DIFF
--- a/sys/src/cmd/8c/cgen64.c
+++ b/sys/src/cmd/8c/cgen64.c
@@ -1564,7 +1564,7 @@ cgen64(Node *n, Node *nn)
 {
 	Type *dt;
 	uchar *args, (*cp)[VLEN], (**optab)[VLEN];
-	int li, ri, lri, dr, si, m, op, sh, cmp, cond;
+	int li, ri, lri, dr, si, m, op, sh, cmp, vcond;
 	Node *c, *d, *l, *r, *t, *s, nod1, nod2, nod3, nod4, nod5;
 
 	if(debug['g']) {
@@ -2093,40 +2093,40 @@ twoop:
 			break;
 		}
 
-		cond = 1;
+		vcond = 1;
 		optab = cmptab;
 		switch(op) {
 		case OEQ:
 			optab = NEtab;
-			cond = 0;
+			vcond = 0;
 			break;
 		case ONE:
 			optab = NEtab;
 			break;
 		case OLE:
 			args = GTargs;
-			cond = 0;
+			vcond = 0;
 			break;
 		case OGT:
 			args = GTargs;
 			break;
 		case OLS:
 			args = HIargs;
-			cond = 0;
+			vcond = 0;
 			break;
 		case OHI:
 			args = HIargs;
 			break;
 		case OLT:
 			args = GEargs;
-			cond = 0;
+			vcond = 0;
 			break;
 		case OGE:
 			args = GEargs;
 			break;
 		case OLO:
 			args = HSargs;
-			cond = 0;
+			vcond = 0;
 			break;
 		case OHS:
 			args = HSargs;
@@ -2138,7 +2138,7 @@ twoop:
 
 		switch(lri) {
 		case IMM(0, 0):
-			biggen(l, r, Z, cond, optab[T0i], args);
+			biggen(l, r, Z, vcond, optab[T0i], args);
 			break;
 		case IMM(0, 1):
 		case IMM(1, 0):
@@ -2147,14 +2147,14 @@ twoop:
 				diag(l, "bad whatof\n");
 				break;
 			case WCONST:
-				biggen(l, r, Z, cond, optab[T0i], args);
+				biggen(l, r, Z, vcond, optab[T0i], args);
 				break;
 			case WHARD:
 				reglcgen(&nod2, r, Z);
 				r = &nod2;
 				/* fall thru */
 			case WADDR:
-				biggen(l, r, Z, cond, optab[T0i], args);
+				biggen(l, r, Z, vcond, optab[T0i], args);
 				if(ri == WHARD)
 					regfree(r);
 				break;
@@ -2169,7 +2169,7 @@ twoop:
 				reglcgen(&nod2, r, Z);
 				r = &nod2;
 			}
-			biggen(l, r, Z, cond, optab[Tii], args);
+			biggen(l, r, Z, vcond, optab[Tii], args);
 			if(li == WHARD)
 				regfree(l);
 			if(ri == WHARD)


### PR DESCRIPTION
cgen64() declared a local 'int cond' that shadowed the external cond(int op) function (declared in gc.h, defined at line 217 of this file). At line 2570, cond(l->op) was being parsed as a call to the local int variable, not the function, producing: "incompatible type: INT for op FUNC"

Root cause: commit b559f97f renamed the 'true' parameter to 'cond' in biggen()/testv() to avoid the 'true'→1 macro expansion. But 'cond' was already a local variable in cgen64() AND the name of an external function. The parameter rename was fine for biggen/testv (separate scopes), but cgen64()'s local variable shadowed the function.

Fix: rename the local variable to vcond throughout cgen64().

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs