### PR TITLE
libap: implement fdopendir

### DIFF
--- a/sys/include/ape/dirent.h
+++ b/sys/include/ape/dirent.h
@@ -49,6 +49,7 @@ extern "C" {
  * functions defined on directories
  */
 DIR		*opendir(const char *);
+DIR		*fdopendir(int);
 struct dirent	*readdir(DIR *);
 void		rewinddir(DIR *);
 int		closedir(DIR *);

--- a/sys/src/ape/lib/ap/dirent/fdopendir.c
+++ b/sys/src/ape/lib/ap/dirent/fdopendir.c
@@ -1,0 +1,50 @@
+#include "lib.h"
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+#define DBLOCKSIZE 20
+
+/*
+ * fdopendir - POSIX.1-2008. Wrap an already-open descriptor in a DIR.
+ *
+ * The descriptor becomes owned by the stream: closedir() closes it,
+ * exactly as it does for one that opendir() opened, so the caller must
+ * not close or otherwise use fd afterwards.
+ *
+ * Everything but where the descriptor comes from is opendir()'s tail,
+ * and FD_CLOEXEC is set on it for the same reason opendir sets it, and
+ * because POSIX requires fdopendir to.
+ */
+DIR *
+fdopendir(int fd)
+{
+	struct stat st;
+	DIR *d;
+
+	if(fstat(fd, &st) < 0)
+		return NULL;
+	if(!S_ISDIR(st.st_mode)){
+		errno = ENOTDIR;
+		return NULL;
+	}
+
+	d = (DIR *)malloc(sizeof(DIR) + DBLOCKSIZE*sizeof(struct dirent));
+	if(d == NULL){
+		errno = ENOMEM;
+		return NULL;
+	}
+	_fdinfo[fd].flags |= FD_CLOEXEC;
+	d->dd_buf = (char *)d + sizeof(DIR);
+	d->dd_fd = fd;
+	d->dd_loc = 0;
+	d->dd_size = 0;
+	d->dirs = NULL;
+	d->dirsize = 0;
+	d->dirloc = 0;
+	d->dd_seek = 0;	/* entry count for telldir/seekdir */
+	return d;
+}

--- a/sys/src/ape/lib/ap/dirent/mkfile
+++ b/sys/src/ape/lib/ap/dirent/mkfile
@@ -6,6 +6,7 @@ LIB=$APEXPROOT/$objtype/lib/ape/libap.a
 OFILES=\
 	dirfd.$O\
 	opendir.$O\
+	fdopendir.$O\
 	closedir.$O\
 	readdir.$O\
 	rewinddir.$O\


### PR DESCRIPTION
  opendirat.c:48 incompatible types: "IND STRUCT _dirdesc" and "INT" for op "AS"

IND STRUCT _dirdesc is DIR *, and the INT is the implicit return of an undeclared function: DIR *dirp = fdopendir (new_fd). APE had neither a declaration nor an implementation. It is POSIX.1-2008 and the pieces were already there -- dirfd exists, and DIR carries the descriptor in dd_fd -- so the gap was just the one function.

Everything past the descriptor is opendir()'s tail. fstat rejects a non-directory with ENOTDIR, and FD_CLOEXEC is set on the descriptor for the reason opendir sets it and because POSIX requires fdopendir to.

The descriptor becomes owned by the stream: closedir already closes dd_fd, so a DIR from fdopendir is closed the same way as one from opendir, and the caller must not touch fd afterwards. Noted in the source, since that ownership is the part callers get wrong.

opendirat came in with grep, which is how this surfaced.

https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs