### PR TITLE
bash: add pattern rule for builtins/%.c as builtext.h side-effect

### DIFF
--- a/sys/src/ape/cmd/bash/mkfile
+++ b/sys/src/ape/cmd/bash/mkfile
@@ -185,10 +185,14 @@ builtins/builtext.h: $MKBUILTINS $DEFFILES
 		../$DEFDIR/type.def ../$DEFDIR/ulimit.def ../$DEFDIR/umask.def \
 		../$DEFDIR/wait.def
 
-# builtins.c and every generated per-def .c are produced by the rule
-# above (single mkbuiltins invocation). Declare them dependent on the
-# header target so mk doesn't try to build them separately.
+# builtins.c and every generated per-def .c file (alias.c, bind.c, ...)
+# are side-effects of the single mkbuiltins invocation above. Depending
+# them on builtext.h with an empty recipe tells mk they exist as soon
+# as builtext.h does, without trying to rebuild them independently.
 builtins/builtins.c: builtins/builtext.h
+	:
+
+builtins/%.c: builtins/builtext.h
 	:
 
 # Every builtin object needs the generated header before it will compile.


### PR DESCRIPTION
The explicit 'builtins/builtins.c: builtins/builtext.h' stub only covered the struct file. For alias.c, bind.c and every other .def- generated .c, mk still complained 'don't know how to make builtins/alias.c' because no rule mentioned that target.

Add a pattern rule 'builtins/%.c: builtins/builtext.h' with an empty recipe so mk treats every generated .c as available once builtext.h has been produced by the mkbuiltins invocation.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs