### PR TITLE
ld/dwarf: increase includestack from 16 to 64

### DIFF
--- a/sys/src/cmd/ld/dwarf.c
+++ b/sys/src/cmd/ld/dwarf.c
@@ -518,7 +518,7 @@ addhistfile(char *zentry)
 static struct {
 	int file;
 	vlong line;
-} includestack[16];
+} includestack[64];
 static int includetop;
 static vlong absline;
 


### PR DESCRIPTION
APE headers have deep transitive include chains that exceed the original Go-era limit of 16. 64 is enough for real-world nesting.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs