### PR TITLE
6l: use ELF32 (ELFCLASS32) format for Plan9 ELF output

### DIFF
--- a/sys/src/cmd/6l/asm.c
+++ b/sys/src/cmd/6l/asm.c
@@ -190,7 +190,7 @@ asmbelf(long textfoff, vlong datafoff, vlong datva)
 	eh->ident[EI_MAG1]    = ELFMAG1;
 	eh->ident[EI_MAG2]    = ELFMAG2;
 	eh->ident[EI_MAG3]    = ELFMAG3;
-	eh->ident[EI_CLASS]   = ELFCLASS64;
+	eh->ident[EI_CLASS]   = ELFCLASS32;	/* Plan9 kernel exec requires ELF32 */
 	eh->ident[EI_DATA]    = ELFDATA2LSB;
 	eh->ident[EI_VERSION] = EV_CURRENT;
 	eh->type      = ET_EXEC;
@@ -207,7 +207,11 @@ asmbelf(long textfoff, vlong datafoff, vlong datva)
 }
 
 /*
- * asmb_elf: assemble ELF64 output (called by asmb when HEADTYPE==5).
+ * asmb_elf: assemble ELF32/AMD64 output (called by asmb when HEADTYPE==5).
+ *
+ * Plan9's kernel exec only accepts ELF32 format (ELFCLASS32), even on amd64.
+ * This matches the original 6l -H5 behaviour (cput(1) = ELFCLASS32 in case 5).
+ * All Plan9 userspace addresses fit in 32 bits, so ELF32 is sufficient.
  */
 static void
 asmb_elf(void)
@@ -218,8 +222,9 @@ asmb_elf(void)
 	uchar *op1;
 	vlong datva, datafoff, pad;
 
-	/* Initialize ELF state */
+	/* Initialize ELF state, then force ELF32 for Plan9 compatibility */
 	elfinit();
+	elfforce32();
 
 	/* NULL section header must be at index 0 — before any other shdr */
 	newElfShdr(0);

--- a/sys/src/cmd/ld/elf.c
+++ b/sys/src/cmd/ld/elf.c
@@ -69,6 +69,19 @@ elfinit(void)
 	}
 }
 
+/* elfforce32: switch to ELF32 format after elfinit().
+ * Plan9's kernel exec only accepts ELF32, even on amd64. */
+void
+elfforce32(void)
+{
+	elf64 = 0;
+	hdr.phoff    = ELF32HDRSIZE;
+	hdr.shoff    = ELF32HDRSIZE;
+	hdr.ehsize   = ELF32HDRSIZE;
+	hdr.phentsize = ELF32PHDRSIZE;
+	hdr.shentsize = ELF32SHDRSIZE;
+}
+
 ElfEhdr*
 getElfEhdr(void)
 {

--- a/sys/src/cmd/ld/elf.h
+++ b/sys/src/cmd/ld/elf.h
@@ -209,6 +209,7 @@ struct Elf_Note
 
 /* Declarations */
 void        elfinit(void);
+void        elfforce32(void);
 ElfEhdr*    getElfEhdr(void);
 ElfShdr*    newElfShdr(vlong);
 ElfPhdr*    newElfPhdr(void);


### PR DESCRIPTION
Plan9's kernel exec only accepts ELF32 format, even on amd64. The original 6l -H5 case always wrote ELFCLASS32 (cput(1) in case 5). Our new asmb_elf() was generating ELFCLASS64 which Plan9's kernel rejects with "exec header invalid".

Fix: add elfforce32() to elf.c, call it in asmb_elf() after elfinit(). This switches elf64=0 and resets all header/phdr/shdr size fields to ELF32 values. All Plan9 userspace addresses fit comfortably in 32 bits (INITTEXT=0x200C00).

The EM_X86_64 machine type in an ELF32 header (ELFCLASS32 + machine=62) is the exact format the original 6l -H5 used and what Plan9/9front expects.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs