### PR TITLE
libap: give xalloc_die an object of its own

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -114,6 +114,7 @@ OFILES=\
 	qcopy-acl.$O\
 	quotearg.$O\
 	regex.$O\
+	renameatu.$O\
 	safe-read.$O\
 	same-inode.$O\
 	secure_getenv.$O\

--- a/sys/src/ape/lib/ap/malloc/mkfile
+++ b/sys/src/ape/lib/ap/malloc/mkfile
@@ -19,6 +19,8 @@ OFILES=\
 	aligned_alloc.$O\
 # GNU xalloc family\
 	xmalloc.$O\
+# xalloc_die is replaceable, so it gets an object of its own\
+	xalloc_die.$O\
 	exitfail.$O\
 
 <$APEXPROOT/sys/src/cmd/mksyslib

--- a/sys/src/ape/lib/ap/malloc/xalloc_die.c
+++ b/sys/src/ape/lib/ap/malloc/xalloc_die.c
@@ -1,0 +1,35 @@
+/*
+ * xalloc_die lives alone in this file on purpose.
+ *
+ * gnulib documents xalloc_die as replaceable: a program that wants its
+ * own diagnostic, or wants to clean up before exiting, defines its own.
+ * GNU patch is one -- src/util.c has a version that reports the program
+ * name and the file being patched.
+ *
+ * A replaceable definition has to be the only thing in its object file.
+ * While it sat in xmalloc.c, any program that both defined its own
+ * xalloc_die and called any other member of the family dragged in the
+ * whole object, and the linker saw the symbol twice:
+ *
+ *   xalloc_die: /amd64/lib/ape/libap.a(xmemdup): redefinition: xalloc_die
+ *
+ * Note the name in parentheses is the symbol the linker was resolving,
+ * not the archive member -- 6l builds that string with the symbol name
+ * (obj.c, "snprint(pname, ..., \"%s(%s)\", file, s->name)"). So the
+ * message names xmemdup, while the member it pulled in was xmalloc.
+ *
+ * Alone here, the object is pulled in only when nothing else has
+ * defined xalloc_die, which is exactly the intended behaviour. gnulib
+ * keeps it in its own module, xalloc-die.c, for the same reason.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <xalloc.h>
+
+void
+xalloc_die(void)
+{
+	fputs("memory exhausted\n", stderr);
+	exit(1);
+}

--- a/sys/src/ape/lib/ap/malloc/xmalloc.c
+++ b/sys/src/ape/lib/ap/malloc/xmalloc.c
@@ -4,13 +4,12 @@
 #include <stddef.h>
 #include <xalloc.h>
 
-/* Called on allocation failure. Programs may override this. */
-void
-xalloc_die(void)
-{
-	fputs("memory exhausted\n", stderr);
-	exit(1);
-}
+/*
+ * xalloc_die is deliberately not here. It is replaceable -- a program
+ * may define its own -- so it has to be alone in its object file, or
+ * defining one drags this whole object in behind it and the linker
+ * reports a redefinition. See xalloc_die.c.
+ */
 
 void *
 xmalloc(size_t n)


### PR DESCRIPTION
Your ar t was right and my stale-member guess was wrong. There is no xmemdup member in libap.a -- 6l builds that string from the symbol it is resolving, not the member it found:

  snprint(pname, sizeof pname, "%s(%s)", file, s->name);   6l/obj.c

So "libap.a(xmemdup)" means the linker went looking for xmemdup, pulled in the member that has it -- xmalloc.6 -- and that member also defined xalloc_die, which was already defined.

The earlier definition is GNU patch's own, in src/util.c. gnulib documents xalloc_die as replaceable, and patch replaces it to report the program name and the file being patched. A replaceable definition has to be alone in its object file, or defining one drags the whole object in behind it; that is why gnulib keeps its copy in a module of its own. libap had it sharing xmalloc.c with the entire x* family. Split out to malloc/xalloc_die.c, so the object is pulled in only when nothing else has defined the symbol.

Also added renameatu.$O, which backupfile.c calls.

Traced the closure of the newly added modules rather than waiting for the next link to report it. What is left unresolved is all accounted for: ISDIGIT, _D_EXACT_NAMLEN, XARGMATCH and S_ISDIR are macros; ckd_add is a macro that reaches the portable arithmetic path here, since pcc defines neither __has_builtin nor __GNUC__ >= 7, so no __builtin_* overflow call survives; imalloc and irealloc are static inline in ialloc.h; at_func2, renameat2, renameatx_np and syscall are behind Linux/macOS guards.

issymlinkat needs no member. config-common.h resolves _GL_EXTERN_INLINE to "static" for pcc -- the __GNUC__ and __STDC_VERSION__ >= 199901L arms both fail, as pcc defines neither -- so the body in issymlinkat.h is compiled into each includer, renameatu.c included. Its readlinkat is in libap's at_functions.c and declared in <unistd.h>. I added the object first and backed it out after checking.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs