### PR TITLE
stdbool.h: drop '#define bool _Bool' — pcc already has both as keywords

### DIFF
--- a/sys/include/ape/stdbool.h
+++ b/sys/include/ape/stdbool.h
@@ -1,10 +1,20 @@
 #ifndef __STDBOOL_H__
 #define __STDBOOL_H__
 
-/* _Bool is a built-in keyword in kencc (Plan9) and all C99 compilers.
- * No typedef needed — defining it would be a syntax error for kencc. */
-#define bool _Bool
-#define true 1
+/*
+ * pcc/kencc treats both `_Bool` (C99) and `bool` (C23) as built-in
+ * type keywords mapped to unsigned char — see sys/src/cmd/cc/lex.c.
+ * So this header does NOT need to '#define bool _Bool': doing so
+ * would introduce a token-substitution round where a cast like
+ * '(bool)expr' turned into '(_Bool)expr' after expansion. In some
+ * macro contexts (e.g. gnulib's ckd_mul, which is
+ * '((bool) _GL_INT_MULTIPLY_WRAPV(...))'), pcc then emitted _Bool
+ * as an external symbol reference from the .o file, causing a
+ * link-time 'undefined: _Bool' error. Using pcc's own `bool`
+ * keyword directly avoids the round-trip.
+ */
+
+#define true  1
 #define false 0
 #define __bool_true_false_are_defined 1
 


### PR DESCRIPTION
pcc/kencc's lex.c registers _Bool AND bool as built-in type keywords (both map to LCHAR/TUCHAR). The '#define bool _Bool' round-trip in stdbool.h was therefore redundant, and worse: it corrupted certain gnulib macros. gnulib's ckd_mul is defined as
    #define ckd_mul(r, a, b) ((bool) _GL_INT_MULTIPLY_WRAPV (a, b, r))
After 'bool -> _Bool' textual substitution, the expression pcc had to parse was a cast to _Bool wrapped around a large _Generic expansion. In that context pcc emitted _Bool as an unresolved external, producing the link-time error 'undefined: _Bool in xreallocarray' when linking bash (whose xmalloc.c uses ckd_mul).

Dropping the macro makes bash's '(bool)' cast use pcc's native bool keyword directly — no round-trip, no external emitted.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs