### PR TITLE
gnulib, diff: make the objects depend on the config headers

### DIFF
--- a/sys/src/ape/cmd/diff/mkfile
+++ b/sys/src/ape/cmd/diff/mkfile
@@ -31,6 +31,19 @@ CLEANFILES=version.c
 
 BIN=$APEXPROOT/$objtype/bin/ape
 
+# mkmany turns $HFILES into a prerequisite of every object, but only if
+# it is set before the include: the rule is expanded where it is read.
+# m4's mkfile is the one that already did this. Without it, editing this
+# directory's config.h or the shared config-common.h rebuilds nothing,
+# and the change appears to have had no effect.
+#
+# GNUSRC is defined up here for the same reason -- HFILES needs it.
+GNUSRC=$APEXPROOT/sys/src/external/gnulib
+HFILES=\
+	config.h\
+	$GNUSRC/config-common.h\
+	$GNUSRC/apexp-decls.h\
+
 <$APEXPROOT/sys/src/cmd/mkmany
 
 CC=pcc -c
@@ -64,7 +77,6 @@ CC=pcc -c
 # renames none of malloc, free, getopt_long, optarg or optind. The
 # rpl_optarg spelling came from gnulib's getopt-pfx-ext.h, which is no
 # longer reached at all.
-GNUSRC=$APEXPROOT/sys/src/external/gnulib
 CFLAGS=-B -p -D_POSIX_SOURCE -DREGEX_MALLOC -I. -I$GNUSRC -I$DIFFSRC/src \
 	-DHAVE_CONFIG_H -DDIFF_PROGRAM="/bin/diff"\
 

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -222,6 +222,24 @@ CFLAGS=-c -B -I. -I$GNUSRC -DHAVE_CONFIG_H -D_POSIX_SOURCE -D_BSD_EXTENSION\
    -DLOCALEDIR="/sys/lib/ape/locale"
 
 
+# Every object depends on the config headers.
+#
+# Without this, editing config-common.h changed nothing: mk saw each
+# object as up to date against its .c alone and rebuilt none of them, so
+# a fix landed only in modules that happened to be new that round. It
+# cost a round trip when turning off SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME
+# left nstrftime.$O still asking for gl_locale_name_unsafe.
+#
+# Listed rather than globbed: mk does not expand globs in prerequisites.
+# The recipe-less pattern rule is how mksyslib adds $HFILES; keep it
+# separate from the rules below, as mksyslib's comment says.
+HFILES=\
+	config.h\
+	$GNUSRC/config-common.h\
+	$GNUSRC/apexp-decls.h\
+
+%.$O: $HFILES			# don't combine with following %.$O rules
+
 # No two modules share a basename across these directories, so the
 # pattern rules cannot collide and mk rule ordering does not matter.
 %.$O: $GNUSRC/%.c


### PR DESCRIPTION
Turning off SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME had no effect: nstrftime still asked for gl_locale_name_unsafe. The define landed, but nothing recompiled. The gnulib mkfile's rules name only the .c file, so mk saw every object as up to date and rebuilt none of them -- allocator appeared in the archive because it was new that round, not because the header had changed.

Declared the dependency: HFILES lists config.h, config-common.h and apexp-decls.h, and a recipe-less "%.$O: $HFILES" adds them to every object. That is how mksyslib does it, kept separate from the compile rules as its comment says. Listed rather than globbed, since mk does not expand globs in prerequisites.

diff had the same gap. mkone and mkmany already carry the "%.$O: $HFILES" rule, so a package only has to set HFILES -- but before the include, because the rule is expanded where it is read. m4's mkfile was the only one doing this. GNUSRC moves above the include too, since HFILES needs it.

patch, grep, sed and bison still have the gap. They build, so they are left alone for now; the fix is one HFILES assignment above their include.

Rebuild the archive from clean this once -- mk cannot know the existing objects predate the dependency:

  cd sys/src/ape/cmd/gnulib && mk clean && mk install


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs