### PR TITLE
libap: make d_ino and d_type real members of struct dirent

### DIFF
--- a/sys/include/ape/dirent.h
+++ b/sys/include/ape/dirent.h
@@ -11,15 +11,37 @@
  */
 #define MAXNAMLEN 255
 
+/*
+ * d_ino and d_type are real members, filled in by readdir() from the
+ * stat information Plan 9 returns. They used to be object-like macros:
+ *
+ *	#define d_ino  d_stat.st_ino
+ *	#define d_type d_stat.st_mode
+ *
+ * which broke twice over.
+ *
+ * As macros they rewrote the names anywhere they appeared, not just
+ * after a dot. gnulib's file-has-acl.c declares a local
+ *
+ *	unsigned char d_type = flags & UCHAR_MAX;
+ *
+ * which became "unsigned char d_stat.st_mode = ...":
+ *
+ *	file-has-acl.c:463 syntax error, last name: d_stat
+ *
+ * And st_mode is not what d_type holds. DT_DIR is 4 where S_IFDIR is
+ * 0040000, so "dp->d_type == DT_DIR" was false for every directory.
+ * libap's own misc/fts.c and regex/glob.c both test d_type against
+ * these constants and were quietly getting the wrong answer.
+ *
+ * Placed after d_stat so the offsets of d_name and d_stat do not move.
+ */
 struct	dirent {
 	char	d_name[MAXNAMLEN + 1];
 	struct stat d_stat;
+	ino_t	d_ino;
+	unsigned char d_type;
 };
-
-/* d_ino compatibility macro: map to the inode field in d_stat */
-#define d_ino d_stat.st_ino
-/* d_type is not available on Plan9; define DT_ constants as stubs */
-#define d_type d_stat.st_mode
 #define DT_UNKNOWN 0
 #define DT_FIFO    1
 #define DT_CHR     2

--- a/sys/src/ape/lib/ap/dirent/readdir.c
+++ b/sys/src/ape/lib/ap/dirent/readdir.c
@@ -10,6 +10,34 @@
 
 #define DBLOCKSIZE 20
 
+/*
+ * st_mode to the d_type value readdir() reports. POSIX gives these as
+ * DT_* constants, which are small integers unrelated to the S_IF* bits,
+ * so the two have to be mapped rather than aliased.
+ *
+ * S_ISFIFO and S_ISSOCK are the same test in APE's <sys/stat.h> -- both
+ * are mode 0010000 -- so a FIFO and a socket cannot be told apart here.
+ * FIFO wins, since mkfifo() can create one and Plan 9 has no Unix-domain
+ * sockets in the filesystem.
+ */
+static unsigned char
+_dtype(mode_t m)
+{
+	if(S_ISREG(m))
+		return DT_REG;
+	if(S_ISDIR(m))
+		return DT_DIR;
+	if(S_ISCHR(m))
+		return DT_CHR;
+	if(S_ISBLK(m))
+		return DT_BLK;
+	if(S_ISLNK(m))
+		return DT_LNK;
+	if(S_ISFIFO(m))
+		return DT_FIFO;
+	return DT_UNKNOWN;
+}
+
 struct dirent *
 readdir(DIR *d)
 {
@@ -42,6 +70,8 @@ readdir(DIR *d)
 			strncpy(dr[i].d_name, dir->name, MAXNAMLEN);
 			dr[i].d_name[MAXNAMLEN] = 0;
 			_dirtostat(&dr[i].d_stat, dir, NULL);
+			dr[i].d_ino = dr[i].d_stat.st_ino;
+			dr[i].d_type = _dtype(dr[i].d_stat.st_mode);
 		}
 		d->dd_loc = 0;
 		d->dd_size = i*sizeof(struct dirent);


### PR DESCRIPTION
  file-has-acl.c:463 syntax error, last name: d_stat

on a line that says

  MAYBE_UNUSED unsigned char d_type = flags & UCHAR_MAX;

<dirent.h> had d_ino and d_type as object-like macros:

  #define d_ino  d_stat.st_ino
  #define d_type d_stat.st_mode

so that declaration became "unsigned char d_stat.st_mode = ...". A macro on a name that common rewrites it everywhere, not only after a dot, and d_type is an ordinary identifier that any program may use for a local.

The second half is worse, and was already costing us. d_type does not hold st_mode: DT_DIR is 4 where S_IFDIR is 0040000, so "dp->d_type == DT_DIR" was false for every directory. libap's own misc/fts.c and regex/glob.c each test d_type against these constants, which means fts has been treating every entry as neither a directory nor unknown, and glob likewise. Nothing in the tree depended on the old meaning -- both existing users wanted the POSIX one and were simply not getting it.

So both become real members, filled by readdir() from the stat Plan 9 already returns, with a mapping from st_mode to the DT_* values rather than an alias. They sit after d_stat, so the offsets of d_name and d_stat do not move.

One thing the mapping cannot do: S_ISFIFO and S_ISSOCK are the same test in APE's <sys/stat.h>, both mode 0010000, so a FIFO and a socket are indistinguishable. FIFO wins, mkfifo() being able to make one and Plan 9 having no Unix-domain sockets in the filesystem.

readdir.c is the only place that fills the structure; readdir_r and scandir go through it.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs