### PR TITLE
cc: let a designator list walk back out of a nested aggregate;

### DIFF
--- a/sys/include/ape/unistd.h
+++ b/sys/include/ape/unistd.h
@@ -184,7 +184,7 @@ int fstatat(int dirfd, const char *path, struct stat *buf, int flags);
 int unlinkat(int dirfd, const char *path, int flags);
 int mkdirat(int dirfd, const char *path, mode_t mode);
 int renameat(int olddirfd, const char *old, int newdirfd, const char *new);
-int readlinkat(int dirfd, const char *path, char *buf, size_t n);
+ssize_t readlinkat(int dirfd, const char *path, char *buf, size_t n);
 int symlinkat(const char *target, int dirfd, const char *linkpath);
 int faccessat(int dirfd, const char *path, int mode, int flags);
 int fchownat(int dirfd, const char *path, uid_t uid, gid_t gid, int flags);

--- a/sys/src/ape/lib/ap/unistd/at_functions.c
+++ b/sys/src/ape/lib/ap/unistd/at_functions.c
@@ -125,7 +125,15 @@ linkat(int olddirfd, const char *oldpath, int newdirfd,
 	return -1;
 }
 
-int
+/* POSIX.1-2008 gives readlinkat an ssize_t return, as readlink has.
+   This said int, so on amd64 the callee wrote 4 bytes where an ssize_t
+   caller read 8. gnulib's careadlinkat takes the function as a
+   parameter and typechecks it:
+
+     diff.c:1265 argument prototype mismatch
+       "IND FUNC(INT, IND CONST CHAR, IND CHAR, UVLONG) INT" for
+       "IND FUNC(INT, IND CONST CHAR, IND CHAR, UVLONG) VLONG" */
+ssize_t
 readlinkat(int dirfd, const char *path, char *buf, size_t bufsiz)
 {
 	/* Plan9 has no symlinks */

--- a/sys/src/cmd/cc/dcl.c
+++ b/sys/src/cmd/cc/dcl.c
@@ -514,7 +514,7 @@ isstruct(Node *a, Type *t)
 Node*
 init1(Sym *s, Type *t, long o, int exflag)
 {
-	Node *a, *l, *r, nod;
+	Node *a, *l, *r, *pre, nod;
 	Type *t1;
 	long e, w, so, mw, bitoff;
 	static Node *bitagg;
@@ -725,8 +725,26 @@ init1(Sym *s, Type *t, long o, int exflag)
 			if(t->width != 0)
 				if(mw >= t->width)
 					break;
+			/*
+			 * If the element type cannot use this designator, the
+			 * designator belongs to an enclosing aggregate: stop,
+			 * and let the caller re-dispatch it. init1 signals that
+			 * by consuming nothing.
+			 *
+			 * Without this, a flat designator list that walks back
+			 * out of an array, as in
+			 *
+			 *   { .file[0].desc = a, .file[1].desc = b }
+			 *
+			 * kept handing .file[1] to the element type, which does
+			 * not have a member called file.
+			 */
+			pre = peekinit();
 			r = init1(s, t->link, o+so, 1);
 			l = newlist(l, r);
+			if(pre != Z && peekinit() == pre)
+			if(pre->op == OELEM || pre->op == OARRAY)
+				break;
 			e++;
 		}
 		if(t->width == 0)
@@ -786,7 +804,21 @@ init1(Sym *s, Type *t, long o, int exflag)
 			if(a->op == OELEM || a->op == OARRAY)
 				goto again;
 		}
-		if(a && (a->op == OELEM || a->op == OARRAY))
+		/*
+		 * A designator naming no member of this struct is an error
+		 * only at a level that has its own braces: exflag is 0 for
+		 * the outermost aggregate and for anything reached through
+		 * doinit, which is the brace case.
+		 *
+		 * When exflag is set we were entered implicitly, without
+		 * braces of our own, so a designator we cannot use is one
+		 * that belongs to an enclosing aggregate. Return, consuming
+		 * nothing, and let that level match it -- the array case
+		 * above watches for exactly this. A designator that matches
+		 * nothing anywhere still reaches the outermost level, where
+		 * exflag is 0 and it is reported.
+		 */
+		if(a && (a->op == OELEM || a->op == OARRAY) && !exflag)
 			diag(a, "structure element not found %F", a);
 		if(bitoff != -1) {
 			if(bitagg)


### PR DESCRIPTION
libap: readlinkat returns ssize_t

Two unrelated failures in diffutils' diff.c.

  diff.c:1265 argument prototype mismatch
    "IND FUNC(INT, IND CONST CHAR, IND CHAR, UVLONG) INT" for
    "IND FUNC(INT, IND CONST CHAR, IND CHAR, UVLONG) VLONG"

POSIX.1-2008 gives readlinkat an ssize_t return, as readlink already has in <sys/stat.h>. APE declared and defined it int, which gnulib caught because careadlinkat takes the reader as a parameter and typechecks it. It was also an ABI bug of the same family as the size_t one: on amd64 the callee wrote four bytes where an ssize_t caller reads eight. readlinkat is the only *at function POSIX gives a non-int return, and the only one in at_functions.c that was wrong.

  diff.c:1412 structure element not found desc

This is a compiler bug, in designator lists that leave a nested aggregate and come back:

  struct comparison cmp = { .file[0].desc = ..., .file[1].desc = ...,
                            .file[0].stat.st_size = ..., .parent = ... };

The grammar builds these chains correctly and init1 descends to the leftmost designator and trims as it matches, so entering file[0].desc works. Coming back out did not. Having initialised file[0], init1 was still inside struct file_data when it peeked at .file[1].desc, found no member named file, and reported the outermost name in the chain -- desc.

A designator that names nothing here is an error only at a level with its own braces. exflag distinguishes them: it is 0 for the outermost aggregate and for every level reached through doinit, which is the brace case, and 1 when init1 was entered implicitly. So when exflag is set, return instead of diagnosing and let the enclosing level match it. A designator that matches nothing anywhere still reaches the outermost level, where exflag is 0, and is reported there as before.

The array case has to cooperate, or it hands the same designator to the element type again. init1 consuming nothing is the signal; peekinit has no side effects, so comparing it across the call is enough. Guarded on the pending node being a designator, so ordinary element initialisers, brace-nested ones and the a == Z case are untouched.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs