### PR TITLE
gnulib: add xfreopen; diff: name the source instead of $prereq

### DIFF
--- a/sys/src/ape/cmd/diff/mkfile
+++ b/sys/src/ape/cmd/diff/mkfile
@@ -80,8 +80,13 @@ CC=pcc -c
 CFLAGS=-B -p -D_POSIX_SOURCE -DREGEX_MALLOC -I. -I$GNUSRC -I$DIFFSRC/src \
 	-DHAVE_CONFIG_H -DDIFF_PROGRAM="/bin/diff"\
 
+# Name the source, not $prereq: HFILES are prerequisites too, so
+# $prereq would put config.h and friends on the pcc command line. pcc
+# happens to ignore an argument whose suffix it does not know, so this
+# was noisy rather than fatal, but it is luck either way. The sibling
+# mkfiles all spell the source out.
 %.$O: $DIFFSRC/src/%.c
-	$CC $CFLAGS $prereq
+	$CC $CFLAGS $DIFFSRC/src/$stem.c
 
 # No rule for $DIFFSRC/lib/%.c: every object comes from src or, for
 # version-etc, from the shared tree. A rule here would let a stale

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -158,6 +158,7 @@ OFILES=\
 	wmempcpy.$O\
 	xasprintf.$O\
 	xconcat-filename.$O\
+	xfreopen.$O\
 	xhash.$O\
 	xmalloca.$O\
 	xmemdup0.$O\


### PR DESCRIPTION
diff links now. diff3 wanted xfreopen, which is its own gnulib module and was not in the archive:

  main: undefined: xfreopen in main

Its closure is empty and libap has no xfreopen.

The compile lines in that same output show a wart I introduced with HFILES:

  pcc -c ... config.h .../config-common.h .../apexp-decls.h .../diff3.c

diff's pattern rule passed $prereq, which now includes the headers, so they landed on the command line. pcc ignores an argument whose suffix it does not recognise -- it only looks for .c, .o, .$O and .a -- so this was noise rather than breakage, but it is luck rather than design. Name the source instead, as every sibling mkfile already does.

Only diff was affected: it is the only package that sets HFILES besides m4, whose rules do not use $prereq. patch, tar, bison, cfront, core, perl, pkgconf and zstd also compile with $prereq, so if any of them gains HFILES later, its rules need the same treatment.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs