### PR TITLE
gnulib: four modules diff needs; libap: unreachable() and the missing…

### DIFF
--- a/sys/include/ape/stddef.h
+++ b/sys/include/ape/stddef.h
@@ -50,4 +50,31 @@ typedef unsigned long size_t;
 typedef unsigned int wchar_t;
 #endif
 
+/*
+ * C23 7.21.1: unreachable() expands to a void expression whose
+ * execution is undefined behaviour. It belongs in this header, and
+ * gnulib's generated <stddef.h> supplied it -- that wrapper is pruned
+ * here for shadowing this one, so without it a caller gets an implicit
+ * function and the link fails:
+ *
+ *   diff_2_files: undefined: unreachable in diff_2_files
+ *
+ * abort() is gnulib's own fallback for a compiler with no
+ * __builtin_unreachable, and is what pcc needs: it swallows unknown
+ * __builtin_* calls and yields a constant, so __builtin_unreachable()
+ * would compile to a no-op that neither traps nor informs the
+ * optimiser. Reaching abort() is at least honest about the bug.
+ *
+ * abort is declared here rather than pulling in <stdlib.h>, as gnulib
+ * also does; the declaration matches the one in <stdlib.h> exactly, so
+ * the two can be seen in either order. C++ has its own std::unreachable
+ * and no _Noreturn, so the whole block sits outside it.
+ */
+#ifndef __cplusplus
+#ifndef unreachable
+extern _Noreturn void abort(void);
+#define unreachable() abort()
+#endif
+#endif
+
 #endif /* __STDDEF_H */

--- a/sys/include/ape/sys/stat.h
+++ b/sys/include/ape/sys/stat.h
@@ -59,6 +59,60 @@ struct	stat {
 #define S_TYPEISSHM(st) 0
 #define S_TYPEISTMO(st) 0
 
+/*
+ * File types Plan 9 does not have. Portable code tests these without
+ * guarding them -- gnulib's c-file-type.c walks the whole list in one
+ * run of unguarded ifs -- because gnulib's generated <sys/stat.h>
+ * defines every one of them, to 0 on a system that lacks the type.
+ * That wrapper is pruned here for shadowing this header, so define them
+ * as gnulib would; undefined, each call is an implicit function and
+ * turns up at link time instead:
+ *
+ *   compare_files: undefined: c_file_type in compare_files
+ *
+ * Each is guarded, so a port that grows a real one of these only has to
+ * define it before including this header.
+ */
+#ifndef S_ISDOOR		/* Solaris 2.5 and up */
+#define S_ISDOOR(m) 0
+#endif
+#ifndef S_ISCTG			/* contiguous file */
+#define S_ISCTG(m) 0
+#endif
+#ifndef S_ISMPB			/* V7 multiplexed block special */
+#define S_ISMPB(m) 0
+#endif
+#ifndef S_ISMPC			/* V7 multiplexed character special */
+#define S_ISMPC(m) 0
+#endif
+#ifndef S_ISMPX			/* AIX */
+#define S_ISMPX(m) 0
+#endif
+#ifndef S_ISNAM			/* Xenix */
+#define S_ISNAM(m) 0
+#endif
+#ifndef S_ISNWK			/* HP-UX network special */
+#define S_ISNWK(m) 0
+#endif
+#ifndef S_ISPORT		/* Solaris 10 and up */
+#define S_ISPORT(m) 0
+#endif
+#ifndef S_ISWHT			/* BSD whiteout */
+#define S_ISWHT(m) 0
+#endif
+#ifndef S_ISOFD			/* Cray migrated, offline with data */
+#define S_ISOFD(m) 0
+#endif
+#ifndef S_ISOFL			/* Cray migrated, offline without data */
+#define S_ISOFL(m) 0
+#endif
+#ifndef S_TYPEISMQ		/* takes a struct stat *, not a mode */
+#define S_TYPEISMQ(st) 0
+#endif
+#ifndef S_TYPEISSEM
+#define S_TYPEISSEM(st) 0
+#endif
+
 #define S_IFMT S__MASK
 #define S_IFDIR 0040000
 #define S_IFCHR 0020000

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -37,9 +37,11 @@ OFILES=\
 	bitsetv.$O\
 	btoc32.$O\
 	c-ctype.$O\
+	c-file-type.$O\
 	c-stack.$O\
 	c-strcasecmp.$O\
 	canonicalize.$O\
+	careadlinkat.$O\
 	clean-temp.$O\
 	clean-temp-simple.$O\
 	close-stream.$O\
@@ -101,6 +103,7 @@ OFILES=\
 	mempcpy.$O\
 	mkstemp-safer.$O\
 	next-prime.$O\
+	nstrftime.$O\
 	open-safer.$O\
 	openat-proc.$O\
 	openat-safer.$O\
@@ -123,6 +126,7 @@ OFILES=\
 	setlocale-lock.$O\
 	setlocale_null.$O\
 	setlocale_null-unlocked.$O\
+	sh-quote.$O\
 	sigsegv.$O\
 	spawn-pipe.$O\
 	stat-time.$O\


### PR DESCRIPTION
… S_IS*

Six undefined symbols from diff's link, in three groups.

Four were modules absent from the shared archive: careadlinkat, c-file-type (c_file_type), sh-quote (shell_quote_length and shell_quote_copy) and nstrftime. nstrftime.c is a twenty-line wrapper that defines my_strftime to nstrftime and includes strftime.c, so only nstrftime.$O is added; strftime.$O would define strftime and collide with libap's. None of the four collides with libap, and their closures are clean: careadlinkat's remaining names are macros, statics and its own parameter, and sh-quote's init_sh_quoting_options is static.

  diff_2_files: undefined: unreachable in diff_2_files

C23 7.21.1 puts unreachable() in <stddef.h>, and gnulib's generated copy supplied it. That wrapper is pruned here for shadowing APE's, so callers got an implicit function. Added to APE's <stddef.h> as abort(), which is gnulib's own fallback where there is no __builtin_unreachable, and the right choice for pcc: it swallows unknown __builtin_* calls and yields a constant, so __builtin_unreachable() would compile to a no-op that neither traps nor informs the optimiser. abort is declared in place rather than by including <stdlib.h>, as gnulib does, spelled exactly as <stdlib.h> spells it so either order works. Outside __cplusplus, which has std::unreachable and no _Noreturn.

  compare_files: undefined: c_file_type in compare_files

c-file-type.c would not have been enough on its own. It walks every file type in one run of unguarded ifs -- S_ISDOOR, S_ISCTG, S_ISMPB and the rest -- because gnulib's generated <sys/stat.h> defines all of them, to 0 where the type does not exist. APE's header was missing thirteen, each of which would have become an implicit call: one undefined symbol traded for thirteen. Defined as gnulib defines them, guarded individually so a port that grows a real one only has to define it first.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs