### PR TITLE
ape/cc: accept -p flag; time.h: add timezone_t; patch: add time_rz

### DIFF
--- a/sys/include/ape/time.h
+++ b/sys/include/ape/time.h
@@ -110,6 +110,13 @@ extern long timezone;
 extern long altzone;
 extern int daylight;
 
+/* POSIX.1-2024: opaque timezone handle used by tzalloc/tzfree/localtime_rz */
+#ifndef __timezone_t_defined
+struct tm_zone;
+typedef struct tm_zone *timezone_t;
+#define __timezone_t_defined 1
+#endif
+
 #include <sys/times.h> /* times */
 #include <sys/time.h> /* gettimeofday */
 

--- a/sys/src/ape/9src/cc.c
+++ b/sys/src/ape/9src/cc.c
@@ -121,6 +121,7 @@ main(int argc, char *argv[])
 			break;
 		case 'N':
 		case 'T':
+		case 'p':
 		case 'w':
 		case 'F':
 			append(&cc, smprint("-%c", ARGC()));

--- a/sys/src/ape/cmd/patch/mkfile
+++ b/sys/src/ape/cmd/patch/mkfile
@@ -17,6 +17,7 @@ LIBO=\
 	gettime.$O\
 	hash.$O\
 	parse-datetime.$O\
+	time_rz.$O\
 	progname.$O\
 	quotearg.$O\
 	tempname.$O\


### PR DESCRIPTION
cc.c: -p (profiling flag) now passes through to native compiler like -w/-F/-N/-T instead of printing 'flag ignored'.

time.h: add timezone_t as a forward-declared opaque type (POSIX.1-2024). Uses 'struct tm_zone *' with __timezone_t_defined guard so gnulib packages that define the full struct remain compatible.

patch/mkfile: add time_rz.$O to LIBO — parse-datetime.c calls tzalloc/tzfree/localtime_rz/mktime_z which are provided by time_rz.c.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs