### PR TITLE
gnulib, bison: fix three link failures, one per cause

### DIFF
--- a/sys/src/ape/cmd/bison/mkfile
+++ b/sys/src/ape/cmd/bison/mkfile
@@ -65,7 +65,16 @@ BISONSRC=../../../external/bison
 #fails on include_next
 CC=$APEXPROOT/$objtype/bin/pcc
 
-CFLAGS=-c -I. -I$BISONSRC -I$BISONSRC/lib -I$BISONSRC/src\
+# -I$GNUSRC comes before -I$BISONSRC/lib on purpose. bison's own
+# gnulib copy is from 2021 and the shared libgnu.a is built from
+# coreutils' 2026 sources, so compiling bison against its own copies
+# of shared module headers links 2021 declarations to 2026 objects.
+# location.c includes mbchar.h, and the 2021 one has an inline that
+# reads is_basic_table[], a table the 2026 mbchar.c no longer defines:
+#   _convM2D: is_basic_table: not defined
+# Headers bison alone provides still resolve, via -I$BISONSRC/lib.
+GNUSRC=$APEXPROOT/sys/src/external/gnulib
+CFLAGS=-c -I. -I$GNUSRC -I$BISONSRC -I$BISONSRC/lib -I$BISONSRC/src\
 		-B -DHAVE_CONFIG_H\
 		-DLOCALEDIR="/sys/lib/ape/locale"
 

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -148,6 +148,7 @@ OFILES=\
 	table.$O\
 	vector.$O\
 	lock.$O\
+	once.$O\
 	spin.$O\
 	u8-uctomb-aux.$O
 

--- a/sys/src/external/gnulib/config.h
+++ b/sys/src/external/gnulib/config.h
@@ -18,10 +18,17 @@
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
 /* Define to the function xargmatch calls on failures. */
-#define ARGMATCH_DIE usage (EXIT_FAILURE)
+/* APExp: coreutils sets ARGMATCH_DIE to usage (EXIT_FAILURE), because
+   every coreutils program exports a usage function. A shared gnulib
+   cannot assume that: bison declares its usage static, so linking
+   bison against argmatch.o built this way fails with
+   "__argmatch_die: undefined: usage". Leaving both undefined lets
+   argmatch.c fall back to its own default, exit (exit_failure), which
+   is program-agnostic. exit_failure comes from libap. */
+/* #undef ARGMATCH_DIE */
 
 /* Define to the declaration of the xargmatch failure function. */
-#define ARGMATCH_DIE_DECL void usage (int _e)
+/* #undef ARGMATCH_DIE_DECL */
 
 /* Define if neither thread safety nor multithreading is desired. */
 /* #undef AVOID_ANY_THREADS */

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -99,6 +99,20 @@ if [ -d "$DEST/sys" ]; then
 fi
 echo "pruned $pruned replacement system headers"
 
+# coreutils sets ARGMATCH_DIE to usage (EXIT_FAILURE) in its config.h,
+# since every coreutils program exports a usage function. A shared
+# gnulib cannot assume that -- bison declares its usage static -- so
+# neutralise both and let argmatch.c use its own default,
+# exit (exit_failure).
+if [ -f "$DEST/config.h" ]; then
+	sed -i.bak \
+		-e 's|^#define ARGMATCH_DIE usage (EXIT_FAILURE)|/* #undef ARGMATCH_DIE */|' \
+		-e 's|^#define ARGMATCH_DIE_DECL void usage (int _e)|/* #undef ARGMATCH_DIE_DECL */|' \
+		"$DEST/config.h"
+	rm -f "$DEST/config.h.bak"
+	echo "neutralised coreutils ARGMATCH_DIE in config.h"
+fi
+
 # Make the snippet macros reachable from config.h.
 #
 # gnulib keeps _GL_ARG_NONNULL and _GL_WARN_ON_USE in standalone snippet


### PR DESCRIPTION
  fstrcmp_free_resources: undefined: glthread_once_multithreaded
  __argmatch_die: undefined: usage
  _convM2D: is_basic_table: not defined

glthread_once_multithreaded lives in glthread/once.c. lock.c and spin.c were in OFILES but once.c was not, and fstrcmp.c calls it. Added.

usage came from coreutils' config.h, which the consolidated tree adopted wholesale:

  #define ARGMATCH_DIE usage (EXIT_FAILURE)
  #define ARGMATCH_DIE_DECL void usage (int _e)

That is fine for coreutils, where every program exports usage, but a shared gnulib cannot assume it: bison declares its usage static, so argmatch.o built this way cannot link. Neutralised both so argmatch.c falls back to its own default, exit (exit_failure), which is program-agnostic and whose exit_failure now comes from libap.

is_basic_table is the header-version skew this consolidation always risked. bison compiled with -I$BISONSRC/lib ahead of the shared tree, so location.c got bison's 2021 mbchar.h, whose inline reads is_basic_table[], while libgnu.a carries coreutils' 2026 mbchar.o, which no longer defines that table. Putting -I$GNUSRC first makes bison's declarations match the objects it links; headers only bison provides still resolve behind it.

The last of those is worth watching. Any package whose own gnulib copy is older than coreutils' can hit it, and it shows up at link time as a missing symbol rather than at compile time, so the same -I ordering may be needed for sed, m4, diff and patch.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs