### PR TITLE
pcc: accept -p instead of forwarding it to the compiler

### DIFF
--- a/sys/src/cmd/pcc.c
+++ b/sys/src/cmd/pcc.c
@@ -121,7 +121,6 @@ main(int argc, char *argv[])
 			break;
 		case 'N':
 		case 'T':
-		case 'p':
 		case 'w':
 		case 'F':
 			append(&cc, smprint("-%c", ARGC()));
@@ -131,6 +130,24 @@ main(int argc, char *argv[])
 			Aflag = 1;
 			break;
 		case 'O':
+			break;
+		/*
+		 * -p asks the compiler to preprocess with the ANSI cpp
+		 * rather than its built-in one. That is already what we
+		 * do -- see the dopipe() below, which runs /bin/cpp and
+		 * feeds the compiler on stdin -- so the request is
+		 * satisfied by accepting it and passing nothing on.
+		 *
+		 * Forwarding it was fatal. cc/lex.c under debug['p']
+		 * calls myaccess(file) before forking its own cpp, and
+		 * with input arriving on a pipe, file is the literal
+		 * string "stdin":
+		 *
+		 *   <eof> stdin does not exist
+		 *
+		 * make, patch and diff all carry -p in CFLAGS.
+		 */
+		case 'p':
 			break;
 		case 'W':
 			s = ARGF();


### PR DESCRIPTION
-p asks the compiler to preprocess with the ANSI cpp rather than its built-in one. pcc already does exactly that: dopipe() runs /bin/cpp and feeds the compiler on stdin. So the flag is satisfied on arrival and there is nothing to pass on.

Forwarding it was fatal rather than redundant. Under debug['p'], cc/lex.c calls myaccess(file) before forking its own cpp, and when the input arrives on a pipe, file is the literal string "stdin":

  <eof> stdin does not exist
  cc: cpp: 6c error

make, patch and diff all carry -p in CFLAGS, so this hit three packages, not just the one that surfaced it. Fixed in pcc rather than in each mkfile: no invocation of pcc can ever honour -p, since it has no path that leaves the compiler reading a named file.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs