### PR TITLE
gnulib: add chdir-long, which save-cwd needs

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -45,6 +45,7 @@ OFILES=\
 	c-strcasecmp.$O\
 	canonicalize.$O\
 	careadlinkat.$O\
+	chdir-long.$O\
 	clean-temp.$O\
 	clean-temp-simple.$O\
 	close-stream.$O\


### PR DESCRIPTION
  restore_cwd: undefined: chdir_long in restore_cwd

save-cwd.c's restore_cwd falls back to chdir_long when it has no saved descriptor. My own closure check printed "save-cwd: chdir_long" when I added save-cwd and I did not follow it up, which cost a round trip. chdir-long.c's only outstanding name is assure, a macro in assure.h, and the openat, fchdir, chdir and close it calls are all in libap.

Also replaced the ad-hoc checking with a proper transitive closure: start from tar's objects and its locally built argp/getopt, resolve each undefined name to the module defining it, add that module, repeat to a fixed point. That is the check that would have caught this one, rather than a single pass that reports a name and leaves it.

It surfaces ten more modules, and all ten are false positives or dead code -- verified individually rather than added:

  progreloc, relocatable, xreadlink, areadlink -- one mistake, four
    modules. safe-read.c defines safe_rw and renames it with
    "#define safe_rw safe_read", so the tool cannot see that safe_read
    is already provided and blamed progreloc, which has a static copy.
    Everything downstream of that was chased for nothing.
  glthread/spin -- spin.$O is in OFILES; the tool spells it with the
    subdirectory.
  posixtm -- "year" matched inside the string literal "year(s)".
  at-func2 -- renameatu.c:269, inside #else of #if HAVE_RENAMEAT, and
    HAVE_RENAMEAT is 1.
  getfilecon -- xattrs.c:648 guards it with HAVE_SELINUX_SELINUX_H != 1,
    and that macro is undefined, so the branch holding it is skipped.
  priv-set -- unlinkdir.c guards it with PRIV_SYS_LINKDIR, Solaris only.
  strerrorname_np -- xvasprintf.c:108 guards it with
    HAVE_WORKING_STRERRORNAME_NP, undefined.

So chdir-long is the only real one, and tar's module set is closed.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs