### PR TITLE
tar: define __getopt_argv_const for the local gnulib getopt objects

### DIFF
--- a/sys/src/ape/cmd/tar/config.h
+++ b/sys/src/ape/cmd/tar/config.h
@@ -65,6 +65,41 @@
 #define LZOP_PROGRAM     "lzop"
 
 /*
+ * __getopt_argv_const, for the gnulib getopt sources this package
+ * builds locally (see the mkfile).
+ *
+ *   getopt1.c:28 syntax error, last name: __getopt_argv_const
+ *
+ * getopt1.c declares
+ *
+ *   getopt_long (int argc, char *__getopt_argv_const *argv, ...)
+ *
+ * and upstream that macro reaches it through the generated getopt.h,
+ * by way of getopt-pfx-ext.h. That wrapper is one of the headers
+ * import.sh prunes for shadowing APE's <getopt.h>, so the name arrives
+ * undefined and the declaration will not parse.
+ *
+ * const, not empty. getopt-pfx-ext.h picks empty only under
+ * __GETOPT_PREFIX; otherwise it uses const, giving "char *const *argv",
+ * which is exactly how APE's <getopt.h> declares getopt_long. The two
+ * have to agree, since APE supplies the declaration and gnulib the
+ * definition.
+ *
+ * Note config-common.h has "#define __GETOPT_PREFIX rpl_", under which
+ * getopt-pfx-ext.h would pick empty instead. It does not apply: that
+ * prefix only takes effect through the same pruned headers, so nothing
+ * renames anything here and the getopt sources define the plain names.
+ * The value has to match APE's declaration, not gnulib's intent.
+ *
+ * Here rather than in config-common.h because tar is the only package
+ * that compiles gnulib's getopt. If another one starts, this is worth
+ * promoting.
+ */
+#ifndef __getopt_argv_const
+#define __getopt_argv_const const
+#endif
+
+/*
  * hash_delete was a deprecated synonym for hash_remove. tar 1.35 was
  * written against a gnulib that still had it; the 2026 hash.c in the
  * shared tree has only hash_remove:


### PR DESCRIPTION
  getopt1.c:28 syntax error, last name: __getopt_argv_const

getopt1.c declares

  getopt_long (int argc, char *__getopt_argv_const *argv, ...)

and upstream that macro reaches it through the generated getopt.h, by way of getopt-pfx-ext.h. That wrapper is one of the headers import.sh prunes for shadowing APE's <getopt.h>, so the name arrives undefined and the declaration will not parse. getopt1.c includes <config.h> first, so this directory's config.h is the place for it.

const, not empty, and the reasoning is not the obvious one. getopt-pfx-ext.h picks empty when __GETOPT_PREFIX is defined -- and config-common.h does define it, to rpl_. That does not apply here: the prefix only takes effect through the same pruned headers, so nothing is renamed and the getopt sources define the plain names. What the value has to match is APE's own declaration,

  int getopt_long(int, char *const *, ...);

since APE supplies the declaration and gnulib the definition. const gives char *const *argv and agrees with it.

Checked the rest of that family for the same kind of gap rather than waiting for each: argp.h defines __THROW, __NTH and error_t itself; _GL_UNUSED and _GL_ATTRIBUTE_PURE come from config.h; getopt_int.h declares _getopt_internal_r and _getopt_long_r unprefixed; and none of the argp or getopt sources reference __GETOPT_PREFIX, __BEGIN_DECLS, __nonnull or __wur.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs