### PR TITLE
ape: make posix_spawn honour file actions and attributes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,35 @@ with proper `extern` declaration.
 **Note:** `ts` parameter to `pthread_cond_timedwait` is **absolute** CLOCK_REALTIME
 time (POSIX). `aio_suspend`'s `ts` is **relative** — convert before calling timedwait.
 
+### process/ — posix_spawn honours file actions
+
+`sys/src/ape/lib/ap/process/posix_spawn.c` was fork+exec with every file
+action and attribute discarded — `posix_spawn_file_actions_adddup2()` and
+friends returned 0 and did nothing, so the child just inherited the parent's
+descriptors. Undetectable by the caller: gnulib's `spawn-pipe.c` wires its
+pipe to the child purely through `adddup2`, and would have got a child on the
+wrong fds with no error anywhere.
+
+Now: actions are recorded in a growable array hung off
+`posix_spawn_file_actions_t.__actions`, replayed in the child between fork
+and exec, with `SETSID`/`SETPGROUP`/`SETSIGDEF`/`SETSIGMASK` applied first.
+Child setup failures come back to the caller as the return value through a
+close-on-exec report pipe (a successful exec closes it, so the parent's read
+returns 0). `RESETIDS` and the scheduling flags are stored and returned
+faithfully but ignored — Plan 9 has no POSIX scheduler.
+
+The old file declared its own `typedef void posix_spawnattr_t;` rather than
+including `<spawn.h>`; it worked only because every use was through a
+pointer. Covered by `sys/lib/tests/posix-spawn-test.c`.
+
+Missing before, and the reason gnulib's own spawn replacement got pulled in:
+`posix_spawnattr_setsigdefault`/`getsigdefault`, `setpgroup`/`getpgroup`,
+`setschedparam`/`setschedpolicy` and their getters were declared in
+`spawn.h` but undefined in libap. **Do not build gnulib's `spawn*.c` or
+`execute.c`/`spawn-pipe.c` into the shared archive** — gnulib's
+`posix_spawnattr_t` has glibc's `_sd`/`_ss` members and does not compile
+against APE's `<spawn.h>`.
+
 ### aio/ — async I/O on pthreads
 
 `sys/src/ape/lib/ap/aio/aio.c` — complete rewrite from Copilot-generated stub.

--- a/sys/include/ape/spawn.h
+++ b/sys/include/ape/spawn.h
@@ -66,6 +66,7 @@ int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t *__restrict, int
 int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t *, int);
 int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *, int, int);
 int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t *__restrict, const char *__restrict);
+int posix_spawn_file_actions_addfchdir(posix_spawn_file_actions_t *, int);
 
 #if defined(_BSD_SOURCE) || defined(_GNU_SOURCE)
 int posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *__restrict, const char *__restrict);

--- a/sys/lib/tests/posix-spawn-test.c
+++ b/sys/lib/tests/posix-spawn-test.c
@@ -1,0 +1,332 @@
+/*
+ * posix-spawn-test.c -- posix_spawn file actions and attributes.
+ *
+ * libap's posix_spawn used to ignore file actions and attributes
+ * altogether: posix_spawn_file_actions_adddup2 and friends returned 0
+ * and did nothing, so the child simply inherited the parent's file
+ * descriptors. That is not a stub a caller can detect. gnulib's
+ * spawn-pipe.c, for one, wires its pipe to the child purely through
+ * adddup2, so it would have got a child talking to the wrong fds with
+ * no error anywhere.
+ *
+ * ap/process/posix_spawn.c now forks, replays the actions in the child
+ * and execs, reporting any setup failure back through a close-on-exec
+ * pipe. These are the cases that distinguishes the two.
+ *
+ * The child is /bin/cat, /bin/pwd and a deliberately absent name; the
+ * test is about plumbing, not about what the child does.
+ *
+ * Build and run:  pcc -o posix-spawn-test posix-spawn-test.c
+ * Prints "PASS" per case; exit status is the number of failures.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <signal.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+
+static int failures;
+
+static void
+check(const char *what, int ok, const char *detail)
+{
+	if (ok)
+		printf("PASS  %s\n", what);
+	else {
+		printf("FAIL  %s: %s\n", what, detail ? detail : "");
+		failures++;
+	}
+}
+
+/* Wait for pid, return its exit status or -1. */
+static int
+reap(pid_t pid)
+{
+	int st;
+
+	while (waitpid(pid, &st, 0) < 0)
+		if (errno != EINTR)
+			return -1;
+	if (WIFEXITED(st))
+		return WEXITSTATUS(st);
+	return -1;
+}
+
+/*
+ * cat with its stdout dup2'd onto the write end of a pipe. If adddup2 is
+ * ignored, cat writes to the test's own stdout and the read below sees
+ * EOF with nothing in it.
+ */
+static void
+test_dup2(void)
+{
+	posix_spawn_file_actions_t fa;
+	pid_t pid;
+	int p[2], q[2], err, n;
+	char buf[64];
+	char *argv[2];
+
+	if (pipe(p) < 0 || pipe(q) < 0) {
+		check("adddup2 redirects stdout", 0, "pipe failed");
+		return;
+	}
+
+	if (posix_spawn_file_actions_init(&fa) != 0) {
+		check("adddup2 redirects stdout", 0, "actions_init failed");
+		return;
+	}
+	/* child: stdin = q read end, stdout = p write end */
+	posix_spawn_file_actions_adddup2(&fa, q[0], 0);
+	posix_spawn_file_actions_adddup2(&fa, p[1], 1);
+	posix_spawn_file_actions_addclose(&fa, q[1]);
+	posix_spawn_file_actions_addclose(&fa, p[0]);
+
+	argv[0] = "cat";
+	argv[1] = NULL;
+	err = posix_spawnp(&pid, "cat", &fa, NULL, argv, NULL);
+	posix_spawn_file_actions_destroy(&fa);
+	if (err != 0) {
+		check("adddup2 redirects stdout", 0, strerror(err));
+		close(p[0]); close(p[1]); close(q[0]); close(q[1]);
+		return;
+	}
+
+	close(p[1]);
+	close(q[0]);
+	write(q[1], "hello\n", 6);
+	close(q[1]);
+
+	n = read(p[0], buf, sizeof buf - 1);
+	if (n < 0)
+		n = 0;
+	buf[n] = '\0';
+	close(p[0]);
+	reap(pid);
+
+	check("adddup2 redirects child stdout to a pipe",
+	      strcmp(buf, "hello\n") == 0, buf[0] ? buf : "read nothing");
+}
+
+/*
+ * cat with stdout opened onto a file by addopen. If addopen is ignored
+ * the file stays empty (or absent) and the output goes to the test's
+ * stdout.
+ */
+static void
+test_addopen(void)
+{
+	posix_spawn_file_actions_t fa;
+	pid_t pid;
+	int q[2], err, n, fd;
+	char buf[64];
+	char *argv[2];
+	const char *out = "spawn-test.out";
+
+	remove(out);
+	if (pipe(q) < 0) {
+		check("addopen redirects stdout to a file", 0, "pipe failed");
+		return;
+	}
+	posix_spawn_file_actions_init(&fa);
+	posix_spawn_file_actions_adddup2(&fa, q[0], 0);
+	posix_spawn_file_actions_addclose(&fa, q[1]);
+	posix_spawn_file_actions_addopen(&fa, 1, out,
+	    O_WRONLY|O_CREAT|O_TRUNC, 0666);
+
+	argv[0] = "cat";
+	argv[1] = NULL;
+	err = posix_spawnp(&pid, "cat", &fa, NULL, argv, NULL);
+	posix_spawn_file_actions_destroy(&fa);
+	if (err != 0) {
+		check("addopen redirects stdout to a file", 0, strerror(err));
+		close(q[0]); close(q[1]);
+		return;
+	}
+	close(q[0]);
+	write(q[1], "written\n", 8);
+	close(q[1]);
+	reap(pid);
+
+	n = 0;
+	fd = open(out, O_RDONLY);
+	if (fd >= 0) {
+		n = read(fd, buf, sizeof buf - 1);
+		if (n < 0)
+			n = 0;
+		close(fd);
+	}
+	buf[n] = '\0';
+	remove(out);
+
+	check("addopen redirects child stdout to a file",
+	      strcmp(buf, "written\n") == 0, n ? buf : "file empty or absent");
+}
+
+/*
+ * A child that cannot be exec'd. The error belongs in posix_spawn's
+ * return value, not in a 127 exit status the caller has to guess at --
+ * that is what the report pipe is for.
+ */
+static void
+test_enoent(void)
+{
+	pid_t pid;
+	int err;
+	char *argv[2];
+	char detail[64];
+
+	argv[0] = "no-such-program-9f3a";
+	argv[1] = NULL;
+	pid = -1;
+	err = posix_spawnp(&pid, "no-such-program-9f3a", NULL, NULL, argv, NULL);
+	sprintf(detail, "returned %d", err);
+	check("failed exec is reported through the return value",
+	      err != 0, detail);
+	if (err == 0)
+		reap(pid);
+}
+
+/*
+ * addopen of a path that does not exist: the failure happens in the
+ * child, after fork, and still has to come back as a return value.
+ */
+static void
+test_open_failure(void)
+{
+	posix_spawn_file_actions_t fa;
+	pid_t pid;
+	int err;
+	char *argv[2];
+	char detail[64];
+
+	posix_spawn_file_actions_init(&fa);
+	posix_spawn_file_actions_addopen(&fa, 1,
+	    "no-such-dir-9f3a/out", O_WRONLY|O_CREAT, 0666);
+
+	argv[0] = "true";
+	argv[1] = NULL;
+	pid = -1;
+	err = posix_spawnp(&pid, "true", &fa, NULL, argv, NULL);
+	posix_spawn_file_actions_destroy(&fa);
+	sprintf(detail, "returned %d", err);
+	check("failed file action is reported through the return value",
+	      err != 0, detail);
+	if (err == 0)
+		reap(pid);
+}
+
+/* The attribute setters have to store what they are given. */
+static void
+test_attr_roundtrip(void)
+{
+	posix_spawnattr_t at;
+	sigset_t set, got;
+	short flags;
+	pid_t pgrp;
+
+	if (posix_spawnattr_init(&at) != 0) {
+		check("attributes round-trip", 0, "attr_init failed");
+		return;
+	}
+
+	check("attr_setflags/getflags",
+	      posix_spawnattr_setflags(&at, POSIX_SPAWN_SETSIGMASK) == 0
+	      && posix_spawnattr_getflags(&at, &flags) == 0
+	      && flags == POSIX_SPAWN_SETSIGMASK, "flags did not survive");
+
+	check("attr_setpgroup/getpgroup",
+	      posix_spawnattr_setpgroup(&at, 12345) == 0
+	      && posix_spawnattr_getpgroup(&at, &pgrp) == 0
+	      && pgrp == 12345, "pgroup did not survive");
+
+	sigemptyset(&set);
+	sigaddset(&set, SIGINT);
+	check("attr_setsigmask/getsigmask",
+	      posix_spawnattr_setsigmask(&at, &set) == 0
+	      && posix_spawnattr_getsigmask(&at, &got) == 0
+	      && sigismember(&got, SIGINT) == 1, "sigmask did not survive");
+
+	sigemptyset(&set);
+	sigaddset(&set, SIGTERM);
+	check("attr_setsigdefault/getsigdefault",
+	      posix_spawnattr_setsigdefault(&at, &set) == 0
+	      && posix_spawnattr_getsigdefault(&at, &got) == 0
+	      && sigismember(&got, SIGTERM) == 1, "sigdefault did not survive");
+
+	posix_spawnattr_destroy(&at);
+}
+
+/*
+ * More actions than the initial eight-entry array, to exercise the
+ * growth path. Only the last dup2 matters to the output.
+ */
+static void
+test_many_actions(void)
+{
+	posix_spawn_file_actions_t fa;
+	pid_t pid;
+	int p[2], q[2], err, n, i;
+	char buf[64];
+	char *argv[2];
+
+	if (pipe(p) < 0 || pipe(q) < 0) {
+		check("many file actions", 0, "pipe failed");
+		return;
+	}
+	posix_spawn_file_actions_init(&fa);
+	/* Closing already-closed descriptors is not an error. */
+	for (i = 0; i < 20; i++)
+		posix_spawn_file_actions_addclose(&fa, 900 + i);
+	posix_spawn_file_actions_adddup2(&fa, q[0], 0);
+	posix_spawn_file_actions_adddup2(&fa, p[1], 1);
+	/* The child must not keep a write end of q, or it never sees
+	   EOF on its stdin once the parent closes its own. */
+	posix_spawn_file_actions_addclose(&fa, q[1]);
+	posix_spawn_file_actions_addclose(&fa, p[0]);
+
+	argv[0] = "cat";
+	argv[1] = NULL;
+	err = posix_spawnp(&pid, "cat", &fa, NULL, argv, NULL);
+	posix_spawn_file_actions_destroy(&fa);
+	if (err != 0) {
+		check("many file actions", 0, strerror(err));
+		close(p[0]); close(p[1]); close(q[0]); close(q[1]);
+		return;
+	}
+	close(p[1]);
+	close(q[0]);
+	write(q[1], "grown\n", 6);
+	close(q[1]);
+	n = read(p[0], buf, sizeof buf - 1);
+	if (n < 0)
+		n = 0;
+	buf[n] = '\0';
+	close(p[0]);
+	reap(pid);
+
+	check("action list grows past its initial size",
+	      strcmp(buf, "grown\n") == 0, buf[0] ? buf : "read nothing");
+}
+
+int
+main(void)
+{
+	test_attr_roundtrip();
+	test_dup2();
+	test_addopen();
+	test_many_actions();
+	test_enoent();
+	test_open_failure();
+
+	if (failures)
+		printf("\n%d failure(s)\n", failures);
+	else
+		printf("\nall ok\n");
+	return failures;
+}

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -59,6 +59,20 @@ GNUSRC=$APEXPROOT/sys/src/external/gnulib
 #                                     selinux/*.h, which this tree keeps,
 #                                     and copy.c calls lgetfilecon_raw
 #                                     with no guard at all.
+#   execute, spawn-pipe,              These build gnulib's own posix_spawn
+#   spawnattr_setdefault              replacement, whose posix_spawnattr_t
+#                                     has glibc's _sd/_ss members. APE's
+#                                     <spawn.h> declares the type itself
+#                                     (__def/__mask), so spawnattr_setdefault.c
+#                                     does not compile against it, and libap
+#                                     implements the whole API in
+#                                     ap/process/posix_spawn.c. Nothing in
+#                                     the shared tree calls execute() or
+#                                     create_pipe_*; bison and m4 do, but
+#                                     from their own lib/ copies. If they
+#                                     ever move here, build execute.c and
+#                                     spawn-pipe.c and let them use libap's
+#                                     posix_spawn -- do not build gnulib's.
 #   progreloc, relocatable            An artefact: safe-read.c defines
 #                                     safe_rw and renames it, so a scanner
 #                                     looking for safe_read finds only
@@ -123,7 +137,6 @@ OFILES=\
 	error.$O\
 	euidaccess.$O\
 	exclude.$O\
-	execute.$O\
 	fadvise.$O\
 	fatal-signal.$O\
 	fd-reopen.$O\
@@ -272,8 +285,6 @@ OFILES=\
 	sigsegv.$O\
 	sm3.$O\
 	sm3-stream.$O\
-	spawn-pipe.$O\
-	spawnattr_setdefault.$O\
 	stat-time.$O\
 	stdbit.$O\
 	stdlib.$O\

--- a/sys/src/ape/lib/ap/process/posix_spawn.c
+++ b/sys/src/ape/lib/ap/process/posix_spawn.c
@@ -1,101 +1,531 @@
 #include "../include/lib.h"
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <sched.h>
+#include <spawn.h>
 
 /*
- * posix_spawn / posix_spawnp - spawn a process
+ * posix_spawn / posix_spawnp -- spawn a process.
  *
- * Full posix_spawn requires spawn file actions and attributes which
- * would need substantial infrastructure. We implement the common
- * case: no file actions, no special attributes — equivalent to
- * fork() + exec(). This satisfies configure probes and programs
- * that use posix_spawn as a portable fork+exec.
+ * Implemented as fork() + exec() with the file actions replayed in the
+ * child, which is what POSIX describes and what glibc does when it has
+ * no better primitive.  The earlier version here ignored file actions
+ * and attributes entirely; that is not a stub a caller can detect, it
+ * just silently gives the child the parent's file descriptors.  gnulib's
+ * spawn-pipe.c, for one, wires up its pipe purely through adddup2, so it
+ * would have got a child talking to the wrong fds.
  *
- * Returns 0 on success with child pid in *pid, or errno on failure.
- * posix_spawn does NOT set errno — it returns the error value directly.
+ * Types come from <spawn.h>.  The old code declared its own
+ *	typedef void posix_spawnattr_t;
+ * which worked only because every use was through a pointer.
+ *
+ * Child setup failures are reported back to the parent through a
+ * close-on-exec pipe: the child writes errno into it and _exit()s, and
+ * the parent, seeing a short read, knows exec succeeded.  Without that,
+ * a failed dup2 or open would look to the caller like a successful spawn
+ * followed by a mysterious exit status.
+ *
+ * Returns 0 on success with the child pid in *pid, or an error number
+ * directly -- posix_spawn does NOT set errno.
  */
 
-/* Opaque types — enough for link-time satisfaction */
-typedef void posix_spawn_file_actions_t;
-typedef void posix_spawnattr_t;
+enum {
+	FA_CLOSE,
+	FA_DUP2,
+	FA_OPEN,
+	FA_CHDIR,
+	FA_FCHDIR,
+};
+
+typedef struct Faction Faction;
+typedef struct Falist Falist;
+
+struct Faction {
+	int	op;
+	int	fd;
+	int	newfd;
+	int	oflag;
+	mode_t	mode;
+	char	*path;		/* malloc'd, owned by the Falist */
+};
+
+struct Falist {
+	int	n;
+	int	cap;
+	Faction	*a;
+};
+
+/*
+ * The header gives posix_spawn_file_actions_t a void* plus padding; we
+ * keep a Falist* in it and nothing else, so that sizeof stays whatever
+ * the header says.
+ */
+#define FALIST(fa)	(*(Falist**)&((posix_spawn_file_actions_t*)(fa))->__actions)
+
+static Faction*
+addaction(posix_spawn_file_actions_t *fa, int op)
+{
+	Falist *l;
+	Faction *a;
+	int cap;
+
+	if(fa == NULL)
+		return NULL;
+	l = FALIST(fa);
+	if(l == NULL){
+		l = malloc(sizeof *l);
+		if(l == NULL)
+			return NULL;
+		l->n = 0;
+		l->cap = 0;
+		l->a = NULL;
+		FALIST(fa) = l;
+	}
+	if(l->n >= l->cap){
+		cap = l->cap ? 2*l->cap : 8;
+		a = realloc(l->a, cap*sizeof *a);
+		if(a == NULL)
+			return NULL;
+		l->a = a;
+		l->cap = cap;
+	}
+	a = &l->a[l->n++];
+	memset(a, 0, sizeof *a);
+	a->op = op;
+	return a;
+}
 
 int
-posix_spawn(pid_t *pid, const char *path,
-            const posix_spawn_file_actions_t *fa,
-            const posix_spawnattr_t *attr,
-            char *const argv[], char *const envp[])
+posix_spawn_file_actions_init(posix_spawn_file_actions_t *fa)
 {
+	if(fa == NULL)
+		return EINVAL;
+	memset(fa, 0, sizeof *fa);
+	return 0;
+}
+
+int
+posix_spawn_file_actions_destroy(posix_spawn_file_actions_t *fa)
+{
+	Falist *l;
+	int i;
+
+	if(fa == NULL)
+		return EINVAL;
+	l = FALIST(fa);
+	if(l != NULL){
+		for(i = 0; i < l->n; i++)
+			free(l->a[i].path);
+		free(l->a);
+		free(l);
+		FALIST(fa) = NULL;
+	}
+	return 0;
+}
+
+int
+posix_spawn_file_actions_addclose(posix_spawn_file_actions_t *fa, int fd)
+{
+	Faction *a;
+
+	if(fd < 0)
+		return EBADF;
+	if((a = addaction(fa, FA_CLOSE)) == NULL)
+		return fa == NULL ? EINVAL : ENOMEM;
+	a->fd = fd;
+	return 0;
+}
+
+int
+posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *fa, int fd, int newfd)
+{
+	Faction *a;
+
+	if(fd < 0 || newfd < 0)
+		return EBADF;
+	if((a = addaction(fa, FA_DUP2)) == NULL)
+		return fa == NULL ? EINVAL : ENOMEM;
+	a->fd = fd;
+	a->newfd = newfd;
+	return 0;
+}
+
+int
+posix_spawn_file_actions_addopen(posix_spawn_file_actions_t *fa, int fd,
+	const char *path, int oflag, mode_t mode)
+{
+	Faction *a;
+	char *p;
+
+	if(fd < 0)
+		return EBADF;
+	if(path == NULL)
+		return EINVAL;
+	if((p = strdup(path)) == NULL)
+		return ENOMEM;
+	if((a = addaction(fa, FA_OPEN)) == NULL){
+		free(p);
+		return fa == NULL ? EINVAL : ENOMEM;
+	}
+	a->fd = fd;
+	a->path = p;
+	a->oflag = oflag;
+	a->mode = mode;
+	return 0;
+}
+
+int
+posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t *fa, const char *path)
+{
+	Faction *a;
+	char *p;
+
+	if(path == NULL)
+		return EINVAL;
+	if((p = strdup(path)) == NULL)
+		return ENOMEM;
+	if((a = addaction(fa, FA_CHDIR)) == NULL){
+		free(p);
+		return fa == NULL ? EINVAL : ENOMEM;
+	}
+	a->path = p;
+	return 0;
+}
+
+int
+posix_spawn_file_actions_addfchdir(posix_spawn_file_actions_t *fa, int fd)
+{
+	Faction *a;
+
+	if(fd < 0)
+		return EBADF;
+	if((a = addaction(fa, FA_FCHDIR)) == NULL)
+		return fa == NULL ? EINVAL : ENOMEM;
+	a->fd = fd;
+	return 0;
+}
+
+int
+posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *fa, const char *path)
+{
+	return posix_spawn_file_actions_addchdir(fa, path);
+}
+
+int
+posix_spawn_file_actions_addfchdir_np(posix_spawn_file_actions_t *fa, int fd)
+{
+	return posix_spawn_file_actions_addfchdir(fa, fd);
+}
+
+/*
+ * Attributes.  Every field is real and is honoured by posix_spawn below,
+ * except the scheduling ones -- Plan 9 has no POSIX scheduler to set, so
+ * those are stored and returned faithfully but have no effect, and
+ * POSIX_SPAWN_SETSCHEDPARAM / SETSCHEDULER are quietly ignored rather
+ * than failing the spawn.
+ */
+
+int
+posix_spawnattr_init(posix_spawnattr_t *a)
+{
+	if(a == NULL)
+		return EINVAL;
+	memset(a, 0, sizeof *a);
+	return 0;
+}
+
+int
+posix_spawnattr_destroy(posix_spawnattr_t *a)
+{
+	if(a == NULL)
+		return EINVAL;
+	return 0;
+}
+
+int
+posix_spawnattr_setflags(posix_spawnattr_t *a, short f)
+{
+	static const short known =
+		POSIX_SPAWN_RESETIDS|POSIX_SPAWN_SETPGROUP|
+		POSIX_SPAWN_SETSIGDEF|POSIX_SPAWN_SETSIGMASK|
+		POSIX_SPAWN_SETSCHEDPARAM|POSIX_SPAWN_SETSCHEDULER|
+		POSIX_SPAWN_USEVFORK|POSIX_SPAWN_SETSID;
+
+	if(a == NULL)
+		return EINVAL;
+	if(f & ~known)
+		return EINVAL;
+	a->__flags = f;
+	return 0;
+}
+
+int
+posix_spawnattr_getflags(const posix_spawnattr_t *a, short *f)
+{
+	if(a == NULL || f == NULL)
+		return EINVAL;
+	*f = (short)a->__flags;
+	return 0;
+}
+
+int
+posix_spawnattr_setpgroup(posix_spawnattr_t *a, pid_t pgrp)
+{
+	if(a == NULL)
+		return EINVAL;
+	a->__pgrp = pgrp;
+	return 0;
+}
+
+int
+posix_spawnattr_getpgroup(const posix_spawnattr_t *a, pid_t *pgrp)
+{
+	if(a == NULL || pgrp == NULL)
+		return EINVAL;
+	*pgrp = a->__pgrp;
+	return 0;
+}
+
+int
+posix_spawnattr_setsigmask(posix_spawnattr_t *a, const sigset_t *s)
+{
+	if(a == NULL || s == NULL)
+		return EINVAL;
+	a->__mask = *s;
+	return 0;
+}
+
+int
+posix_spawnattr_getsigmask(const posix_spawnattr_t *a, sigset_t *s)
+{
+	if(a == NULL || s == NULL)
+		return EINVAL;
+	*s = a->__mask;
+	return 0;
+}
+
+int
+posix_spawnattr_setsigdefault(posix_spawnattr_t *a, const sigset_t *s)
+{
+	if(a == NULL || s == NULL)
+		return EINVAL;
+	a->__def = *s;
+	return 0;
+}
+
+int
+posix_spawnattr_getsigdefault(const posix_spawnattr_t *a, sigset_t *s)
+{
+	if(a == NULL || s == NULL)
+		return EINVAL;
+	*s = a->__def;
+	return 0;
+}
+
+int
+posix_spawnattr_setschedpolicy(posix_spawnattr_t *a, int pol)
+{
+	if(a == NULL)
+		return EINVAL;
+	a->__pol = pol;
+	return 0;
+}
+
+int
+posix_spawnattr_getschedpolicy(const posix_spawnattr_t *a, int *pol)
+{
+	if(a == NULL || pol == NULL)
+		return EINVAL;
+	*pol = a->__pol;
+	return 0;
+}
+
+/*
+ * <spawn.h> declares these with struct sched_param, which <sched.h>
+ * defines as a single sched_priority member.  Store the priority in
+ * __prio.
+ */
+int
+posix_spawnattr_setschedparam(posix_spawnattr_t *a, const struct sched_param *p)
+{
+	if(a == NULL || p == NULL)
+		return EINVAL;
+	a->__prio = p->sched_priority;
+	return 0;
+}
+
+int
+posix_spawnattr_getschedparam(const posix_spawnattr_t *a, struct sched_param *p)
+{
+	if(a == NULL || p == NULL)
+		return EINVAL;
+	p->sched_priority = a->__prio;
+	return 0;
+}
+
+/*
+ * Child side.  Returns the error number to report, or 0 to go on and
+ * exec.  Nothing here may allocate or use stdio -- we are between fork
+ * and exec.
+ */
+static int
+childsetup(const posix_spawn_file_actions_t *fa, const posix_spawnattr_t *at,
+	int errfd)
+{
+	Falist *l;
+	Faction *a;
+	sigset_t mask;
+	int i, fd, flags;
+
+	if(at != NULL){
+		flags = at->__flags;
+		if(flags & POSIX_SPAWN_SETSID)
+			if(setsid() < 0)
+				return errno;
+		if(flags & POSIX_SPAWN_SETPGROUP)
+			if(setpgid(0, at->__pgrp) < 0)
+				return errno;
+		if(flags & POSIX_SPAWN_SETSIGDEF)
+			for(i = 1; i < NSIG; i++)
+				if(sigismember(&at->__def, i) == 1)
+					if(signal(i, SIG_DFL) == SIG_ERR)
+						return errno;
+		if(flags & POSIX_SPAWN_SETSIGMASK){
+			mask = at->__mask;
+			if(sigprocmask(SIG_SETMASK, &mask, NULL) < 0)
+				return errno;
+		}
+		/* RESETIDS, SETSCHEDPARAM and SETSCHEDULER have no
+		 * meaning on Plan 9 and are ignored. */
+	}
+
+	if(fa == NULL)
+		return 0;
+	l = FALIST(fa);
+	if(l == NULL)
+		return 0;
+	for(i = 0; i < l->n; i++){
+		a = &l->a[i];
+		switch(a->op){
+		case FA_CLOSE:
+			if(a->fd == errfd)
+				break;	/* ours; it goes at exec */
+			if(close(a->fd) < 0 && errno != EBADF)
+				return errno;
+			break;
+		case FA_DUP2:
+			if(a->fd == a->newfd){
+				/* POSIX: clear FD_CLOEXEC, do not dup. */
+				if(fcntl(a->newfd, F_SETFD, 0) < 0)
+					return errno;
+				break;
+			}
+			if(dup2(a->fd, a->newfd) < 0)
+				return errno;
+			break;
+		case FA_OPEN:
+			fd = open(a->path, a->oflag, a->mode);
+			if(fd < 0)
+				return errno;
+			if(fd != a->fd){
+				if(dup2(fd, a->fd) < 0){
+					i = errno;
+					close(fd);
+					return i;
+				}
+				close(fd);
+			}
+			break;
+		case FA_CHDIR:
+			if(chdir(a->path) < 0)
+				return errno;
+			break;
+		case FA_FCHDIR:
+			if(fchdir(a->fd) < 0)
+				return errno;
+			break;
+		}
+	}
+	return 0;
+}
+
+static int
+spawn(pid_t *pid, const char *path,
+	const posix_spawn_file_actions_t *fa, const posix_spawnattr_t *at,
+	char *const argv[], char *const envp[], int usepath)
+{
+	int p[2], err, n, status;
 	pid_t child;
-	(void)fa; (void)attr; (void)envp;
+
+	/*
+	 * Error-reporting pipe.  Close-on-exec, so a successful exec
+	 * closes the write end and the parent's read returns 0.
+	 */
+	if(pipe(p) < 0)
+		return errno;
+	if(fcntl(p[1], F_SETFD, FD_CLOEXEC) < 0){
+		err = errno;
+		close(p[0]);
+		close(p[1]);
+		return err;
+	}
 
 	child = fork();
-	if(child < 0)
-		return errno;
+	if(child < 0){
+		err = errno;
+		close(p[0]);
+		close(p[1]);
+		return err;
+	}
 	if(child == 0){
-		execv(path, (const char **)argv);
+		close(p[0]);
+		err = childsetup(fa, at, p[1]);
+		if(err == 0){
+			if(usepath)
+				execvp(path, (const char **)argv);
+			else if(envp != NULL)
+				execve(path, (const char **)argv, (const char **)envp);
+			else
+				execv(path, (const char **)argv);
+			err = errno;
+		}
+		write(p[1], &err, sizeof err);
 		_exit(127);
+	}
+
+	close(p[1]);
+	err = 0;
+	n = read(p[0], &err, sizeof err);
+	close(p[0]);
+	if(n == (int)sizeof err && err != 0){
+		/* Reap the child so it does not linger as a zombie; the
+		 * caller was never told a pid, so nobody else will. */
+		while(waitpid(child, &status, 0) < 0 && errno == EINTR)
+			;
+		return err;
 	}
 	if(pid != NULL)
 		*pid = child;
 	return 0;
+}
+
+int
+posix_spawn(pid_t *pid, const char *path,
+	const posix_spawn_file_actions_t *fa, const posix_spawnattr_t *at,
+	char *const argv[], char *const envp[])
+{
+	return spawn(pid, path, fa, at, argv, envp, 0);
 }
 
 int
 posix_spawnp(pid_t *pid, const char *file,
-             const posix_spawn_file_actions_t *fa,
-             const posix_spawnattr_t *attr,
-             char *const argv[], char *const envp[])
+	const posix_spawn_file_actions_t *fa, const posix_spawnattr_t *at,
+	char *const argv[], char *const envp[])
 {
-	pid_t child;
-	(void)fa; (void)attr; (void)envp;
-
-	child = fork();
-	if(child < 0)
-		return errno;
-	if(child == 0){
-		execvp(file, (const char **)argv);
-		_exit(127);
-	}
-	if(pid != NULL)
-		*pid = child;
-	return 0;
+	return spawn(pid, file, fa, at, argv, envp, 1);
 }
-
-/* spawn file actions stubs — enough to satisfy link-time references */
-int posix_spawn_file_actions_init(posix_spawn_file_actions_t *fa)
-	{ (void)fa; return 0; }
-int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t *fa)
-	{ (void)fa; return 0; }
-int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t *fa, int fd)
-	{ (void)fa; (void)fd; return 0; }
-int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *fa,
-                                     int fd, int newfd)
-	{ (void)fa; (void)fd; (void)newfd; return 0; }
-int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t *fa,
-                                     int fd, const char *path,
-                                     int flags, mode_t mode)
-	{ (void)fa; (void)fd; (void)path; (void)flags; (void)mode; return 0; }
-int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t *fa,
-                                      const char *path)
-	{ (void)fa; (void)path; return 0; }
-int posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *fa,
-                                         const char *path)
-	{ (void)fa; (void)path; return 0; }
-int posix_spawn_file_actions_addfchdir_np(posix_spawn_file_actions_t *fa,
-                                          int fd)
-	{ (void)fa; (void)fd; return 0; }
-
-/* spawnattr stubs */
-int posix_spawnattr_init(posix_spawnattr_t *a)      { (void)a; return 0; }
-int posix_spawnattr_destroy(posix_spawnattr_t *a)   { (void)a; return 0; }
-int posix_spawnattr_setflags(posix_spawnattr_t *a, short f)
-	{ (void)a; (void)f; return 0; }
-int posix_spawnattr_getflags(const posix_spawnattr_t *a, short *f)
-	{ (void)a; if(f) *f=0; return 0; }
-int posix_spawnattr_setsigmask(posix_spawnattr_t *a, const sigset_t *s)
-	{ (void)a; (void)s; return 0; }
-int posix_spawnattr_getsigmask(const posix_spawnattr_t *a, sigset_t *s)
-	{ (void)a; (void)s; return 0; }


### PR DESCRIPTION
gnulib's spawnattr_setdefault.c would not compile: it writes attr->_sd, glibc's member name, while APE's own <spawn.h> declares posix_spawnattr_t with __def/__mask. The closure had pulled it in because libap declared posix_spawnattr_setsigdefault in spawn.h and never defined it -- along with setpgroup/getpgroup, setschedparam/setschedpolicy and the rest of the getters.

Rather than paper over that, ap/process/posix_spawn.c is now a real implementation. It had been fork+exec with every file action and attribute discarded: adddup2 and friends returned 0 and did nothing, so the child inherited the parent's descriptors. That is not a stub a caller can detect -- gnulib's spawn-pipe.c wires its pipe to the child purely through adddup2, and would have got a child on the wrong fds with no error anywhere.

Actions are now recorded in a growable array hung off the __actions member and replayed in the child, with SETSID, SETPGROUP, SETSIGDEF and SETSIGMASK applied first. Setup failures come back as posix_spawn's return value through a close-on-exec report pipe, so a failed dup2 or open is no longer a mysterious 127 exit. RESETIDS and the scheduling flags are stored and returned faithfully but ignored, Plan 9 having no POSIX scheduler.

The old file declared its own 'typedef void posix_spawnattr_t' instead of including <spawn.h>; it worked only because every use was through a pointer.

execute.$O, spawn-pipe.$O and spawnattr_setdefault.$O drop out of the shared gnulib archive, with the reason recorded next to the other deliberate omissions. Nothing in the shared tree calls execute() or create_pipe_*; bison and m4 do, from their own lib/ copies.

New test sys/lib/tests/posix-spawn-test.c covers dup2 and open redirection, list growth past its initial size, the attribute round-trips and both error-reporting paths. Verified against glibc's posix_spawn, where it passes.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs