### PR TITLE
bash: use APExp-local pcc, not system pcc

### DIFF
--- a/sys/src/ape/cmd/bash/mkfile
+++ b/sys/src/ape/cmd/bash/mkfile
@@ -89,8 +89,11 @@ BIN=$APEXPROOT/$objtype/bin/ape
 
 <$APEXPROOT/sys/src/cmd/mkone
 
-CC=pcc
-LD=pcc
+#during building from scratch, the system pcc may predate patches
+#(e.g. C23 bool keyword, include_next behaviour) that bash needs.
+#Use the APExp-local pcc that just got rebuilt.
+CC=$APEXPROOT/$objtype/bin/pcc
+LD=$APEXPROOT/$objtype/bin/pcc
 YACC=bison
 
 DEFS= 	-DHAVE_CONFIG_H -DLOCALEDIR="/sys/lib/ape/locale" -D_POSIX_SOURCE\


### PR DESCRIPTION
'CC=pcc' resolved to the system-installed pcc which may predate the C23 bool/_Bool keyword patches in sys/src/cmd/cc/lex.c. When bash's xmalloc.c expanded ckd_mul (which contains '(bool) ...'), the older system pcc treated 'bool' as an unknown identifier and emitted it as an external symbol, producing 'undefined: bool in xreallocarray' at link time.

Point CC and LD at $APEXPROOT/$objtype/bin/pcc — the local build, matching what m4/bison/grep already do. Their mkfiles carry the same comment: 'the new pcc is not picked up' when building from scratch.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs