### PR TITLE
termios: name the unused parameters in tcgetattr.c

### DIFF
--- a/sys/src/ape/lib/ap/termios/tcgetattr.c
+++ b/sys/src/ape/lib/ap/termios/tcgetattr.c
@@ -87,10 +87,12 @@ tcgetattr(int fd, struct termios *t)
 /* BUG: ignores optional actions */
 
 int
-tcsetattr(int fd, int, const struct termios *t)
+tcsetattr(int fd, int optional_actions, const struct termios *t)
 {
 	int n, i;
 	char buf[100];
+
+	(void)optional_actions;	/* see the BUG note above */
 
 	if(!isptty(fd)) {
 		if(!isatty(fd)) {
@@ -183,8 +185,9 @@ tcdrain(int fd)
 }
 
 int
-tcflush(int fd, int)
+tcflush(int fd, int queue_selector)
 {
+	(void)queue_selector;
 	if(!isatty(fd)){
 		errno = ENOTTY;
 		return -1;
@@ -194,8 +197,9 @@ tcflush(int fd, int)
 }
 
 int
-tcflow(int fd, int)
+tcflow(int fd, int action)
 {
+	(void)action;
 	if(!isatty(fd)){
 		errno = ENOTTY;
 		return -1;
@@ -205,8 +209,9 @@ tcflow(int fd, int)
 }
 
 int
-tcsendbreak(int fd, int)
+tcsendbreak(int fd, int duration)
 {
+	(void)duration;
 	if(!isatty(fd)){
 		errno = ENOTTY;
 		return -1;


### PR DESCRIPTION
Tidy-up, not the fix for the error that prompted it -- see below.

tcsetattr, tcflush, tcflow and tcsendbreak were defined with an unnamed second parameter, "tcsendbreak(int fd, int)". C99 6.9.1p5 requires each parameter in a definition to be named; that spelling is C++. Named them after what termios(3) calls them and marked them unused in the style setgroups.c uses, with the (void) after the declarations rather than among them.

The reported failure is not from this file:

  /sys/src/ape/lib/ap/plan9/tcgetattr.c:199 redeclaration of: tcsendbreak

There is no plan9/tcgetattr.c. It was deleted in 46d4adaf3, the reorganisation that moved these into termios/, and plan9/mkfile does not mention it. So that is a stale source left on disk from before that commit, and it wants deleting: if it ever does compile alongside termios/tcgetattr.c, both land in libap.a and every function in them is defined twice. Worth looking for other leftovers in that directory at the same time -- mk clean removes objects, not stray sources, so a from-scratch build will not clear them.

Not swept: 28 more definitions across 24 files take an unnamed parameter the same way, from setuid and umask to pthread_cond_init. libap builds today, so kencc tolerates the construct, and a 24-file change is not something to land immediately before a from-scratch build meant to catch regressions. Better on its own.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs