### PR TITLE
gnulib: let hard-locale.c reach the real setlocale_null.h, and add streq

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -200,9 +200,21 @@ CC=$APEXPROOT/$objtype/bin/pcc
 # gnulib's regex.c and fts.c from redefining them -- the same
 # duplicate-symbol trap that obstack fell into. Undoing them here, or
 # editing them out of config.h, reintroduces it.
+# -DSETLOCALE_NULL_MAX=257 used to stand here, for hard-locale.c, which
+# uses the macro without including a header that defines it. Nothing in
+# OFILES did, so it went unnoticed until setlocale_null.c was added:
+# that module includes its own setlocale_null.h, which spells the same
+# value differently, and cpp compares replacement lists, not values.
+#
+#   setlocale_null.h:37 ... setlocale_null.c:22
+#     Macro redefinition of SETLOCALE_NULL_MAX
+#
+# apexp-decls.h now includes setlocale_null.h, which is what the deleted
+# <locale.h> wrapper did, so both the macro and setlocale_null_r reach
+# hard-locale.c from the one place that defines them.
 CFLAGS=-c -B -I. -I$GNUSRC -DHAVE_CONFIG_H -D_POSIX_SOURCE -D_BSD_EXTENSION\
   -D__USE_GNU -D_REGEX_LARGE_OFFSETS -DREGEX_MALLOC -DO_BINARY=0\
-   -DSETLOCALE_NULL_MAX=257 -DLOCALEDIR="/sys/lib/ape/locale"
+   -DLOCALEDIR="/sys/lib/ape/locale"
 
 
 # No two modules share a basename across these directories, so the

--- a/sys/src/external/gnulib/apexp-decls.h
+++ b/sys/src/external/gnulib/apexp-decls.h
@@ -49,4 +49,12 @@ extern ptrdiff_t vaszprintf(char **, const char *, va_list);
 extern off64_t vfzprintf(FILE *, const char *, va_list);
 extern off64_t vzprintf(const char *, va_list);
 
+/* locale.h wrapper.
+   The deleted wrapper pulled this header in under GNULIB_SETLOCALE_NULL
+   (locale.in.h:298), which is how hard-locale.c gets SETLOCALE_NULL_MAX
+   and setlocale_null_r -- it includes neither itself. Unlike the rest of
+   this file the real header exists, so include it rather than restating
+   it; it carries its own guard and its own arg-nonnull.h. */
+#include "setlocale_null.h"
+
 #endif /* _APEXP_DECLS_H */

--- a/sys/src/external/gnulib/config-common.h
+++ b/sys/src/external/gnulib/config-common.h
@@ -5879,6 +5879,17 @@
 # define strnul(s) ((s) + strlen (s))
 #endif
 
+/* APExp: streq, the same case as strnul above.
+   It is an inline in the generated string.h (string.in.h:812, under
+   GNULIB_STREQ), so it went with that wrapper. hard-locale.c is the
+   compiled module that calls it, and it includes no header that would
+   declare it. streq.h is a different thing -- the streq0..streq9
+   fixed-length helpers, which call this streq rather than define it.
+   Upstream is "return !strcmp (s1, s2)". */
+#ifndef streq
+# define streq(a, b) (strcmp ((a), (b)) == 0)
+#endif
+
 /* APExp: prototypes and off64_t that the deleted wrapper headers carried.
    See apexp-decls.h for how the list was derived. */
 #include "apexp-decls.h"

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -295,6 +295,13 @@ EOF
 # define strnul(s) ((s) + strlen (s))
 #endif
 
+/* APExp: streq, likewise an inline in the generated string.h.
+   streq.h is a different thing: the streq0..streq9 helpers call this
+   one rather than define it. */
+#ifndef streq
+# define streq(a, b) (strcmp ((a), (b)) == 0)
+#endif
+
 /* APExp: prototypes and off64_t the deleted wrappers carried. */
 #include "apexp-decls.h"
 EOF


### PR DESCRIPTION
  setlocale_null.h:37 ... setlocale_null.c:22
    Macro redefinition of SETLOCALE_NULL_MAX

The gnulib mkfile carried -DSETLOCALE_NULL_MAX=257 for hard-locale.c, which uses the macro without including any header that defines it -- upstream it arrives through the generated <locale.h>, which is deleted here for shadowing APE's. No module in OFILES used the macro, so the -D sat unexamined until setlocale_null.c arrived: that one includes its own setlocale_null.h, which spells the value (256+1). cpp compares replacement lists rather than values, so 257 and (256+1) are a redefinition.

Dropped the -D. apexp-decls.h now includes setlocale_null.h, which is exactly what the deleted wrapper did (locale.in.h:298, under GNULIB_SETLOCALE_NULL), so the macro and setlocale_null_r both reach hard-locale.c from the one place that defines them. Unlike the rest of apexp-decls.h this header really exists, so it is included rather than restated; it is self-guarded and pulls its own arg-nonnull.h, which is also self-guarded, so nothing is defined twice.

hard-locale.c needs streq as well, and would have failed next. It is an inline in the generated string.h (string.in.h:812, under GNULIB_STREQ), so it went the same way strnul did and gets the same treatment, next to it in config-common.h and in import.sh. streq.h is a different thing: the streq0..streq9 fixed-length helpers, which call this streq rather than define it.

m4's mkfile also passes SETLOCALE_NULL_MAX, but spelled (256+1), which is token-for-token what the header says, so it does not collide. It is now redundant rather than wrong, and left alone.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs