### PR TITLE
gnulib: add allocator; turn off strftime's non-Gregorian calendars

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -25,6 +25,7 @@ LIB=libgnu.a$O
 
 OFILES=\
 	acl-internal.$O\
+	allocator.$O\
 	argmatch.$O\
 	asyncsafe-spin.$O\
 	backup-find.$O\

--- a/sys/src/external/gnulib/config-common.h
+++ b/sys/src/external/gnulib/config-common.h
@@ -5879,6 +5879,32 @@
 # define strnul(s) ((s) + strlen (s))
 #endif
 
+/* APExp: no non-Gregorian calendars in strftime.
+   strftime.c defaults SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME to true and
+   then calls gl_locale_name_unsafe to spot th_TH, fa_IR and the like:
+
+     nstrftime: undefined: gl_locale_name_unsafe in nstrftime
+
+   Supplying that means gnulib's localename module, which pulls in
+   localename-environ and getlocalename_l-unsafe, and the last of those
+   ends in "#error Please port ... to your platform" once its
+   glibc/macOS/Solaris/Windows arms all fail. Nothing to port to: Plan 9
+   has one locale, C.UTF-8, which is why libap's own locale machinery is
+   already a set of stubs. A calendar chosen by locale name cannot
+   trigger here.
+
+   strftime.c offers this exact escape: "You can override this via
+   AC_DEFINE([SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME], [false]) and if
+   you do that you may be able to omit Gnulib's localename module and
+   its dependencies."
+
+   Spelled 0 rather than false: it is only ever read by #if, where the
+   two are equivalent, and 0 does not depend on whether false is a macro
+   or a keyword here. */
+#ifndef SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME
+# define SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME 0
+#endif
+
 /* APExp: streq, the same case as strnul above.
    It is an inline in the generated string.h (string.in.h:812, under
    GNULIB_STREQ), so it went with that wrapper. hard-locale.c is the

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -302,6 +302,15 @@ EOF
 # define streq(a, b) (strcmp ((a), (b)) == 0)
 #endif
 
+/* APExp: no non-Gregorian calendars in strftime. Otherwise strftime.c
+   calls gl_locale_name_unsafe, which means gnulib's localename module,
+   whose getlocalename_l-unsafe.c ends in "#error Please port ... to
+   your platform". Plan 9 has one locale, so a calendar selected by
+   locale name cannot trigger. strftime.c documents this override. */
+#ifndef SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME
+# define SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME 0
+#endif
+
 /* APExp: prototypes and off64_t the deleted wrappers carried. */
 #include "apexp-decls.h"
 EOF


### PR DESCRIPTION
  _convM2D: stdlib_allocator: not defined

careadlinkat takes a struct allocator and falls back to stdlib_allocator, which is one line of allocator.c and was not in the archive. Added; its closure is empty. (The name before the colon is the last text symbol the linker saw, not the referrer.)

  nstrftime: undefined: gl_locale_name_unsafe in nstrftime

This one is better removed than satisfied. strftime.c has two calls; the first is behind __NetBSD__ || __sun and dead, but the second is live, under SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME, which the file defaults to true. It is there to notice locales like th_TH and fa_IR and switch calendar.

Satisfying it means gnulib's localename module, and that does not stop at one file: localename-unsafe.c needs gl_locale_name_environ from localename-environ.c and, since config-common.h sets HAVE_GOOD_USELOCALE and leaves HAVE_LOCALE_NULL undefined, both of its branches are live. It also needs getlocalename_l_unsafe from getlocalename_l-unsafe.c, which ends in

  #error "Please port gnulib getlocalename_l-unsafe.c to your platform!"

once its glibc, macOS, Solaris and Windows arms have all failed. There is nothing to port to. Plan 9 has one locale, C.UTF-8 -- which is why libap's locale machinery is already stubs -- so a calendar chosen by locale name can never be selected.

strftime.c offers exactly this way out: "You can override this via AC_DEFINE([SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME], [false]) and if you do that you may be able to omit Gnulib's localename module and its dependencies." Set in config-common.h and in import.sh, spelled 0 rather than false since it is only read by #if, where the two agree and 0 does not depend on whether false is a macro or a keyword here.

I had added the three localename objects before reading that far; they are backed out again in this commit, so only allocator.$O is new.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs