### PR TITLE
cpp: do unsigned division in #if without a compound assignment

### DIFF
--- a/sys/lib/tests/compound-assign-test.c
+++ b/sys/lib/tests/compound-assign-test.c
@@ -1,0 +1,97 @@
+/*
+ * compound-assign-test.c -- mixed-signedness compound assignment.
+ *
+ * C99 6.5.16.2p3: "A compound assignment of the form E1 op= E2 is
+ * equivalent to the simple assignment expression E1 = E1 op (E2)",
+ * bar evaluating E1 once. So the usual arithmetic conversions apply to
+ * "E1 op (E2)" first, and only then is the result converted back to
+ * the type of E1. When E1 is vlong and E2 is uvlong, the operation is
+ * therefore UNSIGNED.
+ *
+ * This came out of cpp's #if evaluator, which had
+ *
+ *   vlong rv1; ... rv1 /= (uvlong)rv2;
+ *
+ * to divide unsigned. It divided signed, so UINTMAX_MAX / 2 evaluated
+ * to 0 rather than INTMAX_MAX, and GNU tar's
+ *
+ *   #if ! (INTMAX_MAX <= UINTMAX_MAX / 2)
+ *   # error "sysinttostr: uintmax_t cannot represent all intmax_t values"
+ *
+ * fired. cpp no longer relies on the implicit conversion, so tar builds
+ * either way; this is here to say whether the compiler itself is right.
+ *
+ * The last case is the interesting comparison: the same operands via a
+ * simple assignment work. If that one passes and the compound ones
+ * fail, the fault is specifically in how op= converts its operands --
+ * most likely converting E2 to the type of E1 before operating, rather
+ * than after.
+ *
+ * Build and run:  pcc -o compound-assign-test compound-assign-test.c
+ * Prints "PASS" per case; exit status is the number of failures.
+ */
+
+#include <stdio.h>
+
+typedef long long vlong;
+typedef unsigned long long uvlong;
+
+static int failures;
+
+static void
+check(const char *what, uvlong got, uvlong want)
+{
+	if (got == want)
+		printf("PASS  %s\n", what);
+	else {
+		printf("FAIL  %s: got %llu, want %llu\n", what,
+		       (unsigned long long)got, (unsigned long long)want);
+		failures++;
+	}
+}
+
+int
+main(void)
+{
+	vlong rv1;
+	vlong rv2;
+	uvlong u;
+
+	/* -1 as a vlong is UINTMAX_MAX as a uvlong. */
+	rv1 = -1;
+	rv2 = 2;
+
+	rv1 /= (uvlong)rv2;
+	check("vlong /= (uvlong): -1 / 2", (uvlong)rv1, 0x7fffffffffffffffULL);
+
+	rv1 = -1;
+	rv2 = 2;
+	rv1 %= (uvlong)rv2;
+	check("vlong %= (uvlong): -1 % 2", (uvlong)rv1, 1);
+
+	rv1 = -1;
+	rv2 = 2;
+	rv1 = (vlong)((uvlong)rv1 / (uvlong)rv2);
+	check("vlong = (uvlong)/(uvlong) [both cast]",
+	      (uvlong)rv1, 0x7fffffffffffffffULL);
+
+	/* Simple assignment, one operand cast: the conversions should make
+	   the whole division unsigned here too. This is the case cpp's
+	   comparisons rely on, and it was working. */
+	rv1 = -1;
+	rv2 = 2;
+	u = (uvlong)rv1 / rv2;
+	check("uvlong = (uvlong)vlong / vlong [simple assign]",
+	      u, 0x7fffffffffffffffULL);
+
+	/* The comparison form, for completeness: this one was already
+	   right, which is why cpp's <= worked while its / did not. */
+	rv1 = -1;
+	check("(uvlong)vlong > 0", (uvlong)((uvlong)rv1 > 0), 1);
+
+	if (failures)
+		printf("\n%d failure(s)\n", failures);
+	else
+		printf("\nall ok\n");
+	return failures;
+}

--- a/sys/src/cmd/cpp/eval.c
+++ b/sys/src/cmd/cpp/eval.c
@@ -326,8 +326,22 @@ evalop(struct pri pri)
 				rtype = UND;
 				break;
 			}
+			/*
+			 * Spelled out rather than "rv1 /= (uvlong)rv2".
+			 * That form asks for a compound assignment whose
+			 * right operand is unsigned and whose left is not,
+			 * and the divide came out signed: UINTMAX_MAX / 2
+			 * gave 0 instead of INTMAX_MAX, so
+			 *
+			 *   #if ! (INTMAX_MAX <= UINTMAX_MAX / 2)
+			 *
+			 * fired GNU tar's #error in src/misc.c. The plain
+			 * comparisons below are unaffected, which is why
+			 * the same test in src/list.c, with the operands
+			 * reversed, passed: 0 <= INTMAX_MAX holds.
+			 */
 			if (rtype==UNS)
-				rv1 /= (uvlong)rv2;
+				rv1 = (vlong)((uvlong)rv1 / (uvlong)rv2);
 			else
 				rv1 /= rv2;
 			break;
@@ -336,8 +350,9 @@ evalop(struct pri pri)
 				rtype = UND;
 				break;
 			}
+			/* Same as SLASH above. */
 			if (rtype==UNS)
-				rv1 %= (uvlong)rv2;
+				rv1 = (vlong)((uvlong)rv1 % (uvlong)rv2);
 			else
 				rv1 %= rv2;
 			break;


### PR DESCRIPTION
The probe named it: 3a fired, "UINTMAX_MAX / 2 is 0 -- division is signed", while 4c and 4d passed, so mixed-signedness comparisons were already right. That asymmetry is the whole answer, and it explains why GNU tar's src/list.c passed while src/misc.c did not: with the division yielding 0, list.c's "UINTMAX_MAX / 2 <= INTMAX_MAX" is 0 <= INTMAX_MAX and holds, while misc.c's "INTMAX_MAX <= UINTMAX_MAX / 2" is INTMAX_MAX <= 0 and does not.

eval.c had

  vlong rv1; ... rv1 /= (uvlong)rv2;

C99 6.5.16.2p3 makes E1 op= E2 equivalent to E1 = E1 op (E2), so the usual arithmetic conversions apply to the division and it should be unsigned. It was not. The plain comparisons a few lines above -- "rv1 = (uvlong)rv1 <= rv2" -- get the same conversion right, which is why only division and modulo were affected. Those two lines were the only compound assignments in the evaluator with a right operand of a different signedness from the left; every other one takes a plain vlong.

Spelled both out as "rv1 = (vlong)((uvlong)rv1 op (uvlong)rv2)", which does not depend on how op= converts.

That leaves the compiler question open, so sys/lib/tests gains compound-assign-test.c to answer it: it runs the same operands through the compound form, the fully-cast form and the simple-assignment form, so if the compound cases fail while the simple one passes, the fault is in how op= converts its operands -- converting E2 to the type of E1 before operating rather than after. Verified the test itself is right by running it on a conforming compiler, where all five cases pass.

cpp no longer depends on the answer, so tar builds either way.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs