### PR TITLE
ape/cc: silence -F and -B 'ignored' warnings

### DIFF
--- a/sys/src/ape/9src/cc.c
+++ b/sys/src/ape/9src/cc.c
@@ -122,7 +122,12 @@ main(int argc, char *argv[])
 		case 'N':
 		case 'T':
 		case 'w':
+		case 'F':
 			append(&cc, smprint("-%c", ARGC()));
+			break;
+		case 'B':
+			append(&cc, "-B");
+			Aflag = 1;
 			break;
 		case 'O':
 			break;


### PR DESCRIPTION
-F comes from CFLAGS=-Fw in sys/src/ape/config (parsed as -F then -w by ARGBEGIN). Pass it through to the native compiler like -w/-N/-T.

-B is passed explicitly by many mkfiles; cc.c already adds it internally when !Aflag. Accept it explicitly, set Aflag=1 to prevent the duplicate, and pass it to the compiler.

Both previously fell to the default: case printing "flag ignored".

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs