### PR TITLE
6l: declare cpos() in l.h

### DIFF
--- a/sys/src/cmd/6l/l.h
+++ b/sys/src/cmd/6l/l.h
@@ -369,6 +369,7 @@ Prog*	brchain(Prog*);
 Prog*	brloop(Prog*);
 void	buildop(void);
 void	cflush(void);
+vlong	cpos(void);
 void	ckoff(Sym*, long);
 Prog*	copyp(Prog*);
 double	cputime(void);


### PR DESCRIPTION
asmbelf() in asm.c uses cpos() to capture file offsets, but cpos() was only declared locally in dwarf.c. Add the declaration to l.h alongside cflush().

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs