### PR TITLE
6l: call dwarfaddfrag when registering D_FILE symbols

### DIFF
--- a/sys/src/cmd/6l/obj.c
+++ b/sys/src/cmd/6l/obj.c
@@ -1,6 +1,7 @@
 #define	EXTERN
 #include	"l.h"
 #include	"../ld/elf.h"
+#include	"../ld/dwarf.h"
 #include	<ar.h>
 
 #ifndef	DEFAULT
@@ -854,6 +855,7 @@ loop:
 				histgen++;
 				s->type = SFILE;
 				s->value = histgen;
+				dwarfaddfrag(s->value, s->name+1);
 			}
 			if(histfrogp < MAXHIST) {
 				histfrog[histfrogp] = s;


### PR DESCRIPTION
ftab (the file fragment table used by dwarf.c's decodez()) was never populated, causing every z entry lookup to fail with "corrupt z entry". Register each new SFILE symbol's fragment string into ftab via dwarfaddfrag() at the same point histgen is assigned.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs