### PR TITLE
diff: keep the package's own lib off the include path

### DIFF
--- a/sys/src/ape/cmd/diff/mkfile
+++ b/sys/src/ape/cmd/diff/mkfile
@@ -29,25 +29,47 @@ BIN=$APEXPROOT/$objtype/bin/ape
 
 <$APEXPROOT/sys/src/cmd/mkmany
 
-RPLS= -Drpl_malloc=malloc -Drpl_free=free -Drpl_getopt_long=getopt_long\
-	-Drpl_optarg=optarg -Drpl_optind=optind
-
 CC=pcc -c
 # -I. finds this directory's config.h, which layers package identity
-# over config-common.h. -I$GNUSRC comes before the package's own lib
-# directory so the shared module headers match the objects in
-# libgnu.a; the package's copies are older than the 2026 sources the
-# library is built from, and a mismatch shows up at link time as a
-# missing symbol rather than at compile time.
+# over config-common.h. -I$GNUSRC supplies the module headers, and they
+# match the objects in libgnu.a; the package's own copies are older than
+# the 2026 sources the library is built from.
+#
+# $DIFFSRC/lib is deliberately absent, unlike the sibling packages.
+# autoconf generated 22 replacement system headers in there -- ctype.h,
+# dirent.h, errno.h, fcntl.h, fnmatch.h, getopt.h, inttypes.h, limits.h,
+# pthread.h, sched.h, signal.h, stddef.h, stdint.h, stdio.h, stdlib.h,
+# string.h, strings.h, time.h, uchar.h, unistd.h, wchar.h, wctype.h --
+# every one of which shadows APE's. import.sh prunes exactly these from
+# the shared tree; here they sit in the package. getopt.h is simply the
+# one the compiler reached first:
+#
+#   gnulib/getopt-ext.h:57 redeclare tag: option
+#
+# diffutils/lib/getopt.h pulls APE's <getopt.h> through #include_next,
+# which declares struct option, then reaches getopt-pfx-ext.h and
+# getopt-ext.h, which declare it again.
+#
+# Nothing is lost by dropping it. Of every header diffutils/src
+# includes, config.h is the only one not found in the shared tree or in
+# APE, and that comes from -I. libap has getopt_long (misc/getopt_long.c)
+# and APE's <getopt.h> declares it, so gnulib's getopt is not wanted.
+#
+# The -Drpl_malloc=malloc family that stood here went with it. Those
+# undid renames a per-package config.h used to make; config-common.h
+# renames none of malloc, free, getopt_long, optarg or optind. The
+# rpl_optarg spelling came from gnulib's getopt-pfx-ext.h, which is no
+# longer reached at all.
 GNUSRC=$APEXPROOT/sys/src/external/gnulib
-CFLAGS=-B -p -D_POSIX_SOURCE -DREGEX_MALLOC -I. -I$GNUSRC -I$DIFFSRC/src -I$DIFFSRC/lib \
-	-DHAVE_CONFIG_H -DDIFF_PROGRAM="/bin/diff" $RPLS\
+CFLAGS=-B -p -D_POSIX_SOURCE -DREGEX_MALLOC -I. -I$GNUSRC -I$DIFFSRC/src \
+	-DHAVE_CONFIG_H -DDIFF_PROGRAM="/bin/diff"\
 
 %.$O: $DIFFSRC/src/%.c
 	$CC $CFLAGS $prereq
 
-%.$O: $DIFFSRC/lib/%.c
-	$CC $CFLAGS $prereq
+# No rule for $DIFFSRC/lib/%.c: every object comes from src or, for
+# version-etc, from the shared tree. A rule here would let a stale
+# package-local module be built by name alone.
 
 $O.diff: $DIFFO $LIB
 $O.diff3: $DIFF3O $LIB


### PR DESCRIPTION
  gnulib/getopt-ext.h:57 redeclare tag: option

diffutils/lib/getopt.h pulls APE's <getopt.h> in through #include_next, which declares struct option, then goes on to getopt-pfx-ext.h and getopt-ext.h, which declare it again.

getopt.h is only the first one the compiler reached. autoconf generated 22 replacement system headers in diffutils/lib -- ctype.h, dirent.h, errno.h, fcntl.h, fnmatch.h, getopt.h, inttypes.h, limits.h, pthread.h, sched.h, signal.h, stddef.h, stdint.h, stdio.h, stdlib.h, string.h, strings.h, time.h, uchar.h, unistd.h, wchar.h, wctype.h -- and every one shadows an APE header. These are the same headers import.sh prunes from the shared tree, for the same reason; diffutils is the one package that still ships a full set. Fixing getopt.h alone would just have moved the failure to the next header.

Dropping -I$DIFFSRC/lib costs nothing. Of every header diffutils/src includes, config.h is the only one not found in either the shared tree or APE, and that comes from -I. libap has getopt_long in misc/getopt_long.c and APE's <getopt.h> declares it, so gnulib's getopt was never wanted here.

The -Drpl_malloc=malloc family goes with it. Those undid renames that a per-package config.h used to make; config-common.h renames none of malloc, free, getopt_long, optarg or optind, and the rpl_optarg spelling came from gnulib's getopt-pfx-ext.h, which is no longer reached at all.

Also dropped the $DIFFSRC/lib pattern rule. No object comes from there -- all 15 are in src, plus version-etc from the shared tree -- and leaving the rule would let a stale package-local module be built by name alone.

Checked the sibling packages for the same exposure: grep, patch and m4 have nothing in their lib that shadows an APE header, and bison and sed have only obstack.h, plus stddef.h and stdint.h for sed. Those build, so they are left alone.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs