### PR TITLE
gnulib: generate fts_.h from the newer template

### DIFF
--- a/sys/src/external/gnulib/fts_.h
+++ b/sys/src/external/gnulib/fts_.h
@@ -1,18 +1,18 @@
 /* Traverse a file hierarchy.
 
-   Copyright (C) 2004-2025 Free Software Foundation, Inc.
+   Copyright (C) 2004-2026 Free Software Foundation, Inc.
 
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU General Public License as published by
-   the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
 
-   This program is distributed in the hope that it will be useful,
+   This file is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
+   GNU Lesser General Public License for more details.
 
-   You should have received a copy of the GNU General Public License
+   You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /*
@@ -62,17 +62,46 @@
 #   define __FLEXIBLE_ARRAY_MEMBER
 #  endif
 # else
+#  if 1
+#   include <sys/cdefs.h>
+#  endif
 #  define __FLEXIBLE_ARRAY_MEMBER FLEXIBLE_ARRAY_MEMBER
-#  undef __THROW
-#  define __THROW
-#  undef __BEGIN_DECLS
-#  undef __END_DECLS
-#  ifdef __cplusplus
-#   define __BEGIN_DECLS extern "C" {
-#   define __END_DECLS }
-#  else
-#   define __BEGIN_DECLS
-#   define __END_DECLS
+#  if defined __clang__
+  /* clang really only groks GNU C 4.2, regardless of its value of __GNUC__.  */
+#   undef __GNUC_PREREQ
+#   define __GNUC_PREREQ(maj, min) ((maj) < 4 + ((min) <= 2))
+#  endif
+#  ifndef __GNUC_PREREQ
+#   if defined __GNUC__ && defined __GNUC_MINOR__
+#    define __GNUC_PREREQ(maj, min) ((maj) < __GNUC__ + ((min) <= __GNUC_MINOR__))
+#   else
+#    define __GNUC_PREREQ(maj, min) 0
+#   endif
+#  endif
+#  ifndef __THROW
+#   if defined __cplusplus && (__GNUC_PREREQ (2,8) || __clang_major__ >= 4)
+#    if __cplusplus >= 201103L
+#     define __THROW      noexcept (true)
+#    else
+#     define __THROW      throw ()
+#    endif
+#   else
+#    define __THROW
+#   endif
+#  endif
+#  ifndef __BEGIN_DECLS
+#   ifdef __cplusplus
+#    define __BEGIN_DECLS extern "C" {
+#   else
+#    define __BEGIN_DECLS /* nothing */
+#   endif
+#  endif
+#  ifndef __END_DECLS
+#   ifdef __cplusplus
+#    define __END_DECLS }
+#   else
+#    define __END_DECLS /* nothing */
+#   endif
 #  endif
 # endif
 
@@ -99,7 +128,15 @@ typedef struct {
 # define FTS_COMFOLLOW  0x0001          /* follow command line symlinks */
 # define FTS_LOGICAL    0x0002          /* logical walk */
 # define FTS_NOCHDIR    0x0004          /* don't change directories */
+
+  /* For efficiency do not set *fts_statp except for fts_statp->st_mode,
+     which is set to zero if the file type is unknown,
+     and which otherwise has at least its S_IFMT type bits set.
+     When fts_info == FTS_NSOK this supports expressions like
+     (fts_statp->st_mode ? !!S_ISFIFO (fts_statp->st_mode): -1), which yields
+     1 for a FIFO, 0 for a non-FIFO, and -1 for unknown.  */
 # define FTS_NOSTAT     0x0008          /* don't get stat info */
+
 # define FTS_PHYSICAL   0x0010          /* physical walk */
 # define FTS_SEEDOT     0x0020          /* return dot and dot-dot */
 # define FTS_XDEV       0x0040          /* don't cross devices */
@@ -148,20 +185,19 @@ typedef struct {
      Use this flag to make fts_open and fts_read defer the stat/lstat/fststat
      of each entry until it is actually processed.  However, note that if you
      use this option and also specify a comparison function, that function may
-     not examine any data via fts_statp.  However, when fts_statp->st_mode is
-     nonzero, the S_IFMT type bits are valid, with mapped dirent.d_type data.
-     Of course, that happens only on file systems that provide useful
-     dirent.d_type data.  */
+     not examine any data via fts_statp, other than fts_statp->st_mode
+     which is set similarly to how FTS_NOSTAT behaves.  */
 # define FTS_DEFER_STAT         0x0400
 
   /* Use this flag to disable stripping of trailing slashes
      from input path names during fts_open initialization.  */
 # define FTS_VERBATIM   0x0800
+# define FTS_MOUNT      0x1000          /* skip other devices */
 
-# define FTS_OPTIONMASK 0x0fff          /* valid user option mask */
+# define FTS_OPTIONMASK 0x1fff          /* valid user option mask */
 
-# define FTS_NAMEONLY   0x1000          /* (private) child names only */
-# define FTS_STOP       0x2000          /* (private) unrecoverable error */
+# define FTS_NAMEONLY   0x2000          /* (private) child names only */
+# define FTS_STOP       0x4000          /* (private) unrecoverable error */
         int fts_options;                /* fts_open options, global flags */
 
         /* Map a directory's device number to a boolean.  The boolean is

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -108,6 +108,22 @@ if [ -d "$DEST/sys" ]; then
 fi
 echo "pruned $pruned replacement system headers"
 
+# Generate fts_.h from the newest fts.in.h.
+#
+# fts.c includes "fts_.h", but newer gnulib ships only the fts.in.h
+# template and generates that header. coreutils supplies fts.c and
+# fts.in.h; ggrep still carries a pre-generated fts_.h, so the copy loop
+# takes fts.c from coreutils and fts_.h from ggrep -- a 2026 source
+# against a 2025 header:
+#   fts.c:1023 name not declared: FTS_MOUNT
+# @HAVE_SYS_CDEFS_H@ is the only substitution the template needs, and APE
+# does have <sys/cdefs.h>. The @(#) left behind is an SCCS id in a
+# comment, not a placeholder.
+if [ -f "$DEST/fts.in.h" ]; then
+	sed 's|@HAVE_SYS_CDEFS_H@|1|g' "$DEST/fts.in.h" > "$DEST/fts_.h"
+	echo "generated fts_.h from fts.in.h"
+fi
+
 # Strip package identity from the shared file. It began as coreutils'
 # config.h, so it says PACKAGE "coreutils" and VERSION "9.11". bison
 # reads VERSION and PACKAGE_STRING for its --version output and would


### PR DESCRIPTION
  fts.c:1023 name not declared: FTS_MOUNT

Version skew inside the shared tree, between a source and its own header. fts.c includes "fts_.h", but newer gnulib ships only fts.in.h and generates that header during configure. coreutils supplies fts.c and fts.in.h and no fts_.h; ggrep still carries a pre-generated fts_.h. So the copy loop took fts.c from coreutils, 2026, and fts_.h from ggrep, 2025, which predates FTS_MOUNT. The source used five symbols the header had never heard of.

Generate fts_.h from fts.in.h instead, keeping the newest-copy-wins rule that governs the rest of the tree. @HAVE_SYS_CDEFS_H@ is the only substitution the template needs and APE does have <sys/cdefs.h>; the @(#) that remains is an SCCS identifier in a comment.

Scanned for the same split elsewhere. Twelve templates have a generated counterpart present, and error.h is the only one still containing @...@ text -- all of it inside comments illustrating the template pattern, so it is a real generated header and compiles. fts was the only genuine case.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs