### PR TITLE
gnulib: reconcile bison's 2021 mbfile.h with the 2026 mbchar.h

### DIFF
--- a/sys/src/ape/cmd/bison/config.h
+++ b/sys/src/ape/cmd/bison/config.h
@@ -26,3 +26,15 @@
 
 /* bison-specific, with no counterpart in the shared file */
 #define PACKAGE_COPYRIGHT_YEAR 2021
+
+/* bison's location.c uses mbfile.h. In the 2026 mbchar.h that this now
+   compiles against, mbchar_t's buf member is guarded by GNULIB_MBFILE,
+   a module flag that coreutils' config.h has no reason to set:
+
+     mbfile.h:113 not a member of struct/union: buf
+
+   bison's own 2021 mbchar.h had buf unconditionally, which is why bison
+   never had to define this before. Harmless for the library object:
+   mbchar.c is 22 lines and never touches struct mbchar, so the two
+   layouts never meet. */
+#define GNULIB_MBFILE 1

--- a/sys/src/external/gnulib/mbfile.h
+++ b/sys/src/external/gnulib/mbfile.h
@@ -52,6 +52,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <wchar.h>
+/* APExp: for mbrtoc32, see the call below. */
+#include <uchar.h>
 
 #include "mbchar.h"
 
@@ -135,7 +137,16 @@ mbfile_multi_getc (struct mbchar *mbc, struct mbfile_multi *mbf)
          behaviour will clobber it.  */
       mbstate_t backup_state = mbf->state;
 
-      bytes = mbrtowc (&mbc->wc, &mbf->buf[0], mbf->bufcount, &mbf->state);
+      /* APExp: mbrtoc32, not mbrtowc. This file is bison's, from 2021,
+         when mbchar_t.wc was a wchar_t. The mbchar.h it now compiles
+         against is the 2026 one, where wc is a char32_t, so mbrtowc
+         gave an argument prototype mismatch: "IND UINT" for
+         "IND USHORT". Passing a char32_t * to mbrtoc32 is also the
+         correct call on APE, whose wchar_t is only 16 bits and cannot
+         hold every rune. libap implements mbrtoc32 in
+         sys/src/ape/lib/ap/multibyte, taking a ucs4_t * which is the
+         same uint32_t as char32_t.  */
+      bytes = mbrtoc32 (&mbc->wc, &mbf->buf[0], mbf->bufcount, &mbf->state);
 
       if (bytes == (size_t) -1)
         {


### PR DESCRIPTION
Compiling bison's location.c gave two problems in mbfile.h, both from the shared tree pairing files of different vintages. mbfile.h exists only in bison's gnulib (2021); mbchar.h came from m4's (2026), coreutils having none.

  mbfile.h:113 not a member of struct/union: buf

mbchar_t's buf member is now wrapped in #if defined GNULIB_MBFILE. The 2021 struct had it unconditionally, which is why bison never defined that flag, and coreutils' config.h has no reason to. bison genuinely does use mbfile, so setting GNULIB_MBFILE in bison's config.h is the honest answer rather than a workaround, and this is what the per-package config.h is for. The differing layout does not reach the library: mbchar.c is 22 lines and never touches struct mbchar.

  mbfile.h:138 argument prototype mismatch "IND UINT" for "IND USHORT"

mbchar_t.wc was a wchar_t in 2021 and is a char32_t now, so the one real mbrtowc call in the file passes a 32-bit pointer where a 16-bit one is expected. Switched to mbrtoc32, which is the right call here regardless of the version skew: APE's wchar_t is 16 bits and cannot hold every rune, while char32_t can. libap already implements mbrtoc32, and its ucs4_t is the same uint32_t as char32_t, so the types agree exactly.

The remaining mbrtowc mentions in that file are comments.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs