### PR TITLE
libap: add the musl <stdio_ext.h> accessors; drop 3 gnulib modules

### DIFF
--- a/sys/include/ape/stdio_ext.h
+++ b/sys/include/ape/stdio_ext.h
@@ -1,0 +1,45 @@
+#ifndef __STDIO_EXT_H__
+#define __STDIO_EXT_H__
+
+#pragma lib "/$M/lib/ape/libap.a"
+
+/*
+ * <stdio_ext.h>: accessors for stdio state that the standard API does
+ * not expose. Originally Solaris; glibc and musl both provide a subset.
+ *
+ * These matter because gnulib's freadahead, fseterr and fwriting
+ * modules each begin with a "#if HAVE___FREADAHEAD / musl libc" branch
+ * that simply forwards to the function here. Without them gnulib falls
+ * through to a long #elif chain that reads FILE internals directly, one
+ * platform at a time, and picks its Plan 9 branch on the strength of
+ * EPLAN9 being defined -- which then reads fp->state, fp->rp and fp->wp
+ * from the old APE FILE that APExp no longer uses.
+ *
+ * The set implemented follows musl.
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Bytes buffered for reading, including anything pushed back by ungetc. */
+extern size_t __freadahead(FILE *);
+
+/* Bytes buffered for writing but not yet flushed. */
+extern size_t __fpending(FILE *);
+
+/* Set the stream's error indicator. */
+extern void __fseterr(FILE *);
+
+/* Stream orientation. */
+extern int __freading(FILE *);
+extern int __fwriting(FILE *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STDIO_EXT_H__ */

--- a/sys/src/ape/cmd/gnulib/README
+++ b/sys/src/ape/cmd/gnulib/README
@@ -45,8 +45,9 @@ Two rules for anyone editing the OFILES list
 
        _obstack_begin: libap.a(obstack_printf): redefinition: _obstack_begin
 
-   Already provided by libap, do not add: obstack, exitfail, and the
-   whole x*alloc family -- xmalloc, xalloc-die, xreallocarray, xnmalloc,
+   Already provided by libap, do not add: obstack, exitfail, the musl
+   <stdio_ext.h> accessors behind freadahead, fseterr and fwriting, and
+   the whole x*alloc family -- xmalloc, xalloc-die, xreallocarray, xnmalloc,
    xnrealloc, xcharalloc, xzalloc, x2realloc, x2nrealloc, xpalloc and the
    idx_t variants (ximalloc, xirealloc, xicalloc, xizalloc, ximemdup,
    ximemdup0).

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -58,11 +58,8 @@ OFILES=\
 	filenamecat-lgpl.$O\
 	findprog-in.$O\
 	fopen-safer.$O\
-	freadahead.$O\
 	free.$O\
-	fseterr.$O\
 	fstrcmp.$O\
-	fwriting.$O\
 	get-errno.$O\
 	get-permissions.$O\
 	gethrxtime.$O\

--- a/sys/src/ape/lib/ap/stdio/mkfile
+++ b/sys/src/ape/lib/ap/stdio/mkfile
@@ -87,6 +87,7 @@ OFILES=\
 # GNU extensions\
 	asnprintf.$O\
 	_fpending.$O\
+	stdio_ext.$O\
 	error.$O\
 
 

--- a/sys/src/ape/lib/ap/stdio/stdio_ext.c
+++ b/sys/src/ape/lib/ap/stdio/stdio_ext.c
@@ -1,0 +1,45 @@
+#include "stdio_impl.h"
+
+/*
+ * Solaris-derived <stdio_ext.h> accessors, in the form musl implements
+ * them. gnulib reaches for these first: freadahead.h, fseterr.h and
+ * fwriting.h each start with an
+ *
+ *	#if HAVE___FREADAHEAD	/ * musl libc * /
+ *	# include <stdio_ext.h>
+ *	# define freadahead(stream) __freadahead (stream)
+ *
+ * branch, and fall back to poking at FILE internals per platform only
+ * when it is absent. APE's FILE is musl's, so supplying these lets
+ * gnulib take the supported path instead of guessing at our layout.
+ */
+
+/* Bytes readable from f's buffer without touching the underlying fd.
+   ungetc pushes back by moving rpos, so those bytes are counted too. */
+size_t
+__freadahead(FILE *f)
+{
+	return f->rend ? (size_t)(f->rend - f->rpos) : 0;
+}
+
+/* Set f's error indicator, as if a write had failed. */
+void
+__fseterr(FILE *f)
+{
+	f->flags |= F_ERR;
+}
+
+/* Nonzero if f is write-oriented: either it can never be read, or it
+   has an active write buffer. */
+int
+__fwriting(FILE *f)
+{
+	return (f->flags & F_NORD) || f->wend != 0;
+}
+
+/* Nonzero if f is read-oriented. The mirror of __fwriting. */
+int
+__freading(FILE *f)
+{
+	return (f->flags & F_NOWR) || f->rend != 0;
+}

--- a/sys/src/external/gnulib/config.h
+++ b/sys/src/external/gnulib/config.h
@@ -5769,3 +5769,14 @@
 
 /* The definition of _GL_ARG_NONNULL is copied here.  */
 
+
+/* APExp: libap implements the musl <stdio_ext.h> accessors, so let
+   freadahead.h, fseterr.h and fwriting.h take their "musl libc" branch
+   and forward to them. Otherwise each falls through to a per-platform
+   #elif chain that selects its Plan 9 case on EPLAN9 and reads
+   fp->state, fp->rp and fp->wp from the old APE FILE. APExp's FILE is
+   musl's, so those members no longer exist. */
+#define HAVE___FREADAHEAD 1
+#define HAVE___FSETERR 1
+#define HAVE___FWRITING 1
+#define HAVE___FREADING 1

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -144,6 +144,20 @@ EOF
 		     /__scanf__, formatstring_parameter, first_argument/ { if (p) exit }' \
 			"$DEST/stdio.in.h"
 	} >> "$DEST/config.h"
+	# libap implements the musl <stdio_ext.h> accessors, so let
+	# freadahead.h, fseterr.h and fwriting.h take their "musl libc"
+	# branch. Otherwise each falls through to a per-platform #elif chain
+	# that selects its Plan 9 case on EPLAN9 and reads fp->state, fp->rp
+	# and fp->wp from the old APE FILE. APExp's FILE is musl's, so those
+	# members do not exist and the compile fails.
+	cat >> "$DEST/config.h" <<'EOF'
+
+/* APExp: libap implements the musl <stdio_ext.h> accessors. */
+#define HAVE___FREADAHEAD 1
+#define HAVE___FSETERR 1
+#define HAVE___FWRITING 1
+#define HAVE___FREADING 1
+EOF
 	echo "appended snippet includes and format attributes to config.h"
 fi
 


### PR DESCRIPTION
freadahead.c failed on fp->state, fp->rp and fp->wp not being members of FILE. It had selected its Plan 9 branch, which reads the old APE FILE; APExp's FILE is musl's, so those members are gone.

Patching that branch would work, but gnulib offers a better route. Each of freadahead.h, fseterr.h and fwriting.h opens with

  #if HAVE___FREADAHEAD  /* musl libc */
  # include <stdio_ext.h>
  # define freadahead(stream) __freadahead (stream)

and only falls through to the per-platform #elif chain when that is absent. The chain is what picks the Plan 9 case, on the strength of EPLAN9 being defined. Note the SLOW_BUT_NO_HACKS branch is not a way out here: in freadahead.c it is abort().

So implement the accessors instead. APE's FILE already is musl's, down to F_ERR, F_NORD and F_NOWR, so these are musl's own one-liners:

  __freadahead  rend ? rend - rpos : 0   (ungetc moves rpos, so counted)
  __fseterr     flags |= F_ERR
  __fwriting    (flags & F_NORD) || wend
  __freading    (flags & F_NOWR) || rend

They live in libap next to the existing __fpending, and are declared in a new sys/include/ape/stdio_ext.h, which APE lacked entirely despite already implementing __fpending.

gnulib's config.h then sets HAVE___FREADAHEAD and friends, and freadahead.$O, fseterr.$O and fwriting.$O leave OFILES, since the .c files are unused once the header forwards. 129 objects becomes 126.

This also settles fseterr.c and fwriting.c, which carry the same stale Plan 9 branch and would have failed next.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs