### PR TITLE
bash, stdint: drop the 16-bit wchar_t workarounds

### DIFF
--- a/sys/include/ape/stdint.h
+++ b/sys/include/ape/stdint.h
@@ -206,7 +206,22 @@ typedef _uintptr_t uintptr_t;
 #define SIZE_WIDTH	32
 #endif
 
-#define WCHAR_WIDTH	16
+/*
+ * wchar_t is 32 bits and equals Rune; see the note in <stddef.h>. This
+ * said 16 while <wchar.h> said WCHAR_MAX was Runemax, 0x10FFFF.
+ *
+ * C99 7.18.3 puts WCHAR_MIN and WCHAR_MAX in this header as well as in
+ * <wchar.h>, and gnulib reads them from here. Spelled numerically because
+ * Runemax comes from <utf.h>, which this header does not pull in; the
+ * guards let the two headers agree in either include order.
+ */
+#define WCHAR_WIDTH	32
+#ifndef WCHAR_MIN
+#define WCHAR_MIN	0
+#endif
+#ifndef WCHAR_MAX
+#define WCHAR_MAX	0x10FFFF
+#endif
 #define WINT_WIDTH	32
 #define SIG_ATOMIC_WIDTH	32
 

--- a/sys/src/external/bash/lib/glob/collsyms.h
+++ b/sys/src/external/bash/lib/glob/collsyms.h
@@ -29,11 +29,26 @@ typedef struct _COLLSYM {
   CHAR code;
 } __COLLSYM;
 
+/* Upstream form. The casts that stood here -- (unsigned short *) in the
+   wide branch, (char *) in the narrow one -- date from when APE's wchar_t
+   was 16-bit while pcc emitted L"..." as an array of Rune, i.e. 32-bit.
+   Casting a narrow literal to unsigned short * made the table match the
+   then-16-bit XCHAR at the cost of never holding a real wide string.
+   wchar_t is now 32 bits and equals Rune, so L##CS produces a literal of
+   exactly the element type XCHAR names, and the casts only mismatch:
+
+     collsyms.h:41 initialization of incompatible pointers: posix_collwcsyms
+     IND UINT and IND USHORT
+
+   The paste is what forms the literal and cannot be dropped: cpp's lexer
+   reaches STRING and CCON from state ST1 (lex.c), so re-lexing the glued
+   text "L\"NUL\"" yields one wide-string token. glob.c, gmisc.c and
+   smatch.c itself already rely on this. */
 #undef L
 #ifdef Lwide
-#define L(CS) (unsigned short *) CS
+#  define L(CS) L##CS
 #else
-#define L(CS) (char *) CS
+#  define L(CS) CS
 #endif
 
 static __COLLSYM POSIXCOLL [] =

--- a/sys/src/external/bash/lib/glob/smatch.c
+++ b/sys/src/external/bash/lib/glob/smatch.c
@@ -479,7 +479,7 @@ is_wcclass (wint_t wc, wchar_t *name)
 
   want_word = (wcscmp (name, L"word") == 0);
   if (want_word)
-    name = (unsigned short *) L"alnum";
+    name = L"alnum";	/* was cast to unsigned short *, for a 16-bit wchar_t */
 
   memset (&state, '\0', sizeof (mbstate_t));
   mbs = (char *) malloc (wcslen(name) * MB_CUR_MAX + 1);


### PR DESCRIPTION
Fallout from widening wchar_t to 32 bits to match Rune.

lib/glob/collsyms.h redefined bash's L() macro as a cast rather than upstream's L##CS paste: (unsigned short *) in the wide branch and (char *) in the narrow one. That made the wide table's names narrow string literals reinterpreted as the then-16-bit XCHAR, so no entry ever held a real wide string. With XCHAR now 32 bits every one of the ~100 entries fails:

  collsyms.h:41 initialization of incompatible pointers: posix_collwcsyms
  IND UINT and IND USHORT

Restored the upstream definition. The paste is what forms the literal and cannot be dropped, but it works here: cpp's lexer reaches STRING and CCON from state ST1, so glue()'s re-lex of "L\"NUL\"" yields one wide-string token, and glob.c, gmisc.c and smatch.c already use L##CS.

smatch.c had the same cast on a genuine wide literal, assigning (unsigned short *) L"alnum" to a wchar_t *. Dropped.

stdint.h still said WCHAR_WIDTH 16 while wchar.h said WCHAR_MAX was Runemax, 0x10FFFF. Corrected, and added the WCHAR_MIN/WCHAR_MAX that C99 7.18.3 requires of this header and that gnulib reads from it, guarded so either include order agrees with wchar.h.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs