### PR TITLE
compiler/: fix APEXPROOT depth and cc.a\$O build dependency

### DIFF
--- a/sys/src/ape/cmd/compiler/mkfile
+++ b/sys/src/ape/cmd/compiler/mkfile
@@ -1,4 +1,4 @@
-APEXPROOT=../../../..
+APEXPROOT=../../../../..
 
 ARCHES=\
 	1c\
@@ -13,6 +13,8 @@ ARCHES=\
 	vc\
 
 install:V:
+	# cc.a$O (cc front-end archive) must exist before arch compilers link
+	cd $APEXPROOT/sys/src/cmd/cc && mk install
 	for(i in $ARCHES) @{
 		cd $i
 		echo ----$i----


### PR DESCRIPTION
All arch mkfiles had APEXPROOT=../../../../.. (5 levels up) which resolved to sys/ rather than the repo root, making CCSRC=$APEXPROOT/sys/src/cmd/cc expand to sys/sys/src/cmd/cc — the double sys/ meant cc.a\$O was never found.

Fixes:
- arch mkfiles (1c..vc): APEXPROOT=../../../../../.. (6 levels up = repo root)
- top-level mkfile: APEXPROOT=../../../../.. (5 levels up = repo root)
- top-level install: build cc.a\$O via sys/src/cmd/cc before the arch loop, since every arch linker step links against \$CCSRC/cc.a\$O

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs