### PR TITLE
gnulib: stop asking for the vasnprintf replacement, libap has it

### DIFF
--- a/sys/src/external/gnulib/config-common.h
+++ b/sys/src/external/gnulib/config-common.h
@@ -4022,7 +4022,14 @@
 /* #undef REPLACE_STRERROR_0 */
 
 /* Define if vasnprintf exists but is overridden by gnulib. */
-#define REPLACE_VASNPRINTF 1
+/* APExp: libap implements vasnprintf and asnprintf, in
+   sys/src/ape/lib/ap/stdio/asnprintf.c, with exactly gnulib's
+   signature and declared in APE's <stdio.h>. Leaving this at 1 makes
+   vasnprintf.h rename both to rpl_*, and since the vasnprintf module
+   is deliberately not in OFILES nothing defines them:
+     fprintf_if: undefined: rpl_vasnprintf
+   Turning it off lets callers bind to libap's. */
+/* #undef REPLACE_VASNPRINTF */
 
 /* Define to 1 if setlocale (LC_ALL, NULL) is thread-safe. */
 #define SETLOCALE_NULL_ALL_MTSAFE 0

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -137,6 +137,16 @@ if [ -f "$DEST/config-common.h" ]; then
 	echo "neutralised coreutils ARGMATCH_DIE in config.h"
 fi
 
+# libap implements vasnprintf and asnprintf with gnulib's signature, so
+# the vasnprintf module is not in OFILES. Left at 1, vasnprintf.h renames
+# both to rpl_* and nothing defines them.
+if [ -f "$DEST/config-common.h" ]; then
+	sed -i.bak 's|^#define REPLACE_VASNPRINTF 1|/* #undef REPLACE_VASNPRINTF */|' \
+		"$DEST/config-common.h"
+	rm -f "$DEST/config-common.h.bak"
+	echo "turned off REPLACE_VASNPRINTF in config-common.h"
+fi
+
 # Make the snippet macros reachable from config.h.
 #
 # gnulib keeps _GL_ARG_NONNULL and _GL_WARN_ON_USE in standalone snippet


### PR DESCRIPTION
  fprintf_if: undefined: rpl_vasnprintf
  fixits_run: undefined: rpl_asnprintf

coreutils' config.h sets REPLACE_VASNPRINTF 1, and vasnprintf.h acts on it directly:

  #if REPLACE_VASNPRINTF
  # define asnprintf rpl_asnprintf
  # define vasnprintf rpl_vasnprintf
  #endif

so bison's calls were renamed to rpl_*, which nothing defines: the vasnprintf module is not in OFILES, and rightly so. libap implements both in stdio/asnprintf.c with exactly gnulib's signature, declared in APE's <stdio.h>. Turning the flag off lets callers bind to those, which is rule 1 in the README rather than a workaround. vaszprintf.c and vfzprintf.c, the two OFILES modules that include vasnprintf.h, get the same plain names.

Audited the rest of that class while here. Three REPLACE_* flags are set without a matching module in OFILES: vasnprintf, posix_spawn and nl_langinfo. Only vasnprintf can bite, because its rename lives in a real module header. The posix_spawn and nl_langinfo renames are in spawn.in.h and langinfo.in.h, templates that were never generated into spawn.h or langinfo.h, so those two are inert and execute.c and spawn-pipe.c call libap's posix_spawn under its plain name. Left alone deliberately; they are not latent bugs.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs