### PR TITLE
6l: fix text PT_LOAD to use Plan9 ELF convention (off=HEADR, vaddr=IN…

### DIFF
--- a/sys/src/cmd/6l/asm.c
+++ b/sys/src/cmd/6l/asm.c
@@ -109,12 +109,12 @@ asmbelf(long textfoff, vlong datafoff, vlong datva)
 	ph = newElfPhdr();
 	ph->type   = PT_LOAD;
 	ph->flags  = PF_R | PF_X;
-	ph->off    = 0;                        /* cover ELF header from offset 0 */
-	ph->vaddr  = INITTEXT - textfoff;      /* 0x200C00 - 0xC00 = 0x200000   */
-	ph->paddr  = INITTEXT - textfoff;
-	ph->filesz = textfoff + textsize;      /* header area + text             */
-	ph->memsz  = textfoff + textsize;
-	ph->align  = 0x1000;
+	ph->off    = textfoff;    /* HEADR=0xC00; Plan9 convention: off=HEADR not 0 */
+	ph->vaddr  = INITTEXT;    /* 0x200C00; alignment ok: 0xC00 ≡ 0x200C00 (mod 0x200000) */
+	ph->paddr  = INITTEXT;
+	ph->filesz = textsize;
+	ph->memsz  = textsize;
+	ph->align  = INITRND;     /* 0x200000 */
 
 	ph = newElfPhdr();
 	ph->type   = PT_LOAD;


### PR DESCRIPTION
…ITTEXT)

Linux-style text PT_LOAD (off=0, vaddr=INITTEXT-HEADR=0x200000) causes Plan9's kernel ELF loader to map the binary incorrectly, producing "general protection violation" on every ELF binary.

Plan9 convention (matching original 6l case 5 and 8l): off=HEADR=0xC00, vaddr=INITTEXT=0x200C00, filesz=textsize, align=INITRND=0x200000.

The alignment constraint is satisfied: 0xC00 ≡ 0x200C00 (mod 0x200000).

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs