### PR TITLE
objc: use a backquote assignment, not a bare rc if

### DIFF
--- a/sys/src/ape/cmd/objc/mkfile
+++ b/sys/src/ape/cmd/objc/mkfile
@@ -1,8 +1,18 @@
 </$objtype/mkfile
 
-BUILD=bootstrap
-if (whatis objc1 > /dev/null >[2=1])
-	BUILD=rebuild
+# objc bootstraps itself: build with the system compiler the first time,
+# then rebuild with the objc1 that produced. Which mkfile to delegate to
+# therefore depends on whether objc1 already exists.
+#
+# This was written as a bare rc "if" at the top of the mkfile, but mk
+# parses this section itself and does not know rc's control flow. It read
+# the >[2=1] redirection as an assignment and stopped with
+#     mkfile:5: syntax error; multiple vars on left side of assignment
+# which broke mk clean for the whole tree, objc being in DIRS.
+#
+# The mk way to run a shell command here is a backquote expression, as in
+# sys/src/cmd/mkfile's TARG.
+BUILD=`{if(whatis objc1 >/dev/null >[2=1]) echo rebuild; if not echo bootstrap}
 
 install:V:
 	mk -f mkfile.$BUILD install


### PR DESCRIPTION
  mkfile:5: syntax error; multiple vars on left side of assignment

objc bootstraps itself -- build once with the system compiler, then rebuild with the objc1 that produced -- so which mkfile it delegates to depends on whether objc1 exists yet. That choice was written as a bare rc "if" at the top of the mkfile:

  BUILD=bootstrap
  if (whatis objc1 > /dev/null >[2=1])
          BUILD=rebuild

but mk parses that section itself and knows nothing of rc's control flow. It read the >[2=1] redirection as an assignment with two names on the left and stopped, which took mk clean down for the whole tree, objc being in DIRS.

Replaced with the mk idiom for running a shell command in an assignment, a backquote expression, as sys/src/cmd/mkfile already uses for TARG:

  BUILD=`{if(whatis objc1 >/dev/null >[2=1]) echo rebuild; if not echo bootstrap}

objc's was the only bare rc if at mkfile top level in the tree.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs