### PR TITLE
time.h: declare tzalloc, tzfree, localtime_rz and mktime_z

### DIFF
--- a/sys/include/ape/time.h
+++ b/sys/include/ape/time.h
@@ -117,6 +117,24 @@ typedef struct tm_zone *timezone_t;
 #define __timezone_t_defined 1
 #endif
 
+/*
+ * Reentrant timezone conversions, POSIX.1-2024. The implementation is
+ * gnulib's time_rz.c, built into libgnu.a rather than libap, so these
+ * only resolve for programs that link it.
+ *
+ * They are declared here because gnulib normally declares them in its
+ * own generated <time.h>, and APExp deletes that wrapper for shadowing
+ * this header. Without a declaration a caller such as parse-datetime.c
+ * gets the implicit int return, and assigning that to a timezone_t is
+ * an error rather than a warning:
+ *
+ *   incompatible types: "IND STRUCT tm_zone" and "INT" for op "AS"
+ */
+extern timezone_t tzalloc(char const *);
+extern void tzfree(timezone_t);
+extern struct tm *localtime_rz(timezone_t, time_t const *, struct tm *);
+extern time_t mktime_z(timezone_t, struct tm *);
+
 #include <sys/times.h> /* times */
 #include <sys/time.h> /* gettimeofday */
 


### PR DESCRIPTION
parse-datetime.c failed at two assignments with

  incompatible types: "IND STRUCT tm_zone" and "INT" for op "AS"

IND STRUCT tm_zone is timezone_t, and the INT is the implicit return type of an undeclared function: tz = tzalloc (...) with no declaration of tzalloc in scope.

APE's time.h already had the timezone_t typedef, added when patch first needed it, but not the functions that use it. gnulib normally declares them in its own generated <time.h>, and that wrapper is one of the headers deleted for shadowing this one, so the declarations disappeared with it.

Signatures match gnulib's time_rz.c, which supplies the definitions:

  timezone_t  tzalloc      (char const *)
  void        tzfree       (timezone_t)
  struct tm  *localtime_rz (timezone_t, time_t const *, struct tm *)
  time_t      mktime_z     (timezone_t, struct tm *)

Noted in the header that the implementation lives in libgnu.a rather than libap, so these only resolve for programs that link it.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs