### PR TITLE
libap: fix stdio no-output bug — _envsetup goto, _fdinit fallback, m-…

### DIFF
--- a/sys/lib/tests/write-diag.c
+++ b/sys/lib/tests/write-diag.c
@@ -1,0 +1,38 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+/*
+ * Diagnostic: test direct write(2) and printf separately.
+ * Output on stdout shows which path works.
+ */
+int
+main(void)
+{
+	const char msg1[] = "write(1) direct: OK\n";
+	const char msg2[] = "printf: OK\n";
+	int r;
+
+	r = write(1, msg1, sizeof msg1 - 1);
+	if(r < 0) {
+		const char err[] = "write(1) FAILED: errno=";
+		char ebuf[32];
+		int e = errno;
+		write(2, err, sizeof err - 1);
+		/* write errno as decimal without printf */
+		if(e == 0) write(2, "0", 1);
+		else {
+			char tmp[12];
+			int i = sizeof tmp;
+			tmp[--i] = '\n';
+			while(e > 0) { tmp[--i] = '0' + (e % 10); e /= 10; }
+			write(2, tmp + i, sizeof tmp - i);
+		}
+	}
+
+	printf("%s", msg2);
+	fflush(stdout);
+
+	return 0;
+}

--- a/sys/src/ape/lib/ap/plan9/_envsetup.c
+++ b/sys/src/ape/lib/ap/plan9/_envsetup.c
@@ -47,8 +47,10 @@ _envsetup(void)
 	fdinited = 0;
 	cnt = 0;
 	dfd = _OPEN("/env", OREAD|OCEXEC);
-	if(dfd < 0)
+	if(dfd < 0) {
+		_fdinit(0, 0);
 		goto done;
+	}
 	psize = Envhunk;
 	ps = p = malloc(psize);
 	nd = _dirreadall(dfd, &d9a);

--- a/sys/src/ape/lib/ap/plan9/_fdinfo.c
+++ b/sys/src/ape/lib/ap/plan9/_fdinfo.c
@@ -34,7 +34,7 @@ readprocfdinit(void)
 	/* construct info from /proc/$pid/fd */
 	char buf[8192];
 	Fdinfo *fi;
-	int fd, pfd, n, tot, m;
+	int fd, pfd, n, tot, m = 0;
 	char *s, *nexts;
 
 	memset(buf, 0, sizeof buf);
@@ -60,7 +60,6 @@ readprocfdinit(void)
 	if(s == 0)
 		return -1;
 	s++;
-	m = 0;
 	for(; s && *s; s=nexts){
 		nexts = strchr(s, '\n');
 		if(nexts)
@@ -75,6 +74,7 @@ readprocfdinit(void)
 		fi->flags = FD_ISOPEN;
 		while(*s == ' ' || *s == '\t')
 			s++;
+		m = 0;
 		if(*s == 'r'){
 			m |= 1;
 			s++;
@@ -141,6 +141,16 @@ _fdinit(char *s, char *se)
 		sfdinit(usedproc, s, se);
 	if(!s && !usedproc)
 		defaultfdinit();
+
+	/* Safety: ensure stdin/stdout/stderr always have FD_ISOPEN set */
+	for(i = 0; i <= 2; i++) {
+		if(!(_fdinfo[i].flags & FD_ISOPEN)) {
+			_fdinfo[i].flags = FD_ISOPEN;
+			_fdinfo[i].oflags = (i == 0) ? O_RDONLY : O_WRONLY;
+			if(_isatty(i))
+				_fdinfo[i].flags |= FD_ISTTY;
+		}
+	}
 
 	for(i = 0; i < OPEN_MAX; i++) {
 		fi = &_fdinfo[i];


### PR DESCRIPTION
…reset

Three bugs in the fd-initialization path caused all write(2) calls to return EBADF silently, producing programs that run but produce no output:

_envsetup.c: If _OPEN("/env", OREAD|OCEXEC) fails, the old code jumped to `done:` without calling _fdinit(), leaving _fdinfo[] all-zeros. FD_ISOPEN was never set for any fd, so pwrite() always returned EBADF. Fix: call _fdinit(0, 0) before the goto so fd 0/1/2 are always initialized.

_fdinfo.c readprocfdinit(): variable `m` (r/w mode flags) was initialized once before the loop but never reset per-iteration, causing oflags to accumulate across fds (fd 1 got O_RDWR instead of O_WRONLY). Fix: move `m = 0` reset to the top of each loop iteration.

_fdinfo.c _fdinit(): add defensive fallback at startup — if fds 0/1/2 still have FD_ISOPEN clear after readprocfdinit+sfdinit, set them explicitly (same logic as defaultfdinit). Guards against any future initialization path that misses these fds.

Also add sys/lib/tests/write-diag.c to test direct write(2) vs printf independently, to make it easy to diagnose similar issues in the future.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs