### PR TITLE
bash: '-Dbool=int' shim in CFLAGS to dodge missing C23 bool keyword

### DIFF
--- a/sys/src/ape/cmd/bash/mkfile
+++ b/sys/src/ape/cmd/bash/mkfile
@@ -96,13 +96,20 @@ CC=$APEXPROOT/$objtype/bin/pcc
 LD=$APEXPROOT/$objtype/bin/pcc
 YACC=bison
 
+#-Dbool=int is a cpp-level shim: even if the installed pcc/6c does not
+# yet know 'bool' as a C23 keyword (the itab entry in cc/lex.c ships
+# with the source but requires a rebuild of cc.a AND 6c to take effect),
+# every 'bool' token in bash's own source and in gnulib macros like
+# ckd_mul is rewritten to 'int' before it reaches the compiler. Without
+# this shim, gnulib's '((bool) _GL_INT_MULTIPLY_WRAPV(...))' cast in
+# xreallocarray triggered 'undefined: bool' at link time.
 DEFS= 	-DHAVE_CONFIG_H -DLOCALEDIR="/sys/lib/ape/locale" -D_POSIX_SOURCE\
 		-D_BSD_EXTENSION -DHAVE_LIMITS_H -D_LIMITS_EXTENSION -DPLAN9\
 		-DCONF_OSTYPE="plan9" -DCONF_MACHTYPE="$objtype-apexp-plan9" -DPROGRAM="bash"\
 		-DPACKAGE="bash" -DPACKAGE_STRING='bash 5.3-release'\
 		-DCONF_VENDOR="apexp" -DCONF_HOSTTYPE="$objtype"\
 		-DHAVE_SYS_RESOURCE_H -DTERM=vt100 -UJOB_CONTROL\
-		-Dbotch=programming_error -DSHELL
+		-Dbotch=programming_error -DSHELL -Dbool=int
 
 
 CFLAGS=	-c -B -I. -I$BASHSRC -I$BASHSRC/include -I$BASHSRC/lib -I$BASHSRC/lib/intl\


### PR DESCRIPTION
The installed pcc/6c may not yet recognise 'bool' as a native C23 type keyword — the entry lives in sys/src/cmd/cc/lex.c but only takes effect once cc.a AND 6c have been rebuilt (which does not happen automatically when a user pulls just the lex.c change).

Without the fix, gnulib's '((bool) _GL_INT_MULTIPLY_WRAPV(...))' cast inside ckd_mul used by bash/xmalloc.c's xreallocarray caused the linker to emit 'undefined: bool in xreallocarray'.

'-Dbool=int' rewrites every 'bool' token to 'int' at cpp time, so the compiler never has to know the keyword and the cast becomes an ordinary (int) cast. Harmless — bash's other bool usages (bashansi.h typedef, stdbool.h include) are guarded and don't clash.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs