### PR TITLE
tcl: redirect the wcs* calls inside tclClock.c, not with -D

### DIFF
--- a/sys/src/ape/cmd/wish/mkfile
+++ b/sys/src/ape/cmd/wish/mkfile
@@ -17,16 +17,11 @@ TCLSRC=$APEXPROOT/sys/src/external/tcl
 # has to be char rather than wchar_t, because tclClock.c assigns
 # getenv's char * straight to a const WCHAR *.
 #
-# Since WCHAR is char here, its string operations are the byte ones.
-# tclClock.c calls wcscmp, wcslen and wcscpy on a WCHAR * holding the TZ
-# value from getenv. That used to work because wchar.h macro'd the whole
-# wcs* family onto str* equivalents; those macros are gone now that libap
-# implements them for real, and the calls stopped matching:
-#   tclClock.c:4758 argument prototype mismatch "IND CONST CHAR" for
-#   "IND CONST UINT": wcscmp
-# Mapping them here keeps the byte behaviour where it is actually wanted,
-# rather than in a header shared by everything. The other wcs* uses in
-# tcl and tk are all under win/, which is not built here.
+# The matching wcscmp/wcslen/wcscpy redirection lives in tclClock.c
+# itself, under #ifdef PLAN9. It cannot be done with -D here: that would
+# rewrite the declarations in wchar.h as well as the calls, leaving
+# "extern int strcmp(const wchar_t *, const wchar_t *)" to collide with
+# the real one in string.h.
 CFLAGS=\
 	-FVp -c\
 	-I$TKSRC/generic\
@@ -39,7 +34,6 @@ CFLAGS=\
 	-DPLAN9\
 	-DMODULE_SCOPE=/***/\
 	-DWCHAR=char\
-	-Dwcscmp=strcmp -Dwcslen=strlen -Dwcscpy=strcpy -Dwcsncmp=strncmp -Dwcsncpy=strncpy -Dwcsrchr=strrchr\
 	-DTK_PLATFORM="plan9"\
 
 

--- a/sys/src/ape/lib/tcl/mkfile
+++ b/sys/src/ape/lib/tcl/mkfile
@@ -97,20 +97,14 @@ CC=pcc
 # has to be char rather than wchar_t, because tclClock.c assigns
 # getenv's char * straight to a const WCHAR *.
 #
-# Since WCHAR is char here, its string operations are the byte ones.
-# tclClock.c calls wcscmp, wcslen and wcscpy on a WCHAR * holding the TZ
-# value from getenv. That used to work because wchar.h macro'd the whole
-# wcs* family onto str* equivalents; those macros are gone now that libap
-# implements them for real, and the calls stopped matching:
-#   tclClock.c:4758 argument prototype mismatch "IND CONST CHAR" for
-#   "IND CONST UINT": wcscmp
-# Mapping them here keeps the byte behaviour where it is actually wanted,
-# rather than in a header shared by everything. The other wcs* uses in
-# tcl and tk are all under win/, which is not built here.
+# The matching wcscmp/wcslen/wcscpy redirection lives in tclClock.c
+# itself, under #ifdef PLAN9. It cannot be done with -D here: that would
+# rewrite the declarations in wchar.h as well as the calls, leaving
+# "extern int strcmp(const wchar_t *, const wchar_t *)" to collide with
+# the real one in string.h.
 CFLAGS=-c -I. -I$TCLSRC/generic -I$TCLSRC/unix -I$TCLSRC/minizip\
 	-I$TCLSRC/libtommath -DHAVE_TCL_CONFIG_H -DPLAN9 -DMODULE_SCOPE=extern\
 	-DWCHAR=char -I$APEXPROOT/sys/src/external/zlib -DMP_FIXED_CUTOFFS\
-	-Dwcscmp=strcmp -Dwcslen=strlen -Dwcscpy=strcpy -Dwcsncmp=strncmp -Dwcsncpy=strncpy -Dwcsrchr=strrchr
 
 %.$O: $TCLSRC/libtommath/%.c
 	$CC $CFLAGS $TCLSRC/libtommath/$stem.c

--- a/sys/src/ape/lib/tk/mkfile
+++ b/sys/src/ape/lib/tk/mkfile
@@ -175,16 +175,11 @@ CC=pcc
 # has to be char rather than wchar_t, because tclClock.c assigns
 # getenv's char * straight to a const WCHAR *.
 #
-# Since WCHAR is char here, its string operations are the byte ones.
-# tclClock.c calls wcscmp, wcslen and wcscpy on a WCHAR * holding the TZ
-# value from getenv. That used to work because wchar.h macro'd the whole
-# wcs* family onto str* equivalents; those macros are gone now that libap
-# implements them for real, and the calls stopped matching:
-#   tclClock.c:4758 argument prototype mismatch "IND CONST CHAR" for
-#   "IND CONST UINT": wcscmp
-# Mapping them here keeps the byte behaviour where it is actually wanted,
-# rather than in a header shared by everything. The other wcs* uses in
-# tcl and tk are all under win/, which is not built here.
+# The matching wcscmp/wcslen/wcscpy redirection lives in tclClock.c
+# itself, under #ifdef PLAN9. It cannot be done with -D here: that would
+# rewrite the declarations in wchar.h as well as the calls, leaving
+# "extern int strcmp(const wchar_t *, const wchar_t *)" to collide with
+# the real one in string.h.
 CFLAGS=\
 	-c\
 	-I.\
@@ -202,7 +197,6 @@ CFLAGS=\
 	-DPLAN9\
 	-DMODULE_SCOPE=extern\
 	-DWCHAR=char\
-	-Dwcscmp=strcmp -Dwcslen=strlen -Dwcscpy=strcpy -Dwcsncmp=strncmp -Dwcsncpy=strncpy -Dwcsrchr=strrchr\
 	-DTK_PLATFORM="plan9"\
 	-DSTATIC_BUILD\
 

--- a/sys/src/external/tcl/generic/tclClock.c
+++ b/sys/src/external/tcl/generic/tclClock.c
@@ -4709,6 +4709,29 @@ ClockSafeCatchCmd(
  *----------------------------------------------------------------------
  */
 
+/*
+ * APExp: on Plan 9 the build sets -DWCHAR=char, following what Tcl
+ * itself does in tclIOUtil.c, because tzNow below takes getenv's char *
+ * directly. The three wcs* calls in this function therefore operate on
+ * bytes, and must be the byte functions.
+ *
+ * This used to happen by itself: APE's <wchar.h> macro'd the whole wcs*
+ * family onto their str* equivalents. libap implements them for real
+ * now, so the calls no longer type-check against a wchar_t * that is 32
+ * bits wide.
+ *
+ * The redirection has to be here rather than a -D in the mkfile. A -D
+ * rewrites the declaration in <wchar.h> as well as these calls, leaving
+ * "extern int strcmp(const wchar_t *, const wchar_t *)" to collide with
+ * the real declaration in <string.h>. Placed after all the includes, it
+ * only affects the uses below.
+ */
+#ifdef PLAN9
+#define wcscmp strcmp
+#define wcslen strlen
+#define wcscpy strcpy
+#endif
+
 #define TZ_INIT_MARKER	((WCHAR *) INT2PTR(-1))
 
 typedef struct {


### PR DESCRIPTION
My previous commit mapped the wcs* family to str* with -D in the three mkfiles. That was wrong and made things worse:

  wchar.h:135 external redeclaration of: strcmp
    EXTERN FUNC(IND CONST UINT, IND CONST UINT) INT  wchar.h:135
    EXTERN FUNC(IND CONST CHAR, IND CONST CHAR) INT  string.h:19

A -D applies to the whole translation unit, so it rewrote the declarations in <wchar.h> as well as the calls. "extern int wcscmp(const wchar_t *, const wchar_t *)" became a declaration of strcmp taking wchar_t *, which collided with the real one in <string.h>. The old wchar.h macros avoided this by sitting after the declarations in the same header, so only later uses were affected.

Put the redirection in tclClock.c instead, below the includes and under #ifdef PLAN9, which all three mkfiles set. Only the three calls in the TZ-caching function are covered, which is all that file uses. The mkfiles keep -DWCHAR=char and the note explaining why it must stay.

Also checked that tk needs nothing similar: its wcs* calls are all under win/, and the generic and unix directories that do get built have none.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs