### PR TITLE
build: bind local $cputype/bin over /bin; rebuild cc.a on any cc sour…

### DIFF
--- a/mount-include
+++ b/mount-include
@@ -5,6 +5,14 @@ if(! test -e /sys/include/ape/THIS_IS_APExp) {
     bind -b $cputype/include/ape /sys/include/ape
     bind -b $cputype/lib/ape /$cputype/lib/ape
     bind -b sys/include/ape /sys/include/ape
+    # Overlay locally-built compilers/linkers/assemblers over /bin so
+    # pcc (which hardcodes /bin/6c, /bin/6l, /bin/6a etc.) picks up
+    # THIS tree's freshly-built compiler with all its C99/C11/C23
+    # patches — bool keyword, _Generic, compound literals, etc.
+    # Without this, an outside-APExp 'mk install' silently uses the
+    # host system's stock 6c, which fails on ap/complex, ap/aio, and
+    # every gnulib-heavy binary in sys/src/ape/cmd that uses (bool).
+    bind -b $cputype/bin /bin
     echo "APExp mounted"
     }
 if not echo "APExp already mounted"

--- a/sys/src/cmd/cc/mkfile.port
+++ b/sys/src/cmd/cc/mkfile.port
@@ -5,7 +5,13 @@ D=${T:%=%c}
 
 default:V: $O.out
 
-$LIB:	../cc/cc.h
+# Rebuild cc.a whenever ANY cc source or header changes.  The old rule
+# depended only on ../cc/cc.h, so edits to lex.c / cc.y / dcl.c / com.c
+# never triggered a rebuild: stale cc.a survived the C99/C11/C23 patches
+# (the 'bool' keyword, _Generic, ...) and every arch backend that links
+# cc.a kept shipping the pre-patch behaviour.  The glob keeps this rule
+# from rotting when a new source file is added to cc/.
+$LIB:	../cc/*.h ../cc/*.c ../cc/cc.y ../cc/macbody
 	cd ../cc
 	mk install
 


### PR DESCRIPTION
…ce change

Two independent bugs made an outside-APExp 'mk install' silently compile with the HOST system's stock 6c instead of this tree's patched one.

1. mount-include did not bind $cputype/bin over /bin.

   pcc hardcodes its backend paths as /bin/6c, /bin/6l, /bin/6a (see smprint("/bin/%s", ot->cc) in sys/src/cmd/pcc.c), so pointing CC= at a local pcc changes nothing — the dispatch still lands on the system compiler. apexp-sh already does 'bind -b $cputype/bin /bin' after calling mount-include, which is why builds from inside the APExp shell worked while a from-scratch 'mk install' at the repo root did not.

   Add the same bind to mount-include. Newly installed backends land in $APEXPROOT/$objtype/bin, which is the bound directory, so they become visible as /bin/6c as soon as sys/src/cmd finishes.

2. mkfile.port rebuilt cc.a only when ../cc/cc.h changed.

   Edits to lex.c, cc.y, dcl.c or com.c left cc.a stale, so every arch backend that links it kept the pre-patch behaviour — including the itab entry that makes 'bool' a C23 type keyword. Depend on all cc sources via a glob so the rule cannot rot as files are added.

Together these explain 'undefined: bool' when linking bash and flex, and the ap/complex and ap/aio failures after a library clean.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs