### PR TITLE
gnulib: drop fseterr, which libap already provides

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -36,6 +36,18 @@ GNUSRC=$APEXPROOT/sys/src/external/gnulib
 #                                     see libap's, because getopt_long.c
 #                                     reaches it through
 #                                     "#define gnu_getopt_long getopt_long".
+#   fseterr                           libap has __fseterr and
+#                                     config-common.h sets
+#                                     HAVE___FSETERR, so fseterr.h
+#                                     redirects every caller to it with
+#                                     "#define fseterr(fp) __fseterr(fp)".
+#                                     fseterr.c carries no such guard of
+#                                     its own -- it says it is "not used
+#                                     on systems that have the __fseterr
+#                                     function" -- so building it walks
+#                                     into the #elif defined EPLAN9 arm
+#                                     and reads fp->state, which musl's
+#                                     FILE does not have.
 #   acl_entries                       Unguarded: it takes an acl_t and
 #                                     assumes POSIX-draft ACLs. Nothing
 #                                     supplies acl_t here -- gnulib's
@@ -131,7 +143,6 @@ OFILES=\
 	fprintftime.$O\
 	fpurge.$O\
 	free.$O\
-	fseterr.$O\
 	fstrcmp.$O\
 	ftoastr.$O\
 	fts.$O\


### PR DESCRIPTION
  fseterr.c:54 not a member of struct/union: state

fseterr.c has no HAVE___FSETERR branch of its own. The guard lives in fseterr.h, which under HAVE___FSETERR does

  #define fseterr(fp) __fseterr (fp)

so every caller already goes to libap's. The .c file says as much at the top -- "not used on systems that have the __fseterr function, namely OpenBSD >= 7.6, musl libc, Haiku" -- so compiling it at all was the mistake, and once compiled it walks down the platform chain to

  #elif defined EPLAN9
    if (fp->state != 0 ...)

which is the old APE FILE. APExp's is musl's and has flags, not state.

The EPLAN9 trap is already written up in import.sh, which sets HAVE___FREADAHEAD, HAVE___FSETERR, HAVE___FWRITING and HAVE___FREADING for exactly this reason -- gnulib detects Plan 9 by whether errno.h defines EPLAN9, and APE's does, at value 1002. fseterr just slipped into OFILES anyway, where the header-level guard cannot help it.

Audited the rest of that family while here. Seven gnulib files select their Plan 9 case on EPLAN9: fpending, fpurge, freadahead, freading, fwriting, fseeko and fseterr. Only fpurge and fseterr were in OFILES. fpurge is safe, because HAVE___FPURGE now makes its musl branch win first. fseterr is removed. The other five are not built.

fpending needed nothing: its header only declares __fpending, with no macro to set, and close-stream.c -- the one caller in the archive -- gets libap's.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs