### PR TITLE
gnulib: six more modules for tar; libap: initgroups

### DIFF
--- a/sys/include/ape/grp.h
+++ b/sys/include/ape/grp.h
@@ -20,6 +20,8 @@ extern struct group *getgrnam(const char *);
 extern int getgrgid_r(gid_t, struct group *, char *, size_t, struct group **);
 extern int getgrnam_r(const char *, struct group *, char *, size_t, struct group **);
 
+extern int initgroups(const char *, gid_t);
+
 extern struct group *getgrent(void);
 extern void setgrent(void);
 extern void endgrent(void);

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -74,8 +74,10 @@ OFILES=\
 	findprog-in.$O\
 	fopen-safer.$O\
 	free.$O\
+	fprintftime.$O\
 	fstrcmp.$O\
 	full-read.$O\
+	full-write.$O\
 	fts.$O\
 	get-errno.$O\
 	get-permissions.$O\
@@ -97,6 +99,7 @@ OFILES=\
 	hashcode-string2.$O\
 	hashkey-string.$O\
 	i-ring.$O\
+	imaxtostr.$O\
 	ialloc.$O\
 	integer_length.$O\
 	integer_length_l.$O\
@@ -115,6 +118,7 @@ OFILES=\
 	next-prime.$O\
 	nstrftime.$O\
 	open-safer.$O\
+	offtostr.$O\
 	openat-proc.$O\
 	openat-safer.$O\
 	opendirat.$O\
@@ -129,6 +133,7 @@ OFILES=\
 	quotearg.$O\
 	regex.$O\
 	renameatu.$O\
+	rpmatch.$O\
 	safe-read.$O\
 	same-inode.$O\
 	savedir.$O\
@@ -158,6 +163,7 @@ OFILES=\
 	timevar.$O\
 	tmpdir.$O\
 	trim.$O\
+	umaxtostr.$O\
 	unicodeio.$O\
 	unlinkdir.$O\
 	unistd.$O\

--- a/sys/src/ape/lib/ap/unistd/initgroups.c
+++ b/sys/src/ape/lib/ap/unistd/initgroups.c
@@ -1,0 +1,22 @@
+#include <sys/types.h>
+#include <grp.h>
+#include <errno.h>
+
+/*
+ * Plan 9 has no supplementary group list, so there is nothing to
+ * initialise. Fails with EPERM, as setgroups() in this directory does:
+ * callers that drop privileges test for exactly that and carry on.
+ * GNU tar's lib/rtapelib.c is one --
+ *
+ *   if (initgroups (pw->pw_name, gid) != 0 && errno != EPERM)
+ *     return "initgroups";
+ *
+ * -- so reporting the truth is better here than pretending success.
+ */
+int
+initgroups(const char *user, gid_t group)
+{
+	(void)user; (void)group;
+	errno = EPERM;
+	return -1;
+}

--- a/sys/src/ape/lib/ap/unistd/mkfile
+++ b/sys/src/ape/lib/ap/unistd/mkfile
@@ -17,6 +17,7 @@ OFILES=\
 	getcwd.$O\
 	getgid.$O\
 	getgroups.$O\
+	initgroups.$O\
 	getlogin.$O\
 	getpgid.$O\
 	getpgrp.$O\


### PR DESCRIPTION
tar compiles clean now and reaches the link. Two kinds of undefined symbol in that list.

Thirteen of them -- human_readable, mode_adjust, streamsavedir, areadlinkat_with_size, base_name, fdutimensat, mkfifoat, dir_name, cannot_unlink_dir, full_read, xgetcwd, xstrtoumax, mode_compile -- are exactly the modules added to OFILES with the tar migration, so libgnu.a has not been rebuilt since. It needs

  cd sys/src/ape/cmd/gnulib && mk install

The rest are genuinely missing and are added here: imaxtostr, offtostr and umaxtostr (each a two-line wrapper that defines anytostr and includes anytostr.c, so all three are needed, while inttostr.c itself is not), fprintftime, full-write and rpmatch. Closures are clean, and none collides with libap; rpmatch's remaining names are the gettext macros it defines itself.

initgroups is not a gnulib module and was missing from libap. Plan 9 has no supplementary group list, so it fails with EPERM the way setgroups() in the same directory does, rather than pretending success. That is what tar wants: lib/rtapelib.c has

  if (initgroups (pw->pw_name, gid) != 0 && errno != EPERM)
    return "initgroups";

so EPERM is the answer it treats as "nothing to do here". Declared in <grp.h>, next to the getgr* family.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs