### PR TITLE
grep: move to the shared gnulib, like the other GNU packages

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -29,9 +29,13 @@ OFILES=\
 	asyncsafe-spin.$O\
 	backup-find.$O\
 	basename-lgpl.$O\
+	binary-io.$O\
 	bitrotate.$O\
 	bitset.$O\
 	bitsetv.$O\
+	btoc32.$O\
+	btowc.$O\
+	c-ctype.$O\
 	c-stack.$O\
 	c-strcasecmp.$O\
 	canonicalize.$O\
@@ -41,13 +45,16 @@ OFILES=\
 	closein.$O\
 	closeout.$O\
 	cmpbuf.$O\
+	colorize-posix.$O\
 	concat-filename.$O\
 	copy-acl.$O\
+	cycle-check.$O\
 	dfa.$O\
 	diagnose.$O\
 	dup-safer.$O\
 	dup-safer-flag.$O\
 	error.$O\
+	exclude.$O\
 	execute.$O\
 	fatal-signal.$O\
 	fd-safer.$O\
@@ -59,6 +66,7 @@ OFILES=\
 	fopen-safer.$O\
 	free.$O\
 	fstrcmp.$O\
+	fts.$O\
 	get-errno.$O\
 	get-permissions.$O\
 	gethrxtime.$O\
@@ -76,12 +84,14 @@ OFILES=\
 	hashcode-string1.$O\
 	hashcode-string2.$O\
 	hashkey-string.$O\
+	i-ring.$O\
 	ialloc.$O\
 	integer_length.$O\
 	integer_length_l.$O\
 	localeinfo.$O\
 	malloca.$O\
 	mbchar.$O\
+	mbscasecmp.$O\
 	mbslen.$O\
 	mbsstr.$O\
 	mbswidth.$O\
@@ -90,6 +100,9 @@ OFILES=\
 	mkstemp-safer.$O\
 	next-prime.$O\
 	open-safer.$O\
+	openat-proc.$O\
+	openat-safer.$O\
+	opendirat.$O\
 	parse-datetime.$O\
 	path-join.$O\
 	pipe-safer.$O\
@@ -100,12 +113,20 @@ OFILES=\
 	qcopy-acl.$O\
 	quotearg.$O\
 	regex.$O\
+	safe-read.$O\
+	same-inode.$O\
 	secure_getenv.$O\
 	set-permissions.$O\
 	sigsegv.$O\
 	spawn-pipe.$O\
+	stat-time.$O\
 	stdbit.$O\
+	stdlib.$O\
+	stpcpy.$O\
+	str_endswith.$O\
 	strerror.$O\
+	strerror-override.$O\
+	stripslash.$O\
 	strnlen1.$O\
 	strsignal.$O\
 	strstr.$O\
@@ -121,6 +142,7 @@ OFILES=\
 	vfzprintf.$O\
 	vzprintf.$O\
 	wait-process.$O\
+	wmempcpy.$O\
 	xasprintf.$O\
 	xconcat-filename.$O\
 	xhash.$O\
@@ -130,6 +152,8 @@ OFILES=\
 	xsize.$O\
 	xstdopen.$O\
 	xstrtoimax.$O\
+	xstrtol.$O\
+	xstrtoul.$O\
 	xvasprintf.$O\
 	dynarray_at_failure.$O\
 	dynarray_emplace_enlarge.$O\
@@ -147,6 +171,7 @@ OFILES=\
 	lock.$O\
 	once.$O\
 	spin.$O\
+	threadlib.$O\
 	u8-uctomb-aux.$O
 
 #during building from scratch, the new pcc is not picked up and compilation

--- a/sys/src/ape/cmd/grep/config.h
+++ b/sys/src/ape/cmd/grep/config.h
@@ -1,0 +1,25 @@
+/*
+ * config.h for grep.
+ *
+ * The platform answers -- HAVE_* probes, type sizes, the APExp
+ * additions -- are shared by every package that links libgnu.a and
+ * live in config-common.h, found through -I$GNUSRC. Only package
+ * identity belongs here: config-common.h began as coreutils'
+ * config.h, and left to itself it makes every program report
+ * PACKAGE "coreutils" and VERSION "9.11".
+ *
+ * The package's own config.h in its source tree is deliberately
+ * unused. Those predate the 2026 gnulib this links against, so
+ * their platform answers no longer describe the objects.
+ */
+
+#include <config-common.h>
+
+#define PACKAGE              "grep"
+#define PACKAGE_NAME         "GNU grep"
+#define PACKAGE_STRING       "GNU grep 3.12"
+#define PACKAGE_TARNAME      "grep"
+#define PACKAGE_VERSION      "3.12"
+#define VERSION              "3.12"
+#define PACKAGE_BUGREPORT    "bug-grep@gnu.org"
+#define PACKAGE_URL          "https://www.gnu.org/software/grep/"

--- a/sys/src/ape/cmd/grep/mkfile
+++ b/sys/src/ape/cmd/grep/mkfile
@@ -4,6 +4,7 @@ APEXPROOT=../../../../..
 TARG=grep
 
 OFILES=\
+	version-etc.$O\
 	dfasearch.$O\
 	grep.$O \
 	kwsearch.$O\
@@ -11,119 +12,7 @@ OFILES=\
 	searchutils.$O\
 	pcresearch.$O
 
-LIB_OBJS=\
-	libgreputils_a-argmatch.$O \
-	libgreputils_a-openat-proc.$O \
-	libgreputils_a-basename-lgpl.$O \
-	libgreputils_a-binary-io.$O \
-	libgreputils_a-bitrotate.$O \
-	libgreputils_a-btoc32.$O \
-	libgreputils_a-btowc.$O \
-	libgreputils_a-c-ctype.$O \
-	libgreputils_a-c-stack.$O \
-	libgreputils_a-c-strcasecmp.$O \
-#	libgreputils_a-c32_apply_type_test.$O \
-#	libgreputils_a-c32_get_type_test.$O \
-#	libgreputils_a-c32tob.$O \
-#	libgreputils_a-chdir-long.$O \
-#	libgreputils_a-cloexec.$O \
-#	libgreputils_a-close-stream.$O \
-	libgreputils_a-closeout.$O \
-	libgreputils_a-cycle-check.$O \
-	libgreputils_a-dfa.$O \
-	libgreputils_a-localeinfo.$O \
-#	libgreputils_a-dirname-lgpl.$O \
-	libgreputils_a-stripslash.$O \
-#	libgreputils_a-dup2.$O \
-#	libgreputils_a-error.$O \
-	libgreputils_a-exclude.$O \
-#	libgreputils_a-exitfail.$O \
-#	libgreputils_a-fcntl.$O \
-#	libgreputils_a-creat-safer.$O \
-	libgreputils_a-open-safer.$O \
-#	libgreputils_a-fd-hook.$O \
-#	libgreputils_a-fdopendir.$O \
-#	libgreputils_a-filenamecat-lgpl.$O \
-#	libgreputils_a-fpending.$O \
-	libgreputils_a-free.$O \
-#	libgreputils_a-fstatat.$O \
-	libgreputils_a-fts.$O \
-#	libgreputils_a-getcwd-lgpl.$O \
-#	libgreputils_a-getopt.$O \
-#	libgreputils_a-getopt1.$O \
-	libgreputils_a-dynarray_at_failure.$O \
-	libgreputils_a-dynarray_emplace_enlarge.$O \
-	libgreputils_a-dynarray_finalize.$O \
-	libgreputils_a-dynarray_resize.$O \
-#	libgreputils_a-dynarray_resize_clear.$O \
-#	libgreputils_a-hard-locale.$O \
-	libgreputils_a-hash.$O \
-#	libgreputils_a-i-ring.$O \
-	libgreputils_a-ialloc.$O \
-#	libgreputils_a-iswctype.$O \
-#	libgreputils_a-localcharset.$O \
-#	libgreputils_a-localeconv.$O \
-#	libgreputils_a-lock.$O \
-#	libgreputils_a-lseek.$O \
-#	libgreputils_a-lstat.$O \
-#	libgreputils_a-malloca.$O \
-#	libgreputils_a-mbrlen.$O \
-#	libgreputils_a-mbrtoc32.$O \
-#	libgreputils_a-mbrtowc.$O \
-#	libgreputils_a-mbscasecmp.$O \
-#	libgreputils_a-mbsrtoc32s.$O \
-#	libgreputils_a-mbsrtowcs.$O \
-#	libgreputils_a-mbszero.$O \
-#	libgreputils_a-mcel.$O \
-	libgreputils_a-memchr2.$O \
-#	libgreputils_a-memrchr.$O \
-#	libgreputils_a-nl_langinfo.$O \
-#	libgreputils_a-once.$O \
-#	libgreputils_a-openat.$O \
-#	libgreputils_a-openat-die.$O \
-	libgreputils_a-openat-safer.$O \
-#	libgreputils_a-opendirat.$O \
-#	libgreputils_a-quotearg.$O \
-#	libgreputils_a-rawmemchr.$O \
-	libgreputils_a-reallocarray.$O \
-	libgreputils_a-regex.$O \
-	libgreputils_a-safe-read.$O \
-	libgreputils_a-same-inode.$O \
-#	libgreputils_a-save-cwd.$O \
-#	libgreputils_a-setlocale_null.$O \
-#	libgreputils_a-setlocale-lock.$O \
-#	libgreputils_a-setlocale_null-unlocked.$O \
-#	libgreputils_a-sigsegv.$O \
-#	libgreputils_a-stackvma.$O\
-	libgreputils_a-stat-time.$O \
-	libgreputils_a-stdlib.$O \
-	libgreputils_a-stpcpy.$O \
-	libgreputils_a-str_endswith.$O \
-	libgreputils_a-strerror.$O \
-	libgreputils_a-strerror-override.$O \
-	libgreputils_a-strnlen1.$O \
-	libgreputils_a-strtoll.$O \
-	libgreputils_a-threadlib.$O \
-	libgreputils_a-unistd.$O \
-#	libgreputils_a-dup-safer.$O \
-	libgreputils_a-fd-safer.$O \
-#	libgreputils_a-pipe-safer.$O \
-	libgreputils_a-version-etc.$O \
-#	libgreputils_a-wctob.$O \
-#	libgreputils_a-wctype.$O \
-#	libgreputils_a-wctype-h.$O \
-	libgreputils_a-wmempcpy.$O \
-#	libgreputils_a-xmalloc.$O \
-#	libgreputils_a-xalloc-die.$O \
-#	libgreputils_a-xbinary-io.$O \
-	libgreputils_a-xstrtoimax.$O \
-	libgreputils_a-xstrtol.$O \
-	libgreputils_a-xstrtoul.$O \
-	libgreputils_a-colorize-posix.$O \
-	libgreputils_a-version-etc-fsf.$O
-
-LIB=libgrep.a$O
-CLEANFILES=$LIB
+LIB=../gnulib/libgnu.a$O
 BIN=$APEXPROOT/$objtype/bin/ape
 
 <$APEXPROOT/sys/src/cmd/mkone
@@ -134,24 +23,24 @@ GREPSRC=../../../external/ggrep
 #fails on include_next
 CC=$APEXPROOT/$objtype/bin/pcc
 
-CFLAGS=-c -I. -I$GREPSRC -I$GREPSRC/src -I$GREPSRC/lib\
+# -I. finds this directory's config.h, which layers grep's identity over
+# config-common.h. -I$GNUSRC comes before grep's own lib directory so the
+# shared module headers match the objects in libgnu.a. grep/src shares no
+# header name with the shared tree, so nothing needs to precede $GNUSRC.
+GNUSRC=$APEXPROOT/sys/src/external/gnulib
+CFLAGS=-c -I. -I$GNUSRC -I$GREPSRC -I$GREPSRC/src -I$GREPSRC/lib\
 		-B -DHAVE_CONFIG_H -DLOCALEDIR="/sys/lib/ape/locale"
 
 %.$O: $GREPSRC/src/%.c
 	$CC $CFLAGS $GREPSRC/src/$stem.c
 
-libgreputils_a-%.$O: $GREPSRC/lib/%.c
-	$CC $CFLAGS -c $prereq -o $target
-
-libgreputils_a-%.$O: $GREPSRC/lib/malloc/%.c
-	$CC $CFLAGS -c $prereq -o $target
-
-libgreputils_a-%.$O: $GREPSRC/lib/glthread/%.c
-	$CC $CFLAGS -c $prereq -o $target
-
-
-libgrep.a$O: $LIB_OBJS
-			ar vu libgrep.a$O $LIB_OBJS
-
 install:V:
 		cp $GREPSRC/doc/grep.in.1 $APEXPROOT/sys/man/1/grep
+
+# version-etc is built here, not taken from the shared libgnu.a.
+# emit_bug_reporting_address() compiles PACKAGE_BUGREPORT, PACKAGE_NAME
+# and PACKAGE_URL straight into the object, so a single shared copy would
+# give every program whichever package built it. See rule 5 in
+# ../gnulib/README.
+version-etc.$O: $GNUSRC/version-etc.c
+	$CC $CFLAGS $GNUSRC/version-etc.c


### PR DESCRIPTION
grep still built its own libgrep.a from a private list of 49 objects with 60 more commented out, and was failing to link on six symbols that were among the commented ones: i_ring_*, opendirat, mbscasecmp, close_stream, the quotearg family and dup_safer. Uncommenting six lines would have fixed it, but grep is the last package maintaining a parallel gnulib, so the alternative was worth measuring rather than assuming.

The numbers favour migrating. Of the 55 modules grep needs, 27 were already in libgnu.a, and 27 of the remaining 28 were already in the consolidated source tree -- only threadlib had to be found, and it was in glthread/. So the change adds 25 objects, 124 to 149, and deletes 109 lines of object list.

Checked the three ways this could have gone wrong first:

Rule 1, libap collisions. Two of the 28 are implemented by libap: reallocarray and strtoll. gnulib's reallocarray.c defines its function unconditionally, so putting it in the shared archive would give every package a duplicate. Neither is added; grep drops them and uses libap's, which is what every other package already does.

Rule 3, duplicate symbols inside the archive. Nothing new. The four names that appear twice -- init_fatal_signal_set, nonintr_close, nonintr_open and integer_length -- are static in each file, or in integer_length's case come from integer_length_l.c compiling the same body under #define FUNC.

Rule 4, header collisions. grep/src shares no header name with the shared tree, unlike bison and its configmake.h, so -I$GNUSRC can sit directly after -I. with nothing between.

grep also gets a config.h holding its identity over config-common.h, and builds version-etc itself under rule 5.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs