### PR TITLE
gnulib: restore the prototypes and off64_t the deleted wrappers carried

### DIFF
--- a/sys/src/external/gnulib/apexp-decls.h
+++ b/sys/src/external/gnulib/apexp-decls.h
@@ -1,0 +1,52 @@
+#ifndef _APEXP_DECLS_H
+#define _APEXP_DECLS_H
+
+/*
+ * Declarations that gnulib puts in its generated replacement headers.
+ *
+ * APExp deletes those wrappers, because they shadow APE's headers and
+ * #include_next back into them until cpp reports "#if too deeply
+ * nested". The modules themselves are still built, so a caller in
+ * another translation unit is left with no prototype and the compiler
+ * falls back to the implicit int return:
+ *
+ *   tmpdir.c:110 incompatible types: "IND CONST CHAR" and "INT" for op "AS"
+ *
+ * Everything here was found by listing the _GL_FUNCDECL_SYS and
+ * _GL_FUNCDECL_RPL names in the deleted *.in.h templates, keeping the
+ * ones a module in OFILES actually calls, and dropping the ones APE
+ * already declares. Signatures are copied from each defining .c file.
+ *
+ * Not included, having turned out to be dead code under this config.h:
+ * timespec_get (gettime.c takes the clock_gettime branch, since
+ * HAVE_CLOCK_GETTIME is set), strerrorname_np (xvasprintf.c guards it
+ * with HAVE_WORKING_STRERRORNAME_NP, which is undef), and mkstemps and
+ * mkostemps (mkstemp-safer.c guards them with GNULIB_MKSTEMPS and
+ * GNULIB_MKOSTEMPS, neither of which is defined).
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+/* off64_t came from the deleted sys/types.h wrapper, where gnulib
+   defines it as long long. APE's off_t is already 64 bit, so alias that
+   instead and stay consistent with the rest of the system. */
+#ifndef _APEXP_HAVE_OFF64_T
+#define _APEXP_HAVE_OFF64_T 1
+typedef off_t off64_t;
+#endif
+
+/* string.h wrapper */
+extern size_t mbslen(const char *);
+
+/* stdlib.h wrapper */
+extern char *secure_getenv(char const *);
+
+/* stdio.h wrapper */
+extern ptrdiff_t vaszprintf(char **, const char *, va_list);
+extern off64_t vfzprintf(FILE *, const char *, va_list);
+extern off64_t vzprintf(const char *, va_list);
+
+#endif /* _APEXP_DECLS_H */

--- a/sys/src/external/gnulib/config.h
+++ b/sys/src/external/gnulib/config.h
@@ -5799,3 +5799,7 @@
 #ifndef strnul
 # define strnul(s) ((s) + strlen (s))
 #endif
+
+/* APExp: prototypes and off64_t that the deleted wrapper headers carried.
+   See apexp-decls.h for how the list was derived. */
+#include "apexp-decls.h"

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -170,6 +170,9 @@ EOF
 #ifndef strnul
 # define strnul(s) ((s) + strlen (s))
 #endif
+
+/* APExp: prototypes and off64_t the deleted wrappers carried. */
+#include "apexp-decls.h"
 EOF
 	echo "appended snippet includes and format attributes to config.h"
 fi


### PR DESCRIPTION
tmpdir.c:110 is

  const char *d = __libc_secure_getenv ("TMPDIR");

which tmpdir.c maps to secure_getenv, and it failed with

  incompatible types: "IND CONST CHAR" and "INT" for op "AS"

secure_getenv.c is built and in OFILES, but the prototype lived in the generated stdlib.h, so the caller took the implicit int return.

This is the fourth failure of that shape, so rather than fix one more in isolation, enumerate them: take every _GL_FUNCDECL_SYS and _GL_FUNCDECL_RPL name in the deleted *.in.h templates (412 of them), keep those a module in OFILES actually calls, and drop those APE already declares. Nine remain, of which four are dead code under this config.h and are documented as such rather than declared:

  timespec_get      gettime.c takes the clock_gettime branch
  strerrorname_np   guarded by HAVE_WORKING_STRERRORNAME_NP, undef
  mkstemps          guarded by GNULIB_MKSTEMPS, undef
  mkostemps         guarded by GNULIB_MKOSTEMPS, undef

The other five are declared in a new apexp-decls.h, with signatures copied from each defining .c: mbslen, secure_getenv, vaszprintf, vfzprintf and vzprintf.

off64_t comes along because vfzprintf and vzprintf return it and it was defined in the deleted sys/types.h wrapper. gnulib makes it long long; aliasing APE's off_t is better, since that is already 64 bit. A scan for other lost typedefs found none, though note it can report a false negative: off64_t itself looked present because zconf.h mentions it in "#define z_off64_t off64_t".

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs