### PR TITLE
ape: define ESTALE, and fill the tail of sys_errlist

### DIFF
--- a/sys/include/ape/errno.h
+++ b/sys/include/ape/errno.h
@@ -100,5 +100,17 @@ extern int *_errnoloc;
 
 #define EBADMSG		71
 
+/*
+ * Nothing in APE ever sets this -- Plan 9 has no NFS client whose
+ * handles can go stale.  It is here because POSIX requires the name and
+ * portable code tests for it unguarded: gnulib's savewd.c has
+ *
+ *	bool try_fork = errno == EACCES || errno == ESTALE;
+ *
+ * with no #ifdef.  Defining it to a value errno never takes gives that
+ * test the right answer.
+ */
+#define ESTALE		72
+
 
 #endif /* __ERRNO */

--- a/sys/src/ape/lib/ap/string/strerror.c
+++ b/sys/src/ape/lib/ap/string/strerror.c
@@ -88,6 +88,12 @@ char *sys_errlist[] = {
 
 	"Value too large for defined data type", /* EOVERFLOW */
 	"Too many symbolic links encountered",	/* ELOOP */
+
+	"Illegal byte sequence",		/* EILSEQ */
+	"State not recoverable",		/* ENOTRECOVERABLE */
+	"Owner died",				/* EOWNERDEAD */
+	"Bad message",				/* EBADMSG */
+	"Stale file handle",			/* ESTALE */
 };
 #define	_IO_nerr	(sizeof sys_errlist/sizeof sys_errlist[0])
 int sys_nerr = _IO_nerr;


### PR DESCRIPTION
gnulib's savewd.c tests

	bool try_fork = errno == EACCES || errno == ESTALE;

with no #ifdef, so ESTALE has to exist as a name even though Plan 9 has no NFS client whose handles can go stale. Defined as 72, a value errno never takes, which gives that test the right answer.

Of the errno names gnulib and coreutils compare against, ESTALE was the only one used unguarded -- EDQUOT, ENODATA, EPROTO, EIDRM, ENOLINK, EMULTIHOP, ETIME, ENOSR, ENOSTR, ENOTBLK and EREMOTE all appear only inside '#if defined' in errno-iter.c, so they stay undefined.

sys_errlist stopped at ELOOP (67) while errno.h had gone on to EBADMSG (71), so EILSEQ, ENOTRECOVERABLE, EOWNERDEAD and EBADMSG all printed as "Unknown error". Filled those in along with ESTALE; the table is now 73 entries, one per value 0..72.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs