### PR TITLE
libap: implement timespec_get

### DIFF
--- a/sys/include/ape/time.h
+++ b/sys/include/ape/time.h
@@ -34,6 +34,10 @@ struct timespec {
 
 #define TIMER_ABSTIME 1
 
+/* C11 7.27.1: the time base for timespec_get. TIME_UTC is the only one
+   the standard defines, and the only one implemented here. */
+#define TIME_UTC 1
+
 #ifndef _TIMER_T
 #define _TIMER_T
 typedef void* timer_t;
@@ -81,6 +85,7 @@ extern size_t strftime(char *, size_t, const char *, const struct tm *);
 extern int clock_gettime(clockid_t, struct timespec *);
 extern int clock_settime(clockid_t, struct timespec *);
 extern int clock_getres(clockid_t, struct timespec *);
+extern int timespec_get(struct timespec *, int);
 
 extern struct tm *gmtime_r(const time_t *, struct tm *);
 extern struct tm *localtime_r(const time_t *, struct tm *);

--- a/sys/src/ape/lib/ap/time/mkfile
+++ b/sys/src/ape/lib/ap/time/mkfile
@@ -17,6 +17,7 @@ OFILES=\
 	sleep.$O\
 	time.$O\
 	times.$O\
+	timespec_get.$O\
 	tzset.$O\
 # musl\
 	__map_file.$O\

--- a/sys/src/ape/lib/ap/time/timespec_get.c
+++ b/sys/src/ape/lib/ap/time/timespec_get.c
@@ -1,0 +1,27 @@
+/*
+ * timespec_get -- C11 7.27.2.5.
+ *
+ * Sets ts to the current time in the time base named by base, and
+ * returns base on success or zero on failure. TIME_UTC is the only
+ * base the standard defines; an implementation may add others, and
+ * this one does not.
+ *
+ * Note the return value is base, not 0, when it works -- the reverse of
+ * the usual POSIX convention, and the reverse of clock_gettime, which
+ * this is written over.
+ */
+
+#include <time.h>
+#include <errno.h>
+
+int
+timespec_get(struct timespec *ts, int base)
+{
+	if(base != TIME_UTC){
+		errno = EINVAL;
+		return 0;
+	}
+	if(clock_gettime(CLOCK_REALTIME, ts) < 0)
+		return 0;
+	return base;
+}


### PR DESCRIPTION
  context.c:57 name not declared: TIME_UTC

diffutils' context.c calls timespec_get (&now, TIME_UTC) to stamp stdin with the current time, as POSIX requires. APE had neither the macro nor the function; TIME_UTC failed at compile time, and timespec_get would have followed at link time, since an undeclared call would only have been given the implicit int return.

Written over clock_gettime (CLOCK_REALTIME), which libap already has, alongside struct timespec and CLOCK_REALTIME in <time.h>. Worth noting the C11 return convention is inverted relative to what it is built on: timespec_get returns base on success and zero on failure, where clock_gettime returns zero on success.

No duplicate: gnulib has a timespec_get module, but it is deliberately not in OFILES -- gettime.c takes the clock_gettime branch, so it was dead code here -- and config-common.h does not rename timespec_get to rpl_timespec_get, so context.c's call reaches libap's.

config-common.h still has HAVE_TIMESPEC_GET undefined, which is now stale but left alone: setting it would switch gnulib modules onto code paths that have never been built here, for no gain.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs