### PR TITLE
libap: add IFTODT and DTTOIF; gnulib: define _GL_DT_NOTDIR

### DIFF
--- a/sys/include/ape/dirent.h
+++ b/sys/include/ape/dirent.h
@@ -51,6 +51,40 @@ struct	dirent {
 #define DT_LNK     10
 #define DT_SOCK    12
 
+/*
+ * BSD's conversions between a stat mode and a d_type value. Real
+ * systems put these in <dirent.h>; gnulib carries its own in
+ * dirent.in.h, which import.sh prunes for shadowing this header, so
+ * without them a caller gets an implicit function:
+ *
+ *   file-has-acl.c:979  IFTODT (sb->st_mode)
+ *
+ * No DT_WHT arm: BSD whiteout entries do not exist here, and neither
+ * DT_WHT nor S_IFWHT is defined, so an unknown mode simply reports
+ * DT_UNKNOWN and an unknown type maps back through the same shift
+ * gnulib uses.
+ *
+ * S_ISFIFO and S_ISSOCK are the same test in <sys/stat.h>, both mode
+ * 0010000, so the FIFO arm is reached first and a socket cannot be
+ * distinguished -- the same limitation readdir() has when it fills
+ * d_type. DTTOIF has it in the other direction: S_IFSOCK is S_IFIFO.
+ */
+#ifndef IFTODT
+#define IFTODT(mode) \
+   (S_ISREG(mode) ? DT_REG : S_ISDIR(mode) ? DT_DIR \
+    : S_ISLNK(mode) ? DT_LNK : S_ISBLK(mode) ? DT_BLK \
+    : S_ISCHR(mode) ? DT_CHR : S_ISFIFO(mode) ? DT_FIFO \
+    : S_ISSOCK(mode) ? DT_SOCK : DT_UNKNOWN)
+#endif
+#ifndef DTTOIF
+#define DTTOIF(dirtype) \
+   ((dirtype) == DT_REG ? S_IFREG : (dirtype) == DT_DIR ? S_IFDIR \
+    : (dirtype) == DT_LNK ? S_IFLNK : (dirtype) == DT_BLK ? S_IFBLK \
+    : (dirtype) == DT_CHR ? S_IFCHR : (dirtype) == DT_FIFO ? S_IFIFO \
+    : (dirtype) == DT_SOCK ? S_IFSOCK \
+    : (dirtype) << 12)
+#endif
+
 typedef struct _dirdesc {
 	int	dd_fd;		/* file descriptor */
 	long	dd_loc;		/* buf offset of entry from last readdir() */

--- a/sys/src/external/gnulib/config-common.h
+++ b/sys/src/external/gnulib/config-common.h
@@ -5949,6 +5949,16 @@
 # define streq(a, b) (strcmp ((a), (b)) == 0)
 #endif
 
+/* APExp: _GL_DT_NOTDIR, from the deleted dirent.h wrapper.
+   file-has-acl.c and qcopy-acl.c set it in the flags word they pass to
+   file_has_aclinfo, to say the entry is known not to be a directory.
+   gnulib's own value, from dirent.in.h:102. The IFTODT beside it in
+   that file is a BSD macro rather than a gnulib one, so it went into
+   APE's <dirent.h> instead. */
+#ifndef _GL_DT_NOTDIR
+# define _GL_DT_NOTDIR 0x100
+#endif
+
 /* APExp: prototypes and off64_t that the deleted wrapper headers carried.
    See apexp-decls.h for how the list was derived. */
 #include "apexp-decls.h"

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -361,6 +361,11 @@ EOF
 # define SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME 0
 #endif
 
+/* APExp: _GL_DT_NOTDIR, from the deleted dirent.h wrapper. */
+#ifndef _GL_DT_NOTDIR
+# define _GL_DT_NOTDIR 0x100
+#endif
+
 /* APExp: prototypes and off64_t the deleted wrappers carried. */
 #include "apexp-decls.h"
 EOF


### PR DESCRIPTION
  file-has-acl.c:981 name not declared: _GL_DT_NOTDIR

Both come from dirent.in.h, the template for the generated dirent.h that import.sh prunes for shadowing APE's. Same class as strnul, streq and unreachable.

They go to different places, because they are different kinds of thing. IFTODT and DTTOIF are BSD macros that a real system puts in <dirent.h>, so APE's gets them; _GL_DT_NOTDIR is gnulib's own, a flag bit meaning "known not to be a directory", so it sits with strnul and streq in the APExp tail of config-common.h, and in import.sh.

IFTODT was the more dangerous of the two and did not announce itself. file-has-acl.c:979 calls it one line above the reported error, and with no definition in scope it was becoming an implicit function call rather than a diagnostic -- a link failure later, and the wrong value if anything had defined a function of that name.

APE's versions drop gnulib's DT_WHT arm: BSD whiteout entries do not exist here and neither DT_WHT nor S_IFWHT is defined, so an unknown mode reports DT_UNKNOWN and an unknown type falls through the same shift gnulib uses. The FIFO/socket ambiguity from the readdir change applies here too, in both directions: S_ISFIFO and S_ISSOCK are one test, and S_IFSOCK is S_IFIFO.

Checked the round trip on a conforming compiler for all six types APE distinguishes -- REG, DIR, LNK, BLK, CHR, FIFO -- mode to DT and back.

_GL_DT_NOTDIR is the only _GL_DT_* name any built module uses, and file-has-acl.c and qcopy-acl.c are the only two users.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs