### PR TITLE
gnulib: match sibling package mkfile conventions

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -1,5 +1,4 @@
-APE=../../../ape
-<$APE/config
+</$objtype/mkfile
 APEXPROOT=../../../../..
 
 # One shared libgnu.a for every GNU package that needs gnulib.
@@ -170,7 +169,7 @@ UNRPL=-Drpl_readlink=readlink -Drpl_lseek=lseek -Drpl_open=open\
 CFLAGS=-c -B -I. -I$GNUSRC -DHAVE_CONFIG_H\
 	-D_POSIX_SOURCE -D_BSD_EXTENSION -D__USE_GNU\
 	-D_REGEX_LARGE_OFFSETS -DREGEX_MALLOC -DO_BINARY=0\
-	-DSETLOCALE_NULL_MAX=(256+1)\
+	-DSETLOCALE_NULL_MAX=257\
 	-DLOCALEDIR="/sys/lib/ape/locale" $UNRPL
 
 # No two modules share a basename across these directories, so the
@@ -204,7 +203,7 @@ $LIB:	$OFILES
 	rm -f $LIB
 	ar vu $LIB $OFILES
 
-# Rebuilding from scratch matters here: 'ar vu' only ever appends, so a
+# Rebuilding from scratch matters here. 'ar vu' only ever appends, so a
 # member dropped from OFILES survives in a stale archive and keeps
 # breaking the link. Always remove the archive, never update in place.
 clean:V:


### PR DESCRIPTION
'mk: mkfile:169: syntax error; unknown attribute -' came from the gnulib mkfile being written unlike every other package mkfile in sys/src/ape/cmd. Two constructs were unique to it:

* It opened with '<$APE/config' instead of '</$objtype/mkfile'. No other package mkfile pulls in sys/src/ape/config, which carries list-valued assignments such as INSOWNER=() alongside INSTALL and INSMODE. bison, m4, sed and grep all include /$objtype/mkfile directly and set CC themselves, which this now does too. That include also explains why mk's reported line number pointed at a blank line, since mk counts the lines it pulls in.

* CFLAGS carried -DSETLOCALE_NULL_MAX=(256+1). Parentheses are list syntax to mk, so the value is replaced with the literal 257.

Also removed a colon from a comment so no comment line can be mistaken for a rule.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs