### PR TITLE
bash: use pcc (not cc) to build mkbuiltins

### DIFF
--- a/sys/src/ape/cmd/bash/mkfile
+++ b/sys/src/ape/cmd/bash/mkfile
@@ -143,7 +143,7 @@ DEFFILES=\
 	$DEFDIR/wait.def
 
 $MKBUILTINS: $BASHSRC/builtins/mkbuiltins.c
-	cc -I$BASHSRC -I$BASHSRC/include -o $target $prereq
+	pcc -I$BASHSRC -I$BASHSRC/include -o $target $prereq
 
 # Generate builtins/builtext.h and builtins/builtins.c into the LOCAL
 # build directory. -includefile names the header that the generated


### PR DESCRIPTION
'cc' is not an executable in APE — pcc is the APE-aware compiler wrapper. The old mkfile inherited the 'cc' invocation from the upstream Makefile where CC_FOR_BUILD is the host compiler.

Fixes: rcmain 'file does not exist: ./cc' when generating mkbuiltins.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs