### PR TITLE
stdint: make INT8_MIN..INT64_MIN usable in #if, as C99 requires

### DIFF
--- a/sys/include/ape/stdint.h
+++ b/sys/include/ape/stdint.h
@@ -76,10 +76,24 @@ typedef _uintptr_t uintptr_t;
 #define INTMAX_C(c)  c##LL
 #define UINTMAX_C(c) c##ULL
 
-#define INT8_MIN	((int8_t)0x80)
-#define INT16_MIN	((int16_t)0x8000)
-#define INT32_MIN	((int32_t)0x80000000)
-#define INT64_MIN	((int64_t)0x8000000000000000LL)
+/*
+ * C99 7.18: these macros must be usable in #if. A cast is not allowed
+ * there -- the type name is not a macro, so cpp reads it as 0 and the
+ * expression falls apart. They were spelled ((int64_t)0x8000...LL) and
+ * so on, which cost GNU tar:
+ *
+ *   list.c:744 Syntax error in #if/#elif
+ *
+ * on "#if ! (INTMAX_MAX <= UINTMAX_MAX && - (INTMAX_MIN + 1) <= UINTMAX_MAX)".
+ *
+ * -MAX-1 is the usual spelling and is well defined besides: 0x80000000
+ * has type unsigned int, since it does not fit in int, so casting it to
+ * int32_t was implementation-defined where negating the maximum is not.
+ */
+#define INT8_MIN	(-INT8_MAX-1)
+#define INT16_MIN	(-INT16_MAX-1)
+#define INT32_MIN	(-INT32_MAX-1)
+#define INT64_MIN	(-INT64_MAX-1)
 #define INTMAX_MIN	INT64_MIN
 
 #define UINT8_MIN	0


### PR DESCRIPTION
  list.c:744 Syntax error in #if/#elif

on tar's

  #if ! (INTMAX_MAX <= UINTMAX_MAX && - (INTMAX_MIN + 1) <= UINTMAX_MAX)

C99 7.18 requires these macros to be suitable for #if. All four INTn_MIN were spelled with a cast -- ((int64_t)0x8000000000000000LL) and the smaller ones likewise -- and a cast cannot appear there: a type name is not a macro, so cpp reads int64_t as 0 and the expression falls apart. INTMAX_MIN is INT64_MIN, so any conditional touching it failed.

Respelled -MAX-1, which is what glibc and musl use. It is also better defined: 0x80000000 has type unsigned int, since it does not fit in int, so casting it to int32_t was implementation-defined, while negating the maximum is not. The four MIN macros were the only casts in the header; every MAX was already plain.

Checked the values are unchanged and that both of tar's conditionals now pass, by compiling the same #if against the same definitions: -128, -32768, -2147483648, -9223372036854775808.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs