### PR TITLE
6l: fix datblk loop in asmb_elf: sizeof(buf) not sizeof(buf.dbuf)

### DIFF
--- a/sys/src/cmd/6l/asm.c
+++ b/sys/src/cmd/6l/asm.c
@@ -275,9 +275,9 @@ asmb_elf(void)
 		Bprint(&bso, "%5.2f asmb elf data\n", cputime());
 	Bflush(&bso);
 
-	for(v = 0; v < datsize; v += sizeof(buf.dbuf) - Dbufslop) {
-		if(datsize - v > sizeof(buf.dbuf) - Dbufslop)
-			datblk(v, sizeof(buf.dbuf) - Dbufslop);
+	for(v = 0; v < datsize; v += sizeof(buf) - Dbufslop) {
+		if(datsize - v > sizeof(buf) - Dbufslop)
+			datblk(v, sizeof(buf) - Dbufslop);
 		else
 			datblk(v, datsize - v);
 	}


### PR DESCRIPTION
buf.dbuf is char[1], so sizeof(buf.dbuf)=1. With Dbufslop=100 the step was 1-100=-99, which got passed as the write count to pwrite, causing "bad address in syscall". The correct size is sizeof(buf) (the full union), matching the existing asmb() data loop.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs