### PR TITLE
diff: generate version.c; gnulib: add the hard_locale chain

### DIFF
--- a/sys/src/ape/cmd/diff/mkfile
+++ b/sys/src/ape/cmd/diff/mkfile
@@ -10,20 +10,24 @@ TARG=\
 
 LIB= ../gnulib/libgnu.a$O
 
+# version.$O is not version-etc.$O. The first carries this package's
+# version string, the second is the shared gnulib module that prints it.
 CMPO=\
-	cmp.$O system.$O version-etc.$O
+	cmp.$O system.$O version.$O version-etc.$O
 
 DIFFO=\
 	analyze.$O context.$O diff.$O \
 	dir.$O ed.$O ifdef.$O io.$O \
 	normal.$O side.$O system.$O \
-	util.$O version-etc.$O
+	util.$O version.$O version-etc.$O
 
 DIFF3O=\
-	diff3.$O system.$O version-etc.$O
+	diff3.$O system.$O version.$O version-etc.$O
 
 SDIFFO=\
-	sdiff.$O system.$O version-etc.$O
+	sdiff.$O system.$O version.$O version-etc.$O
+
+CLEANFILES=version.c
 
 BIN=$APEXPROOT/$objtype/bin/ape
 
@@ -84,4 +88,32 @@ $O.sdiff: $SDIFFO $LIB
 # copy in this package's own lib is older.
 version-etc.$O: $GNUSRC/version-etc.c
 	$CC $CFLAGS $GNUSRC/version-etc.c
+
+# src/version.c is generated, not shipped. diffutils' Makefile.am writes
+# it at build time:
+#
+#   printf 'char const *Version = "$(PACKAGE_VERSION)";\n' >> $@t
+#
+# so the source tree has only the matching version.h, and Version came
+# out undefined at link time:
+#
+#   _convM2D: Version: not defined
+#
+# (the name before the colon is whichever text symbol the linker last
+# saw, not the referrer.)
+#
+# Written here rather than into the external tree, as bash's generated
+# builtins are, so the source stays clean. PACKAGE_VERSION comes from
+# this directory's config.h instead of being repeated in the recipe,
+# which keeps one copy of the number; upstream spells the literal only
+# because autoconf substitutes it.
+version.c:
+	echo '#include <config.h>' >version.c
+	echo '#include <version.h>' >>version.c
+	echo 'char const *Version = PACKAGE_VERSION;' >>version.c
+
+# An explicit rule: the $DIFFSRC/src pattern rule below would otherwise
+# be chosen and look for a version.c that is not there.
+version.$O: version.c
+	$CC $CFLAGS version.c
 

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -80,6 +80,7 @@ OFILES=\
 	gl_linkedhash_list.$O\
 	gl_rbtree_oset.$O\
 	gl_rbtreehash_list.$O\
+	hard-locale.$O\
 	hash.$O\
 	hashcode-named-file.$O\
 	hashcode-string1.$O\
@@ -119,6 +120,9 @@ OFILES=\
 	same-inode.$O\
 	secure_getenv.$O\
 	set-permissions.$O\
+	setlocale-lock.$O\
+	setlocale_null.$O\
+	setlocale_null-unlocked.$O\
 	sigsegv.$O\
 	spawn-pipe.$O\
 	stat-time.$O\


### PR DESCRIPTION
Two link failures, unrelated to each other.

  _convM2D: Version: not defined

src/version.c is generated, not shipped. diffutils' Makefile.am writes it at build time:

  printf 'char const *Version = "$(PACKAGE_VERSION)";\n' >> $@t

so the source tree carries only the matching version.h and nothing ever defined the variable. (The name before the colon is whichever text symbol the linker last saw, not the referrer -- _convM2D is a libap 9p routine and has nothing to do with it.)

Generated into the build directory rather than the external tree, as bash's builtins are, so the source stays clean. PACKAGE_VERSION is taken from this directory's config.h instead of being repeated in the recipe; upstream spells the literal only because autoconf substitutes it. version.$O needs an explicit rule, or the $DIFFSRC/src pattern rule is chosen and looks for a version.c that is not there. Added to all four object lists and to CLEANFILES.

  hard_locale_LC_MESSAGES: undefined: hard_locale

hard_locale_LC_MESSAGES is a static function in cmp.c; hard_locale is the gnulib module, which was not in the archive. Followed the chain rather than adding the one name: hard-locale.c calls setlocale_null_r, which is in setlocale_null.c, which calls setlocale_null_r_unlocked and setlocale_null_unlocked from setlocale_null-unlocked.c, and -- since config-common.h has SETLOCALE_NULL_ALL_MTSAFE and _ONE_MTSAFE both 0 and AVOID_ANY_THREADS undefined -- gl_get_setlocale_null_lock from setlocale-lock.c. All four added.

The rest of what those modules reference is accounted for: the Windows API and _wsetlocale are dead; the C11 threads entry points are dead because USE_ISOC_THREADS is undefined; and pthread_in_use() is the plain "1" definition in glthread/once.h, since USE_POSIX_THREADS_WEAK and PTHREAD_IN_USE_DETECTION_HARD are both undefined, so it does not drag in c11_threads_in_use. None of the four collides with libap.

Note this touches diff/mkfile, which also changed on main for the cmp build rule; the two want merging.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs