### PR TITLE
cc: pick the compound-assignment opcode from the promoted type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,7 +481,7 @@ Adding `TVLONG`/`TUVLONG` to `typesuvinit[]` in `cc/sub.c` breaks the entire
 ABI by making vlong-returning functions use struct-return convention.
 The correct content: `{ TSTRUCT, TUNION, TCFLOAT, TCDOUBLE, -1 }`.
 
-### Mixed-signedness compound assignment is miscompiled (OPEN)
+### Mixed-signedness compound assignment (FIXED)
 
 `E1 op= E2` where E1 is signed and E2 unsigned does the operation
 **signed**. C99 6.5.16.2p3 makes it equivalent to `E1 = E1 op (E2)`, so
@@ -523,9 +523,21 @@ pair takes the first branch. The opcode is selected from `n->type`
 *after* it has been overwritten with `t`, so it is chosen from E1's type
 rather than from the type the operation is performed in.
 
-The fix is to select the opcode from the arith type before `n->type` is
-overwritten. Not applied: it touches every architecture and every
-compound assignment, and needs the self-hosting check above.
+Fixed by reading the promoted type's signedness into a local, `uns`,
+immediately after `arith(n, 0)` and before those branches overwrite
+`n->type`, then selecting the opcode from `uns`. Both sites; `OASMUL`
+and `OASLMUL` fall into the `OASDIV` case, so `*=` is covered too.
+
+The shift case above it needs no change and must not get one: C99
+6.5.7p3 gives `E1 << E2` the promoted type of the *left* operand, so
+reading the lvalue's type there is already right.
+
+Still wrong, and a separate problem: kencc performs a compound
+assignment in the lvalue's own width, casting the right operand down
+first. `long x; x /= (uvlong)y;` therefore divides in 32 bits on amd64
+where C requires 64. Fixing that means rewriting `E1 op= E2` as
+`E1 = (T1)(E1 op E2)`, far more than choosing an opcode.
+`compound-assign-test.c` reports it without counting it as a failure.
 
 Found via cpp's `#if` evaluator, which did `rv1 /= (uvlong)rv2` to
 divide unsigned. `UINTMAX_MAX / 2` came out 0, so GNU tar's

--- a/sys/lib/tests/compound-assign-test.c
+++ b/sys/lib/tests/compound-assign-test.c
@@ -89,6 +89,59 @@ main(void)
 	rv1 = -1;
 	check("(uvlong)vlong > 0", (uvlong)((uvlong)rv1 > 0), 1);
 
+	/* *= shares the OASDIV case in cc/com.c, so it takes the same
+	   path. Signed and unsigned multiply agree in the low bits, so
+	   this cannot tell them apart -- it is here to catch the block
+	   being broken outright. */
+	rv1 = -1;
+	rv2 = 3;
+	rv1 *= (uvlong)rv2;
+	check("vlong *= (uvlong): -1 * 3", (uvlong)rv1, (uvlong)(vlong)-3);
+
+	/* Shifts have their own block and were already right: C99
+	   6.5.7p3 gives the result the promoted LEFT operand's type, so
+	   reading the lvalue's type there is correct. Controls. */
+	rv1 = -1;
+	rv1 >>= 1;
+	check("vlong >>= 1 stays arithmetic", (uvlong)rv1, (uvlong)(vlong)-1);
+
+	u = ~0ULL;
+	u >>= 1;
+	check("uvlong >>= 1 is logical", u, 0x7fffffffffffffffULL);
+
+	/*
+	 * Not counted, and expected to differ: a KNOWN LIMITATION beyond
+	 * the signedness fix.
+	 *
+	 * C99 promotes the long to uvlong, divides in 64 bits unsigned,
+	 * then converts back, giving -1. kencc performs a compound
+	 * assignment in the lvalue's own width, casting the right operand
+	 * down to long first, which divides 0xffffffff by 2 and gives
+	 * 2147483647. Making this agree means rewriting E1 op= E2 as
+	 * E1 = (T1)(E1 op E2), which is a much larger change than
+	 * choosing the right opcode.
+	 */
+	{
+		long lv = -1;
+		uvlong d = 2;
+		unsigned long got, want;
+
+		/* What C requires: promote lv to uvlong, divide there,
+		   convert the result back to long. Computed rather than
+		   written out, because long is 64-bit on an LP64 host and
+		   32-bit on Plan 9 amd64, and only the narrower case can
+		   differ. */
+		want = (unsigned long)(long)(((uvlong)(long)-1) / 2);
+
+		lv /= d;
+		got = (unsigned long)lv;
+		printf("%s  long /= uvlong: got %lu, C requires %lu%s\n",
+		       got == want ? "note " : "KNOWN",
+		       got, want,
+		       got == want ? " (widths equal here, nothing to truncate)"
+				   : " -- the width limitation described above");
+	}
+
 	if (failures)
 		printf("\n%d failure(s)\n", failures);
 	else

--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -66,7 +66,7 @@ tcomo(Node *n, int f)
 {
 	Node *l, *r;
 	Type *t;
-	int o;
+	int o, uns;
 
 	if(n == Z) {
 		diag(Z, "Z in tcom");
@@ -266,6 +266,27 @@ tcomo(Node *n, int f)
 		arith(n, 0);
 		while(n->left->op == OCAST)
 			n->left = n->left->left;
+		/*
+		 * C99 6.5.16.2p3: "E1 op= E2" is equivalent to
+		 * "E1 = E1 op (E2)", so the usual arithmetic conversions
+		 * apply to the operation and only the result is converted
+		 * back to E1's type. The operation is therefore performed
+		 * in arith()'s promoted type, and that is what decides
+		 * whether it is signed.
+		 *
+		 * Read it here, before the branches below overwrite
+		 * n->type with t. They used to leave the test reading
+		 * E1's type instead, so a signed lvalue with an unsigned
+		 * operand divided signed:
+		 *
+		 *   vlong rv1 = -1, rv2 = 2;
+		 *   rv1 /= (uvlong)rv2;   gave 0, not 0x7fffffffffffffff
+		 *
+		 * mixedasop only spots an integer lvalue with a floating
+		 * operand, so a signed/unsigned pair never reached it.
+		 * See sys/lib/tests/compound-assign-test.c.
+		 */
+		uns = typeu[n->type->etype];
 		if(!mixedasop(t, n->type)) {
 			if(!sametype(t, n->type)) {
 				r = new1(OCAST, n->right, Z);
@@ -277,7 +298,7 @@ tcomo(Node *n, int f)
 			n->type = t;
 			break;
 		}
-		if(typeu[n->type->etype]) {
+		if(uns) {
 			if(n->op == OASDIV)
 				n->op = OASLDIV;
 			if(n->op == OASMUL)
@@ -326,6 +347,8 @@ tcomo(Node *n, int f)
 		arith(n, 0);
 		while(n->left->op == OCAST)
 			n->left = n->left->left;
+		/* as for OASDIV above */
+		uns = typeu[n->type->etype];
 		if(!mixedasop(t, n->type)) {
 			if(!sametype(t, n->type)) {
 				r = new1(OCAST, n->right, Z);
@@ -335,7 +358,7 @@ tcomo(Node *n, int f)
 			}
 		}else
 			n->type = t;
-		if(typeu[n->type->etype]) {
+		if(uns) {
 			if(n->op == OASMOD)
 				n->op = OASLMOD;
 		}


### PR DESCRIPTION
C99 6.5.16.2p3 makes "E1 op= E2" equivalent to "E1 = E1 op (E2)", so the usual arithmetic conversions apply to the operation and only the result is converted back to E1's type. The operation therefore happens in arith()'s promoted type, and that is what decides whether it is signed.

com.c read it from n->type after the branches below had already overwritten n->type with the lvalue's type, so a signed lvalue with an unsigned operand divided signed:

  vlong rv1 = -1, rv2 = 2;
  rv1 /= (uvlong)rv2;   gave 0, not 0x7fffffffffffffff
  rv1 %= (uvlong)rv2;   gave -1, not 1

mixedasop never caught it: it detects only an integer lvalue with a floating operand, so a signed/unsigned pair took the other branch.

Read the signedness into a local straight after arith(), before either branch runs, and select the opcode from that. Both sites -- OASDIV and OASMOD -- and OASMUL/OASLMUL fall into the OASDIV case, so *= is covered.

The shift case between them is left alone deliberately. C99 6.5.7p3 gives E1 << E2 the promoted type of the LEFT operand, so reading the lvalue's type there is already correct; "fixing" it to match the others would break it.

compound-assign-test.c grows coverage for *= and for both shift forms as controls, and an informational case for what this does not fix: kencc performs a compound assignment in the lvalue's own width, casting the right operand down first, so "long x; x /= (uvlong)y" divides in 32 bits on amd64 where C requires 64. That case computes its own expected value rather than hard-coding one, since long is 64-bit on an LP64 host and 32-bit here, and it is reported without counting as a failure.

Untested here -- kencc does not build on the machine this was written on. Needs the usual order, cc first for y.tab.h, then the arch compilers, then compound-assign-test.c, then a self-host.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs