### PR TITLE
gnulib: import .def fragments too, for timevar.def

### DIFF
--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -37,8 +37,10 @@ for t in $TREES; do
 	src=$EXT/$t
 	[ -d "$src" ] || { echo "skip (absent): $t"; continue; }
 	n=0
-	# .c and .h only: no Makefiles, no .in.h templates that need autoconf
-	for f in $(cd "$src" && find . -name '*.c' -o -name '*.h' -o -name 'config.h'); do
+	# Sources and headers, plus the .def fragments some headers #include
+	# textually: timevar.h expands timevar.def to build its enum and its
+	# name table. No Makefiles, no .in.h templates that need autoconf.
+	for f in $(cd "$src" && find . -name '*.c' -o -name '*.h' -o -name '*.def'); do
 		d=$DEST/$(dirname "$f")
 		if [ -e "$DEST/$f" ]; then
 			skipped=$((skipped + 1))

--- a/sys/src/external/gnulib/timevar.def
+++ b/sys/src/external/gnulib/timevar.def
@@ -1,0 +1,63 @@
+/* This file contains the definitions for timing variables used to -*- C -*-
+   measure run-time performance of the compiler.
+
+   Copyright (C) 2002, 2007, 2009-2015, 2018-2021 Free Software
+   Foundation, Inc.
+
+   Contributed by Akim Demaille <akim@freefriends.org>.
+
+   This file is part of Bison, the GNU Compiler Compiler.
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* This file contains timing variable definitions, used by timevar.h
+   and timevar.c.
+
+   Syntax:
+
+     DEFTIMEVAR (id, name)
+
+   where ID is the enum value used to identify the timing
+   variable, and NAME is a character string describing its purpose.  */
+
+/* The total execution time.  */
+DEFTIMEVAR (tv_total                 , "total time")
+
+/* Time spent in the reader.  */
+DEFTIMEVAR (tv_reader                , "reader")
+DEFTIMEVAR (tv_scanning              , "scanner")
+DEFTIMEVAR (tv_parsing               , "parser")
+
+/* Time spent handling the grammar.  */
+DEFTIMEVAR (tv_reduce                , "reducing the grammar")
+DEFTIMEVAR (tv_sets                  , "computing the sets")
+DEFTIMEVAR (tv_lr0                   , "LR(0)")
+DEFTIMEVAR (tv_lalr                  , "LALR(1)")
+DEFTIMEVAR (tv_ielr_phase1           , "IELR(1) Phase 1")
+DEFTIMEVAR (tv_ielr_phase2           , "IELR(1) Phase 2")
+DEFTIMEVAR (tv_ielr_phase3           , "IELR(1) Phase 3")
+DEFTIMEVAR (tv_ielr_phase4           , "IELR(1) Phase 4")
+DEFTIMEVAR (tv_conflicts             , "conflicts")
+
+/* Time spent outputting results.  */
+DEFTIMEVAR (tv_report                , "outputting report")
+DEFTIMEVAR (tv_graph                 , "outputting graph")
+DEFTIMEVAR (tv_html                  , "outputting html")
+DEFTIMEVAR (tv_xml                   , "outputting xml")
+DEFTIMEVAR (tv_actions               , "parser action tables")
+DEFTIMEVAR (tv_parser                , "outputting parser")
+DEFTIMEVAR (tv_m4                    , "running m4")
+
+/* Time spent by freeing the memory :).  */
+DEFTIMEVAR (tv_free                  , "freeing")


### PR DESCRIPTION
timevar.c failed with

  timevar.h:80 Could not find include file "timevar.def"

timevar.h includes that file textually, twice, to build both the TIMEVAR_* enum and the matching name table from one list. import.sh copied only *.c and *.h, so it never arrived.

Widen the filter to *.def and copy the file, which comes from bison, the only tree that carries the timevar module. A scan of the whole consolidated tree for includes of anything that is not a .c or .h turns up timevar.def alone, so nothing else is missing for this reason.

Dropped the redundant -name 'config.h' from the find while there, since *.h already matches it.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs