### PR TITLE
gnulib: record HAVE_SETLOCALE and four more; tar: drop the doubled -c

### DIFF
--- a/sys/src/ape/cmd/tar/mkfile
+++ b/sys/src/ape/cmd/tar/mkfile
@@ -94,7 +94,7 @@ CC=pcc -c
 # config-common.h. -I$GNUSRC comes next so the module headers match the
 # objects in libgnu.a. Nothing in $GTARSRC/src or $GTARSRC/lib shadows
 # an APE header, so they can follow.
-CFLAGS=-c -B -p -I. -I$GNUSRC -I$GTARSRC -I$GTARSRC/src -I$GTARSRC/lib\
+CFLAGS=-B -p -I. -I$GNUSRC -I$GTARSRC -I$GTARSRC/src -I$GTARSRC/lib\
 	-DHAVE_CONFIG_H -DLOCALEDIR="/sys/lib/ape/locale"
 
 %.$O: $GTARSRC/src/%.c

--- a/sys/src/external/gnulib/config-common.h
+++ b/sys/src/external/gnulib/config-common.h
@@ -5879,6 +5879,39 @@
 # define strnul(s) ((s) + strlen (s))
 #endif
 
+/* APExp: platform answers coreutils' configure never recorded.
+   coreutils reaches these through gnulib modules, so its config.h has
+   no line for them at all -- not even a "#undef" -- and every package
+   that tests them directly gets the default of 0. tar's lib/system.h
+   does, and the result was not a missing feature but a broken header:
+
+     #if !HAVE_SETLOCALE
+     # define setlocale(category, locale)      <-- expands to nothing
+     #endif
+
+   turned <locale.h>'s own declaration into "extern char *;"
+
+     /sys/include/ape/locale.h:49 syntax error, last name: char
+
+   All five hold here: APE has <locale.h>, <fcntl.h> and <memory.h>,
+   libap has setlocale (locale/locale_stubs.c), and struct stat has
+   st_blksize. */
+#ifndef HAVE_LOCALE_H
+# define HAVE_LOCALE_H 1
+#endif
+#ifndef HAVE_SETLOCALE
+# define HAVE_SETLOCALE 1
+#endif
+#ifndef HAVE_FCNTL_H
+# define HAVE_FCNTL_H 1
+#endif
+#ifndef HAVE_MEMORY_H
+# define HAVE_MEMORY_H 1
+#endif
+#ifndef HAVE_STRUCT_STAT_ST_BLKSIZE
+# define HAVE_STRUCT_STAT_ST_BLKSIZE 1
+#endif
+
 /* APExp: no non-Gregorian calendars in strftime.
    strftime.c defaults SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME to true and
    then calls gl_locale_name_unsafe to spot th_TH, fa_IR and the like:

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -302,6 +302,27 @@ EOF
 # define streq(a, b) (strcmp ((a), (b)) == 0)
 #endif
 
+/* APExp: platform answers coreutils' configure never recorded, because
+   it reaches these through gnulib modules. Absent entirely, not even
+   "#undef", so a package testing them directly defaults to 0 -- which
+   made tar's lib/system.h define setlocale() away and break
+   <locale.h>. All five hold on APE. */
+#ifndef HAVE_LOCALE_H
+# define HAVE_LOCALE_H 1
+#endif
+#ifndef HAVE_SETLOCALE
+# define HAVE_SETLOCALE 1
+#endif
+#ifndef HAVE_FCNTL_H
+# define HAVE_FCNTL_H 1
+#endif
+#ifndef HAVE_MEMORY_H
+# define HAVE_MEMORY_H 1
+#endif
+#ifndef HAVE_STRUCT_STAT_ST_BLKSIZE
+# define HAVE_STRUCT_STAT_ST_BLKSIZE 1
+#endif
+
 /* APExp: no non-Gregorian calendars in strftime. Otherwise strftime.c
    calls gl_locale_name_unsafe, which means gnulib's localename module,
    whose getlocalename_l-unsafe.c ends in "#error Please port ... to


### PR DESCRIPTION
  /sys/include/ape/locale.h:49 syntax error, last name: char

Not a bug in locale.h. tar's lib/system.h has

  #if !HAVE_SETLOCALE
  # define setlocale(category, locale)
  #endif

and config-common.h has no line for HAVE_SETLOCALE at all -- not even a "#undef", the way autoconf records a probe that failed. coreutils reaches setlocale through a gnulib module, so its configure never asked, and any package testing the macro directly gets the default of 0. The result was not a missing feature but a function-like macro taking two arguments, which turned locale.h's own declaration into "extern char *;"

Five such probes are referenced by tar and absent from config-common.h in that way, and all five hold here, so they are recorded in the shared file rather than in tar's: APE has <locale.h>, <fcntl.h> and <memory.h>, libap has setlocale in locale/locale_stubs.c, and struct stat has st_blksize. Guarded, so a package can still override.

Found by listing every HAVE_*, USE_* and ENABLE_* that tar tests in a conditional and subtracting those config-common.h either defines or records as absent. The other eighteen are all correctly 0 -- xattrs, POSIX ACLs, birthtime, /dev/fd, and a row of tape-drive headers from AIX, HP-UX and Xenix.

Also: CFLAGS carried a -c that CC already had, so every tar compile ran "pcc -c -c". Harmless, but it was in the failing command line.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs