### PR TITLE
9src/cc: exec dw2elf via /bin/dw2elf (Plan9 union mount path)

### DIFF
--- a/sys/src/ape/9src/cc.c
+++ b/sys/src/ape/9src/cc.c
@@ -236,8 +236,7 @@ main(int argc, char *argv[])
 			for(i = 0; i < srcs.n; i++)
 				append(&dw2elf_cmd,
 				       changeext(srcs.strings[i], "dwtypes"));
-			doexec(smprint("/%s/bin/ape/dw2elf", ot->name),
-			       &dw2elf_cmd);
+			doexec("/bin/dw2elf", &dw2elf_cmd);
 		}
 	}
 


### PR DESCRIPTION
apexp-sh bind-mounts $cputype/bin/ape into /bin, so all APE binaries are reachable as /bin/<name>. Using the arch-qualified path /$objtype/bin/ape/dw2elf was wrong.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs