### PR TITLE
bison: add M4 macros, and pass dll_dirs to execute and create_pipe_bidi

### DIFF
--- a/sys/src/ape/cmd/bison/config.h
+++ b/sys/src/ape/cmd/bison/config.h
@@ -38,3 +38,10 @@
    mbchar.c is 22 lines and never touches struct mbchar, so the two
    layouts never meet. */
 #define GNULIB_MBFILE 1
+
+/* bison invokes m4 to expand its skeletons, and takes both the program
+   path and the option that selects GNU m4 from its config. Neither has
+   a counterpart in coreutils'. Values as bison's own config.h had them,
+   where M4 was already pointed at APE's m4. */
+#define M4 "/bin/m4"
+#define M4_GNU_OPTION "--gnu"

--- a/sys/src/external/bison/src/output.c
+++ b/sys/src/external/bison/src/output.c
@@ -783,6 +783,13 @@ output_skeleton (void)
       }
 
     pid = create_pipe_bidi ("m4", m4, argv,
+                            /* APExp: dll_dirs was added to create_pipe_bidi
+                               after bison 3.8, and this links the 2026
+                               gnulib. It lists extra directories to search
+                               for DLLs on Windows, so NULL is both the
+                               correct value here and what every caller on a
+                               Unix-like system passes.  */
+                            /* dll_dirs */ NULL,
                             /* directory */ NULL,
                             /* null_stderr */ false,
                             /* slave_process */ true,

--- a/sys/src/external/bison/src/print-xml.c
+++ b/sys/src/external/bison/src/print-xml.c
@@ -565,6 +565,9 @@ print_html (void)
   int status
     = execute (argv[0],
                argv[0], argv,
+               /* APExp: dll_dirs, added after bison 3.8. See the same
+                  argument in output.c's create_pipe_bidi call.  */
+               /* dll_dirs */ NULL,
                /* directory */ NULL,
                /* ignore_sigpipe */ false,
                /* null_stdin, null_stdout, null_stderr */ true, true, true,


### PR DESCRIPTION
Two more consequences of bison 3.8 meeting the 2026 gnulib.

  output.c:757 name not declared: M4_GNU_OPTION

M4 and M4_GNU_OPTION are bison's own config values, telling it which m4 to run and which option selects GNU m4. coreutils has no counterpart, so they belong in bison's config.h. Values carried over from bison's own, where M4 was already pointed at "/bin/m4" for APE. Rather than wait for these one at a time, compared every macro bison's config.h defines against config-common.h and kept the ones bison/src actually uses; these two are the only ones beyond the identity macros already present.

  output.c:785 not enough function arguments: create_pipe_bidi

gnulib added a dll_dirs parameter to both create_pipe_bidi and execute, after prog_argv, some time after bison 3.8. It lists extra directories to search for DLLs on Windows, so NULL is both correct here and what every caller on a Unix-like system passes. Added to output.c's create_pipe_bidi call and print-xml.c's execute call, the only two sites in bison.

Checked the other packages linking libgnu.a for the same drift. m4 calls execute with 12 arguments and create_pipe_in with 10, which already match the 2026 prototypes, its own gnulib being the same vintage. sed, diff and patch do not call this family at all.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs