### PR TITLE
core: version-etc per package; gnulib: fadvise, fpurge, xdecto{i,u}max;

### DIFF
--- a/sys/include/ape/stdio_ext.h
+++ b/sys/include/ape/stdio_ext.h
@@ -29,6 +29,7 @@ extern "C" {
 extern size_t __freadahead(FILE *);
 
 /* Bytes buffered for writing but not yet flushed. */
+extern void __fpurge(FILE *);
 extern size_t __fpending(FILE *);
 
 /* Set the stream's error indicator. */

--- a/sys/src/ape/cmd/core/mkfile
+++ b/sys/src/ape/cmd/core/mkfile
@@ -122,7 +122,7 @@ TARG=\
 
 # Linked into every program: mkmany puts $OFILES on each link line.
 # src/version.c is generated, not shipped -- see the foot of this file.
-OFILES=version.$O
+OFILES=version.$O version-etc.$O
 
 LIB=../gnulib/libgnu.a$O
 BIN=$APEXPROOT/$objtype/bin/ape
@@ -329,5 +329,12 @@ version.c:
 
 version.$O: version.c
 	$CC $CFLAGS version.c
+
+# version-etc is built here, not taken from the shared libgnu.a.
+# emit_bug_reporting_address() compiles PACKAGE_BUGREPORT, PACKAGE_NAME
+# and PACKAGE_URL straight into the object, so one shared copy would give
+# every program whichever package built it. Rule 5 in ../gnulib/README.
+version-etc.$O: $GNUSRC/version-etc.c
+	$CC $CFLAGS $GNUSRC/version-etc.c
 
 CLEANFILES=version.c version.h

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -76,6 +76,8 @@ OFILES=\
 	fopen-safer.$O\
 	free.$O\
 	fprintftime.$O\
+	fadvise.$O\
+	fpurge.$O\
 	fstrcmp.$O\
 	full-read.$O\
 	full-write.$O\
@@ -179,6 +181,8 @@ OFILES=\
 	wmempcpy.$O\
 	xasprintf.$O\
 	xconcat-filename.$O\
+	xdectoimax.$O\
+	xdectoumax.$O\
 	xfreopen.$O\
 	xgetcwd.$O\
 	xhash.$O\

--- a/sys/src/ape/lib/ap/stdio/stdio_ext.c
+++ b/sys/src/ape/lib/ap/stdio/stdio_ext.c
@@ -43,3 +43,20 @@ __freading(FILE *f)
 {
 	return (f->flags & F_NOWR) || f->rend != 0;
 }
+
+/* Discard whatever is buffered in either direction, without touching
+   the underlying fd. musl clears the write pointers and the read
+   pointers; there is nothing else in the buffer to drop.
+
+   gnulib's fpurge.c wants this: with neither HAVE___FPURGE nor
+   HAVE_FPURGE it falls through to a chain of per-platform branches that
+   poke at FILE by hand -- _IO_EOF_SEEN for glibc, __sferror for the
+   BSDs -- none of which describes this FILE. Supplying __fpurge and
+   setting HAVE___FPURGE puts it back on the musl branch, which is the
+   one that actually matches. */
+void
+__fpurge(FILE *f)
+{
+	f->wpos = f->wbase = f->wend = 0;
+	f->rpos = f->rend = 0;
+}

--- a/sys/src/external/gnulib/config-common.h
+++ b/sys/src/external/gnulib/config-common.h
@@ -3495,7 +3495,7 @@
 
 
 /* Define to 1 if you have the `__fpurge' function. */
-/* #undef HAVE___FPURGE */
+#define HAVE___FPURGE 1	/* APExp: libap stdio/stdio_ext.c */
 
 /* Define to 1 if you have the `__freadahead' function. */
 /* #undef HAVE___FREADAHEAD */

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -180,6 +180,15 @@ if [ -f "$DEST/config-common.h" ]; then
 	rm -f "$DEST/config-common.h.bak"
 fi
 
+# libap implements __fpurge in stdio/stdio_ext.c. Without this, fpurge.c
+# takes neither the musl nor the BSD branch and falls through to poking
+# at FILE internals it does not recognise.
+if [ -f "$DEST/config-common.h" ]; then
+	sed -i.bak 's|^/\* #undef HAVE___FPURGE \*/|#define HAVE___FPURGE 1|' \
+		"$DEST/config-common.h"
+	rm -f "$DEST/config-common.h.bak"
+fi
+
 # Guard config.h's copy of _UC_RESTRICT, the way unitypes.h guards its own.
 #
 # config.h carries a deliberate duplicate of the unitypes.h definition,


### PR DESCRIPTION
libap: __fpurge

b2sum's link, five symbols in three groups.

version_etc and emit_bug_reporting_address: version-etc is built per package, not taken from the shared archive, because emit_bug_reporting_address compiles PACKAGE_BUGREPORT, PACKAGE_NAME and PACKAGE_URL straight into the object -- rule 5 in ../gnulib/README. Added to OFILES so every one of the 91 links it, alongside version.$O.

fadvise and xnumtoimax: two modules missing from the shared archive. xnumtoimax comes from xdectoimax.c, which is four #defines over xdectoint.c and defines xdectoimax and xnumtoimax together; xdectoumax.$O added with it, since the unsigned pair will be wanted the moment another program asks. Both closures clean. fadvise's posix_fadvise call is behind HAVE_POSIX_FADVISE, which is undefined, so nothing else comes with it.

fpurge needed more than the module. With neither HAVE___FPURGE nor HAVE_FPURGE set, fpurge.c falls past the musl and BSD branches into a chain that pokes at FILE by hand -- _IO_EOF_SEEN for glibc, __sferror for the BSDs -- and none of those describes this FILE. But APE's FILE *is* musl's, so the right fix is to supply what the musl branch wants: __fpurge in libap's stdio/stdio_ext.c, two assignments as musl writes them, declared in <stdio_ext.h> and recorded as HAVE___FPURGE in config-common.h and import.sh.

That header had already declared __fpending without stdio_ext.c defining it; checked, and libap has it in stdio/_fpending.c, so that one was covered.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs