### PR TITLE
gnulib: drop acl_entries, which cannot build here

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -36,6 +36,17 @@ GNUSRC=$APEXPROOT/sys/src/external/gnulib
 #                                     see libap's, because getopt_long.c
 #                                     reaches it through
 #                                     "#define gnu_getopt_long getopt_long".
+#   acl_entries                       Unguarded: it takes an acl_t and
+#                                     assumes POSIX-draft ACLs. Nothing
+#                                     supplies acl_t here -- gnulib's
+#                                     sys/ wrappers are pruned -- and
+#                                     file-has-acl.c only calls it from a
+#                                     branch USE_ACL 0 removes.
+#                                     getfilecon.c looks similar but is
+#                                     fine: gnulib ships stub
+#                                     selinux/*.h, which this tree keeps,
+#                                     and copy.c calls lgetfilecon_raw
+#                                     with no guard at all.
 #   progreloc, relocatable            An artefact: safe-read.c defines
 #                                     safe_rw and renames it, so a scanner
 #                                     looking for safe_read finds only
@@ -47,7 +58,6 @@ LIB=libgnu.a$O
 OFILES=\
 	acl-errno-valid.$O\
 	acl-internal.$O\
-	acl_entries.$O\
 	alignalloc.$O\
 	allocator.$O\
 	areadlink.$O\
@@ -129,8 +139,8 @@ OFILES=\
 	full-write.$O\
 	get-errno.$O\
 	get-permissions.$O\
-	getfilecon.$O\
 	gethrxtime.$O\
+	getfilecon.$O\
 	getprogname.$O\
 	gettime.$O\
 	gettime-res.$O\


### PR DESCRIPTION
  acl_entries.c:34 syntax error, last name: acl

It takes an acl_t and assumes POSIX-draft ACLs; the file says as much, that it is compiled only where the system already has ACLs. Nothing supplies acl_t here, since import.sh prunes gnulib's sys/ wrappers, and file-has-acl.c reaches it only from a branch that USE_ACL 0 removes. So it comes back out of OFILES and is written into the exclusion list.

I also removed getfilecon in the same pass and have put it back. It looked like the same case -- twenty-six references to SELinux names and no USE_ACL guard -- but gnulib ships stub selinux/selinux.h, selinux/context.h and selinux/label.h, which are not pruned because APE has no counterpart to shadow. Their #if HAVE_SELINUX_SELINUX_H is false here, so the #else supplies the types and getfilecon.c compiles against them. It is also not optional: copy.c calls lgetfilecon_raw with no guard at all, so cp, mv and install need it. Judging it by a grep count rather than by whether a header made it buildable was the mistake.

Scanned the other 285 for the same shape -- an unconditional include of a header APE lacks -- and found nothing further. The two it flagged were both false: openat-priv.h is gnulib's own, matched by a pattern meant for Solaris priv.h, and APE does have spawn.h.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs