### PR TITLE
gnulib: define strnul, lost with the generated string.h

### DIFF
--- a/sys/src/external/gnulib/config.h
+++ b/sys/src/external/gnulib/config.h
@@ -5780,3 +5780,22 @@
 #define HAVE___FSETERR 1
 #define HAVE___FWRITING 1
 #define HAVE___FREADING 1
+
+/* APExp: strnul.
+   gnulib declares strnul in its generated string.h, as a macro over the
+   inline _gl_strnul, and that wrapper is deleted here for shadowing
+   APE's <string.h>. strnul.c is no help: it exists only to emit the
+   out-of-line copy of that same inline, so it compiles to nothing once
+   the header is gone. time_rz.c is the only compiled module that calls
+   strnul, and without a definition it got the implicit int return:
+
+     time_rz.c:149 incompatible types: "IND CHAR" and "INT" for op "AS"
+
+   gnulib documents strnul (s) as equivalent to s + strlen (s). Kept as a
+   macro rather than a function so the result stays const-correct for a
+   const argument, which is what gnulib's _Generic version achieves.
+   Note it evaluates s twice; every current caller passes a plain
+   variable. */
+#ifndef strnul
+# define strnul(s) ((s) + strlen (s))
+#endif

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -158,6 +158,17 @@ EOF
 #define HAVE___FWRITING 1
 #define HAVE___FREADING 1
 EOF
+	# strnul is declared in the generated string.h as a macro over an
+	# inline; strnul.c only emits the out-of-line copy of that inline, so
+	# both vanish with the header. time_rz.c is the only compiled module
+	# that calls it. gnulib documents it as s + strlen (s).
+	cat >> "$DEST/config.h" <<'EOF'
+
+/* APExp: strnul, normally declared in the generated string.h. */
+#ifndef strnul
+# define strnul(s) ((s) + strlen (s))
+#endif
+EOF
 	echo "appended snippet includes and format attributes to config.h"
 fi
 


### PR DESCRIPTION
time_rz.c:149 is

  zone_copy = strnul (zone_copy) + 1;

and failed with

  incompatible types: "IND CHAR" and "INT" for op "AS"

strnul was undeclared, so it took the implicit int return and the assignment to a char * became an error.

gnulib declares strnul in its generated string.h, as a macro over the inline _gl_strnul, and that wrapper is deleted here for shadowing APE's <string.h>. strnul.c is no substitute: it exists only to emit the out-of-line copy of that same inline, so it compiles to nothing once the header is gone.

gnulib documents strnul (s) as equivalent to s + strlen (s), so define it that way in config.h. Kept as a macro rather than a function so the result stays const-correct for a const argument, which is what gnulib's _Generic version achieves. It evaluates s twice; time_rz.c is the only compiled module that calls strnul and it passes a plain variable, and the caveat is recorded next to the definition.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs