### PR TITLE
libap: add idx_t (ptrdiff_t) xmalloc variants

### DIFF
--- a/sys/include/ape/xalloc.h
+++ b/sys/include/ape/xalloc.h
@@ -28,6 +28,14 @@ extern void *x2nrealloc(void *, size_t *, size_t);  /* growing: ~1.5x */
 extern void *x2realloc(void *, size_t *);
 extern void *xpalloc(void *, ptrdiff_t *, ptrdiff_t, ptrdiff_t, ptrdiff_t);
 
+/* idx_t (ptrdiff_t) signed-size variants */
+extern void *ximalloc(ptrdiff_t);
+extern void *xirealloc(void *, ptrdiff_t);
+extern void *xicalloc(ptrdiff_t, ptrdiff_t);
+extern void *xizalloc(ptrdiff_t);
+extern void *ximemdup(void const *, ptrdiff_t);
+extern char *ximemdup0(void const *, ptrdiff_t);
+
 /* Convenience: typed versions */
 #define XMALLOC(t, n)        ((t *)xmalloc((n) * sizeof(t)))
 #define XCALLOC(t, n)        ((t *)xcalloc((n), sizeof(t)))

--- a/sys/src/ape/lib/ap/malloc/xmalloc.c
+++ b/sys/src/ape/lib/ap/malloc/xmalloc.c
@@ -169,3 +169,43 @@ xpalloc(void *pa, ptrdiff_t *pn, ptrdiff_t n_incr_min, ptrdiff_t n_max, ptrdiff_
 	*pn = n;
 	return pa;
 }
+
+/* idx_t (ptrdiff_t) variants — same semantics, signed-size argument. */
+
+void *
+ximalloc(ptrdiff_t s)
+{
+	return xmalloc((size_t)s);
+}
+
+void *
+xirealloc(void *p, ptrdiff_t s)
+{
+	return xrealloc(p, (size_t)s);
+}
+
+void *
+xicalloc(ptrdiff_t n, ptrdiff_t s)
+{
+	return xcalloc((size_t)n, (size_t)s);
+}
+
+void *
+xizalloc(ptrdiff_t s)
+{
+	return xicalloc(s, 1);
+}
+
+void *
+ximemdup(void const *p, ptrdiff_t s)
+{
+	return xmemdup(p, (size_t)s);
+}
+
+char *
+ximemdup0(void const *p, ptrdiff_t s)
+{
+	char *result = ximalloc(s + 1);
+	result[s] = '\0';
+	return memcpy(result, p, s);
+}


### PR DESCRIPTION
Add ximalloc, xirealloc, xicalloc, xizalloc, ximemdup, ximemdup0 — the signed-size (idx_t) counterparts to the size_t xmalloc family. Implemented as simple casts to size_t delegating to the existing unsigned variants. gnulib's idx_t is typedef'd as ptrdiff_t.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs