### PR TITLE
9src/cc: fix objs list to use objext, not hardcoded "o"

### DIFF
--- a/sys/src/ape/9src/cc.c
+++ b/sys/src/ape/9src/cc.c
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
 				suf++;
 				if(strcmp(suf, "c") == 0) {
 					append(&srcs, s);
-					append(&objs, changeext(s, "o"));
+					append(&objs, changeext(s, objext));
 				} else if(strcmp(suf, "o") == 0 ||
 					  strcmp(suf, ot->o) == 0 ||
 					  strcmp(suf, "a") == 0 ||


### PR DESCRIPTION
The object written by the compiler used objext (.6 for amd64 pcc) but the objs list still held .o, so 6l was handed a nonexistent filename.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs