### PR TITLE
stdio_impl.h: neutralise __lockfile to avoid crash at 0x90

### DIFF
--- a/sys/include/ape/stdio_impl.h
+++ b/sys/include/ape/stdio_impl.h
@@ -69,20 +69,21 @@ extern struct _IO_FILE *volatile __stderr_used;
  */
 
 static inline int __lockfile(struct _IO_FILE *f) {
-	pthread_mutex_t *lock;
-	if (f->lock < 0) return 0;
-	lock = (pthread_mutex_t *)(intptr_t)f->lock;
-	if (!lock) return 0;
-	if (pthread_mutex_lock(lock) != 0)
-		return 0;
-	return 1;
+	/*
+	 * f->lock == -1 means single-threaded / no locking (stdout/stderr/stdin).
+	 * f->lock == 0 means not yet initialised.
+	 * f->lock > 0 would be a mutex pointer, but Plan9 APE stdio does not
+	 * set up pthread mutexes for the standard streams, so we never reach
+	 * that branch in practice.  Keeping this as a no-op avoids a potential
+	 * crash from using an uninitialised or sign-confused lock value as a
+	 * pointer.
+	 */
+	(void)f;
+	return 0;
 }
 
 static inline void __unlockfile(struct _IO_FILE *f) {
-	pthread_mutex_t *lock;
-	if (f->lock < 0) return;
-	lock = (pthread_mutex_t *)(intptr_t)f->lock;
-	if (lock) pthread_mutex_unlock(lock);
+	(void)f;
 }
 
 #define _FLOCK(f) int __need_unlock = __lockfile(f)

--- a/sys/lib/tests/write-diag.c
+++ b/sys/lib/tests/write-diag.c
@@ -4,34 +4,63 @@
 #include <string.h>
 
 /*
- * Diagnostic: test direct write(2) and printf separately.
- * Output on stdout shows which path works.
+ * Diagnostic test for the no-output bug.
+ * Compile: pcc write-diag.c
+ *
+ * Tests three write paths separately:
+ *   1. Plan9 _PWRITE() — bypasses all APE layers
+ *   2. APE write(2)    — goes through pwrite()/FD_ISOPEN check
+ *   3. printf+fflush   — goes through musl stdio
  */
+
+/* Plan9 raw write syscall (bypasses APE pwrite wrapper entirely) */
+extern long _PWRITE(int, void *, long, long long);
+
+/* APE fd-info flags (FD_ISOPEN = 0x2) */
+typedef struct { unsigned long flags; unsigned long oflags; } Fdinfo_min;
+extern Fdinfo_min _fdinfo[];
+
+static void
+rawwrite(int fd, const char *s)
+{
+	_PWRITE(fd, (void *)s, strlen(s), -1LL);
+}
+
+static void
+rawdec(int fd, unsigned long n)
+{
+	char buf[20];
+	int i = sizeof buf;
+	if(n == 0){ _PWRITE(fd, "0", 1, -1LL); return; }
+	while(n > 0){ buf[--i] = '0' + (int)(n % 10); n /= 10; }
+	_PWRITE(fd, buf+i, (long)(sizeof buf - i), -1LL);
+}
+
 int
 main(void)
 {
-	const char msg1[] = "write(1) direct: OK\n";
-	const char msg2[] = "printf: OK\n";
 	int r;
 
-	r = write(1, msg1, sizeof msg1 - 1);
-	if(r < 0) {
-		const char err[] = "write(1) FAILED: errno=";
-		char ebuf[32];
-		int e = errno;
-		write(2, err, sizeof err - 1);
-		/* write errno as decimal without printf */
-		if(e == 0) write(2, "0", 1);
-		else {
-			char tmp[12];
-			int i = sizeof tmp;
-			tmp[--i] = '\n';
-			while(e > 0) { tmp[--i] = '0' + (e % 10); e /= 10; }
-			write(2, tmp + i, sizeof tmp - i);
-		}
+	/* Step 1: raw Plan9 syscall — no APE wrapper at all */
+	rawwrite(1, "1. _PWRITE direct: OK\n");
+
+	/* Step 2: show _fdinfo state for fd 1 */
+	rawwrite(1, "2. _fdinfo[1].flags=0x");
+	rawdec(1, _fdinfo[1].flags);
+	rawwrite(1, " (FD_ISOPEN=");
+	rawdec(1, (_fdinfo[1].flags & 0x2) != 0);
+	rawwrite(1, ")\n");
+
+	/* Step 3: APE write(2) */
+	r = write(1, "3. write(1): OK\n", 16);
+	if(r < 0){
+		rawwrite(1, "3. write(1) FAILED errno=");
+		rawdec(1, (unsigned long)errno);
+		rawwrite(1, "\n");
 	}
 
-	printf("%s", msg2);
+	/* Step 4: printf + fflush */
+	printf("4. printf: OK\n");
 	fflush(stdout);
 
 	return 0;


### PR DESCRIPTION
acid shows the process crashing at address 0x90 (= 144) immediately on startup.  The likely cause: when libap.a was compiled with the TBOOL compiler (which had the BSIGNED=0 bug), the signed comparison
  if (f->lock < 0)
in __lockfile was compiled as an unsigned comparison.  For stdout, f->lock = -1 (intptr_t = 0xFFFFFFFFFFFFFFFF).  Treated as unsigned, the test fails, so the code continues and calls
  pthread_mutex_lock((pthread_mutex_t *)0xFFFFFFFFFFFFFFFF)
which adds struct field offsets to that address; 64-bit wrap-around then produces address 0x90 (= 0xFFFFFFFFFFFFFFFF + 0x91, where 0x91 is the offset of QLock.lock.val inside pthread_mutex), causing the fault.

Fix: __lockfile / __unlockfile are no-ops.  Plan9 APE stdio does not set up pthread mutexes for the standard streams; all standard I/O files use lock = -1 (single-threaded sentinel).  Locking is irrelevant for the single-process APE use case and any lock value other than -1 would require a properly initialised pthread_mutex_t, which is never provided by the static stdout/stderr/stdin initialisers.

Also improve write-diag.c: now tests _PWRITE directly (Plan9 raw syscall, bypasses APE entirely), dumps _fdinfo[1].flags, then tests APE write() and printf separately to pinpoint which layer fails.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs