### PR TITLE
gnulib: define the printf format attributes after the header prune

### DIFF
--- a/sys/src/external/gnulib/config.h
+++ b/sys/src/external/gnulib/config.h
@@ -5698,3 +5698,74 @@
    they shadow APE's, so include the snippets directly instead. */
 #include "arg-nonnull.h"
 #include "warn-on-use.h"
+
+/* APExp: printf and scanf format attributes.
+   Another set gnulib splices into its generated stdio.h. error.c and
+   the vasnprintf family declare functions with
+   _GL_ATTRIBUTE_FORMAT_PRINTF_STANDARD, so without these the compiler
+   meets an unknown identifier and reports a syntax error on the
+   argument that follows it. Copied verbatim from stdio.in.h, which is
+   free of unsubstituted placeholders in this range. They all reduce to
+   _GL_ATTRIBUTE_FORMAT, which config.h already defines as empty for
+   non-GCC compilers, so on pcc these expand to nothing. */
+/* An __attribute__ __format__ specifier for a function that takes a format
+   string and arguments, where the format string directives are the ones
+   standardized by ISO C99 and POSIX.
+   _GL_ATTRIBUTE_SPEC_PRINTF_STANDARD  */
+/* __gnu_printf__ is supported in GCC >= 4.4.  */
+#if (__GNUC__ + (__GNUC_MINOR__ >= 4) > 4) && !defined __clang__
+# define _GL_ATTRIBUTE_SPEC_PRINTF_STANDARD __gnu_printf__
+#else
+# define _GL_ATTRIBUTE_SPEC_PRINTF_STANDARD __printf__
+#endif
+
+/* An __attribute__ __format__ specifier for a function that takes a format
+   string and arguments, where the format string directives are the ones of the
+   system printf(), rather than the ones standardized by ISO C99 and POSIX.
+   _GL_ATTRIBUTE_SPEC_PRINTF_SYSTEM  */
+/* On mingw, Gnulib sets __USE_MINGW_ANSI_STDIO in order to get closer to
+   the standards.  The macro GNULIB_PRINTF_ATTRIBUTE_FLAVOR_GNU indicates
+   whether this change is effective.  On older mingw, it is not.  */
+#if GNULIB_PRINTF_ATTRIBUTE_FLAVOR_GNU
+# define _GL_ATTRIBUTE_SPEC_PRINTF_SYSTEM _GL_ATTRIBUTE_SPEC_PRINTF_STANDARD
+#else
+# define _GL_ATTRIBUTE_SPEC_PRINTF_SYSTEM __printf__
+#endif
+
+/* _GL_ATTRIBUTE_FORMAT_PRINTF_STANDARD
+   indicates to GCC that the function takes a format string and arguments,
+   where the format string directives are the ones standardized by ISO C99
+   and POSIX.  */
+#define _GL_ATTRIBUTE_FORMAT_PRINTF_STANDARD(formatstring_parameter, first_argument) \
+  _GL_ATTRIBUTE_FORMAT ((_GL_ATTRIBUTE_SPEC_PRINTF_STANDARD, formatstring_parameter, first_argument))
+
+/* _GL_ATTRIBUTE_FORMAT_PRINTF_SYSTEM is like _GL_ATTRIBUTE_FORMAT_PRINTF_STANDARD,
+   except that it indicates to GCC that the supported format string directives
+   are the ones of the system printf(), rather than the ones standardized by
+   ISO C99 and POSIX.  */
+#define _GL_ATTRIBUTE_FORMAT_PRINTF_SYSTEM(formatstring_parameter, first_argument) \
+  _GL_ATTRIBUTE_FORMAT ((_GL_ATTRIBUTE_SPEC_PRINTF_SYSTEM, formatstring_parameter, first_argument))
+
+/* _GL_ATTRIBUTE_FORMAT_SCANF
+   indicates to GCC that the function takes a format string and arguments,
+   where the format string directives are the ones standardized by ISO C99
+   and POSIX.  */
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 4)
+# define _GL_ATTRIBUTE_FORMAT_SCANF(formatstring_parameter, first_argument) \
+   _GL_ATTRIBUTE_FORMAT ((__gnu_scanf__, formatstring_parameter, first_argument))
+#else
+# define _GL_ATTRIBUTE_FORMAT_SCANF(formatstring_parameter, first_argument) \
+   _GL_ATTRIBUTE_FORMAT ((__scanf__, formatstring_parameter, first_argument))
+#endif
+
+/* _GL_ATTRIBUTE_FORMAT_SCANF_SYSTEM is like _GL_ATTRIBUTE_FORMAT_SCANF,
+   except that it indicates to GCC that the supported format string directives
+   are the ones of the system scanf(), rather than the ones standardized by
+   ISO C99 and POSIX.  */
+#define _GL_ATTRIBUTE_FORMAT_SCANF_SYSTEM(formatstring_parameter, first_argument) \
+  _GL_ATTRIBUTE_FORMAT ((__scanf__, formatstring_parameter, first_argument))
+
+/* The definitions of _GL_FUNCDECL_RPL etc. are copied here.  */
+
+/* The definition of _GL_ARG_NONNULL is copied here.  */
+

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -126,7 +126,25 @@ if [ -f "$DEST/config.h" ] && ! grep -q 'APExp: snippet macros' "$DEST/config.h"
 #include "arg-nonnull.h"
 #include "warn-on-use.h"
 EOF
-	echo "appended snippet includes to config.h"
+	# The printf and scanf format attributes are spliced into the
+	# generated stdio.h too. error.c and the vasnprintf family declare
+	# functions with _GL_ATTRIBUTE_FORMAT_PRINTF_STANDARD, so without
+	# these the compiler meets an unknown identifier and reports a
+	# syntax error on whatever argument follows it. Lift the block out
+	# of stdio.in.h between two stable anchors rather than by line
+	# number. Everything in it reduces to _GL_ATTRIBUTE_FORMAT, which
+	# config.h already defines as empty for non-GCC compilers.
+	{
+		echo
+		echo "/* APExp: printf and scanf format attributes, lifted from"
+		echo "   stdio.in.h because the generated stdio.h that normally"
+		echo "   carries them is deleted above. */"
+		awk '/__gnu_printf__ is supported in GCC/ { p = 1 }
+		     p { print }
+		     /__scanf__, formatstring_parameter, first_argument/ { if (p) exit }' \
+			"$DEST/stdio.in.h"
+	} >> "$DEST/config.h"
+	echo "appended snippet includes and format attributes to config.h"
 fi
 
 echo "---"


### PR DESCRIPTION
error.c:218 failed with "syntax error, last name: 3" on

  static void _GL_ATTRIBUTE_FORMAT_PRINTF_STANDARD (3, 0) _GL_ARG_NONNULL ((3))

_GL_ATTRIBUTE_FORMAT_PRINTF_STANDARD was an unknown identifier, so the parser choked on the 3 that follows it. error.c defines the macro itself, but only inside its #if _LIBC branch; every other build expects the generated stdio.h to supply it, and that header was deleted for shadowing APE's.

Same root cause as the _GL_ARG_NONNULL fix, so this commit also audited the rest rather than waiting for the next one. Comparing every _GL_ identifier used by the sources in OFILES against every definition still reachable leaves only this family genuinely missing. The remainder of that list is noise: token-paste fragments, feature-test macros that are only ever #ifdef-tested, and _GL_ATTRIBUTE_NORETURN, which survives in a comment. unistd.c looked like a third case but defines _GL_UNISTD_INLINE itself and reduces to "typedef int dummy;" once its header is APE's, so it compiles to an empty object and is left alone.

Copied the block out of stdio.in.h, which has no unsubstituted placeholders in that range. Everything in it reduces to _GL_ATTRIBUTE_FORMAT, which config.h already defines as empty for non-GCC compilers, so on pcc these expand to nothing and no diagnostic is lost that pcc would have produced.

import.sh lifts the same block between two stable anchors rather than by line number, so a re-import reproduces it.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs