### PR TITLE
gnulib: make the snippet macros reachable after the header prune

### DIFF
--- a/sys/src/external/gnulib/config.h
+++ b/sys/src/external/gnulib/config.h
@@ -5691,3 +5691,10 @@
 # define GNULIB_TEXT_DOMAIN/**/"gnulib"
 #endif
 
+
+/* APExp: snippet macros.
+   gnulib normally splices arg-nonnull.h and warn-on-use.h into its
+   generated replacement headers. Those headers are removed here because
+   they shadow APE's, so include the snippets directly instead. */
+#include "arg-nonnull.h"
+#include "warn-on-use.h"

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -97,6 +97,38 @@ if [ -d "$DEST/sys" ]; then
 fi
 echo "pruned $pruned replacement system headers"
 
+# Make the snippet macros reachable from config.h.
+#
+# gnulib keeps _GL_ARG_NONNULL and _GL_WARN_ON_USE in standalone snippet
+# files and has autoconf splice their text into each generated
+# replacement header. The deleted stdio.h alone carried 91 uses of
+# _GL_ARG_NONNULL along with the definition. With those headers gone the
+# macros vanish, and a module header such as stdio-safer.h that says
+#
+#   FILE *fopen_safer (char const *, char const *) _GL_ARG_NONNULL ((1, 2))
+#
+# reaches the compiler with _GL_ARG_NONNULL still an unknown identifier,
+# which is a syntax error rather than a missing-header one.
+#
+# Both snippets are self-guarded and free of unsubstituted @PLACEHOLDER@
+# text, so they can simply be included. Every gnulib source includes
+# config.h first, so pulling them in from there covers all of them.
+#
+# c++defs.h is deliberately not included: it still has @PLACEHOLDER@ text
+# and only matters for the C++ aliasing that this build does not use.
+if [ -f "$DEST/config.h" ] && ! grep -q 'APExp: snippet macros' "$DEST/config.h"; then
+	cat >> "$DEST/config.h" <<'EOF'
+
+/* APExp: snippet macros.
+   gnulib normally splices arg-nonnull.h and warn-on-use.h into its
+   generated replacement headers. Those headers are removed here because
+   they shadow APE's, so include the snippets directly instead. */
+#include "arg-nonnull.h"
+#include "warn-on-use.h"
+EOF
+	echo "appended snippet includes to config.h"
+fi
+
 echo "---"
 echo "imported $copied files into $DEST ($skipped already present, newer copy kept)"
 echo


### PR DESCRIPTION
clean-temp.c failed with

  stdio-safer.h:34 syntax error, last name: __func__

on this declaration:

  FILE *fopen_safer (char const *, char const *) _GL_ARG_NONNULL ((1, 2))

_GL_ARG_NONNULL was an unknown identifier, so the error is a syntax one rather than a missing header.

gnulib keeps _GL_ARG_NONNULL and _GL_WARN_ON_USE in standalone snippet files and has autoconf splice their text into every generated replacement header. The stdio.h removed in the previous commit carried 91 uses of _GL_ARG_NONNULL and the definition along with them, so deleting those headers took the macros with it.

Both snippets are self-guarded and carry no unsubstituted @PLACEHOLDER@ text, so include them from config.h, which every gnulib source includes first. c++defs.h is left alone: it still has placeholders in it and only matters for C++ aliasing this build does not do.

Done in import.sh as well as in the tree, so a re-import reproduces it.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs