### PR TITLE
ape: sigsets held three signals; execvp never searched PATH; EDQUOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,58 @@ with proper `extern` declaration.
 **Note:** `ts` parameter to `pthread_cond_timedwait` is **absolute** CLOCK_REALTIME
 time (POSIX). `aio_suspend`'s `ts` is **relative** — convert before calling timedwait.
 
+### signal/ — sigset_t held only three signals
+
+`ap/signal/sigset.c` gated every operation on
+
+```c
+static sigset_t stdsigs = SIGHUP|SIGINT|SIGQUIT|...|SIGUSR2;
+```
+
+which ORs the signal **numbers** together, not their bits: `1|2|3|…|13` is
+15. `sigaddset`/`sigdelset`/`sigismember` all tested `BITSIG(signo)` (i.e.
+`2<<signo`) against that, so only signals 0, 1 and 2 were accepted — everything
+else returned `-1`/`EINVAL` and changed nothing, and `sigfillset()` produced a
+set naming SIGHUP and SIGINT alone.
+
+Silent, because almost nothing checks `sigaddset`'s return value: the caller
+just got an empty mask and blocked nothing. Fixed to accept every signal in
+`signal.h` (1..NSIG-1). `_psigblocked` is the only sigset the rest of libap
+keeps, and it is only saved and restored (`sigprocmask`, `notetramp`) — never
+tested against a signal number — so no stored set changed meaning.
+Covered by `sys/lib/tests/sigset-test.c`. Found via
+`posix_spawnattr_setsigdefault`, whose test put SIGTERM (11) in a set and got
+an empty one back.
+
+### process/ — execvp searches PATH
+
+`execvp`, `execvpe` and `execlp` each carried
+
+```
+BUG: instead of looking at PATH env variable,
+just try prepending /bin/ if name fails...
+```
+
+Fine while everything is in `/bin`; wrong under APExp, where the APE binaries
+live in `/$objtype/bin/ape` and are reached through PATH. Every coreutils
+program that ends in `execvp()` — `env`, `nohup`, `timeout`, `chroot`,
+`stdbuf` — could therefore only run things in `/bin`.
+
+New `ap/process/execpath.c` holds `_execpath()`, shared by all three: a name
+containing `/` is used as given, otherwise each PATH element is tried
+(empty element = cwd), and the reported errno is EACCES if some candidate
+existed but could not be run, else ENOENT. `/bin` is the fallback when PATH
+is unset, and is also tried last, so nothing that worked before stops.
+
+Each candidate is `access(X_OK)`-checked before exec is attempted, because in
+APE **a failed `execve()` is not free**: it has already done
+`_RFORK(RFCENVG)`, rewritten `/env/_fdinfo` and `/env/_sighdlr`, and closed
+every `FD_CLOEXEC` descriptor by the time the exec itself is tried. Which is
+also why `posix_spawn` cannot report exec failures in the parent — its
+close-on-exec report pipe is gone before exec is attempted, so an exec failure
+surfaces only as the child exiting 127. POSIX leaves that unspecified;
+glibc reports it, APE does not.
+
 ### process/ — posix_spawn honours file actions
 
 `sys/src/ape/lib/ap/process/posix_spawn.c` was fork+exec with every file
@@ -372,10 +424,9 @@ wrong fds with no error anywhere.
 Now: actions are recorded in a growable array hung off
 `posix_spawn_file_actions_t.__actions`, replayed in the child between fork
 and exec, with `SETSID`/`SETPGROUP`/`SETSIGDEF`/`SETSIGMASK` applied first.
-Child setup failures come back to the caller as the return value through a
-close-on-exec report pipe (a successful exec closes it, so the parent's read
-returns 0). `RESETIDS` and the scheduling flags are stored and returned
-faithfully but ignored — Plan 9 has no POSIX scheduler.
+Setup failures come back to the caller as the return value through a
+close-on-exec report pipe. `RESETIDS` and the scheduling flags are stored and
+returned faithfully but ignored — Plan 9 has no POSIX scheduler.
 
 The old file declared its own `typedef void posix_spawnattr_t;` rather than
 including `<spawn.h>`; it worked only because every use was through a

--- a/sys/include/ape/errno.h
+++ b/sys/include/ape/errno.h
@@ -112,5 +112,20 @@ extern int *_errnoloc;
  */
 #define ESTALE		72
 
+/*
+ * Like ESTALE: no APE call sets these, but portable code tests for them
+ * without an #ifdef and needs the names.  coreutils' copy.c and ln.c
+ * classify link(2) and copy_file_range(2) failures with EDQUOT, and its
+ * selinux.c, ls.c and chcon.c with ENODATA -- coreutils' own system.h
+ * falls back to "#define ENODATA (-1)", which then aliases ENODATA onto
+ * a value no errno ever has, in a different way, less visibly.
+ */
+#define EDQUOT		73
+#define ENODATA		74
+
+/* glibc spells EDEADLK this way too; coreutils' getlimits.c prints it
+ * under "#if defined EDEADLOCK && EDEADLOCK == EDEADLK". */
+#define EDEADLOCK	EDEADLK
+
 
 #endif /* __ERRNO */

--- a/sys/lib/tests/posix-spawn-test.c
+++ b/sys/lib/tests/posix-spawn-test.c
@@ -169,27 +169,35 @@ test_addopen(void)
 }
 
 /*
- * A child that cannot be exec'd. The error belongs in posix_spawn's
- * return value, not in a 127 exit status the caller has to guess at --
- * that is what the report pipe is for.
+ * A child that cannot be exec'd. POSIX leaves it unspecified whether
+ * this comes back as posix_spawn's return value or as the child exiting
+ * 127; either is a pass, and what must not happen is a spawn that looks
+ * entirely successful.
+ *
+ * On APE it is always the 127, because execve() closes FD_CLOEXEC
+ * descriptors -- the report pipe among them -- before it attempts the
+ * exec, so the child has nothing left to write to when exec fails.
  */
 static void
 test_enoent(void)
 {
 	pid_t pid;
-	int err;
+	int err, status;
 	char *argv[2];
-	char detail[64];
+	char detail[80];
 
 	argv[0] = "no-such-program-9f3a";
 	argv[1] = NULL;
 	pid = -1;
 	err = posix_spawnp(&pid, "no-such-program-9f3a", NULL, NULL, argv, NULL);
-	sprintf(detail, "returned %d", err);
-	check("failed exec is reported through the return value",
-	      err != 0, detail);
-	if (err == 0)
-		reap(pid);
+	if (err != 0) {
+		check("failed exec is diagnosed", 1, NULL);
+		return;
+	}
+	status = reap(pid);
+	sprintf(detail, "spawn returned 0 and the child exited %d, not 127",
+	        status);
+	check("failed exec is diagnosed", status == 127, detail);
 }
 
 /*

--- a/sys/lib/tests/sigset-test.c
+++ b/sys/lib/tests/sigset-test.c
@@ -1,0 +1,176 @@
+/*
+ * sigset-test.c -- sigemptyset/sigfillset/sigaddset/sigdelset/sigismember.
+ *
+ * libap's ap/signal/sigset.c had
+ *
+ *	static sigset_t stdsigs = SIGHUP|SIGINT|SIGQUIT|SIGILL|SIGABRT|
+ *		SIGFPE|SIGKILL|SIGSEGV|SIGPIPE|SIGALRM|SIGTERM|
+ *		SIGUSR1|SIGUSR2;
+ *
+ * which ORs the signal NUMBERS together rather than their bits, giving
+ * 15. Every one of these functions then tested its signal's bit against
+ * that, so only signals 0, 1 and 2 were accepted; sigaddset (SIGTERM)
+ * returned -1/EINVAL and added nothing, and sigfillset() produced a set
+ * naming SIGHUP and SIGINT alone.
+ *
+ * It was quiet because almost nothing checks sigaddset's return value:
+ * the caller just got an empty mask and blocked nothing. Found through
+ * posix_spawnattr_setsigdefault, whose test built a set holding SIGTERM
+ * and got back a set holding nothing.
+ *
+ * Build and run:  pcc -o sigset-test sigset-test.c
+ * Prints "PASS" per case; exit status is the number of failures.
+ */
+
+#include <stdio.h>
+#include <signal.h>
+#include <errno.h>
+#include <string.h>
+
+static int failures;
+
+static void
+check(const char *what, int ok, const char *detail)
+{
+	if (ok)
+		printf("PASS  %s\n", what);
+	else {
+		printf("FAIL  %s%s%s\n", what, detail ? ": " : "",
+		       detail ? detail : "");
+		failures++;
+	}
+}
+
+/* Signals every POSIX system has, spread across the range so that a
+   mask that only covers the low bits cannot pass by accident. */
+static const struct {
+	int	sig;
+	const char *name;
+} sigs[] = {
+	{ SIGHUP,  "SIGHUP"  },
+	{ SIGINT,  "SIGINT"  },
+	{ SIGQUIT, "SIGQUIT" },
+	{ SIGILL,  "SIGILL"  },
+	{ SIGABRT, "SIGABRT" },
+	{ SIGFPE,  "SIGFPE"  },
+	{ SIGKILL, "SIGKILL" },
+	{ SIGSEGV, "SIGSEGV" },
+	{ SIGPIPE, "SIGPIPE" },
+	{ SIGALRM, "SIGALRM" },
+	{ SIGTERM, "SIGTERM" },
+	{ SIGUSR1, "SIGUSR1" },
+	{ SIGUSR2, "SIGUSR2" },
+	{ SIGCHLD, "SIGCHLD" },
+	{ SIGCONT, "SIGCONT" },
+	{ SIGSTOP, "SIGSTOP" },
+	{ SIGTSTP, "SIGTSTP" },
+	{ SIGTTIN, "SIGTTIN" },
+	{ SIGTTOU, "SIGTTOU" },
+};
+#define NSIGS ((int)(sizeof sigs / sizeof sigs[0]))
+
+int
+main(void)
+{
+	sigset_t set;
+	char detail[128];
+	int i, bad;
+
+	/* Every one of them must be addable, then reported present. */
+	bad = -1;
+	sigemptyset(&set);
+	for (i = 0; i < NSIGS; i++)
+		if (sigaddset(&set, sigs[i].sig) != 0) {
+			bad = i;
+			break;
+		}
+	if (bad >= 0)
+		sprintf(detail, "sigaddset(%s=%d) failed, errno %d",
+		        sigs[bad].name, sigs[bad].sig, errno);
+	check("sigaddset accepts every standard signal", bad < 0, detail);
+
+	bad = -1;
+	for (i = 0; i < NSIGS; i++)
+		if (sigismember(&set, sigs[i].sig) != 1) {
+			bad = i;
+			break;
+		}
+	if (bad >= 0)
+		sprintf(detail, "%s=%d is not in the set it was added to",
+		        sigs[bad].name, sigs[bad].sig);
+	check("sigismember finds every signal added", bad < 0, detail);
+
+	/* Distinctness: deleting one must not disturb the others. This is
+	   what catches an encoding where several signals share a bit. */
+	sigdelset(&set, SIGTERM);
+	check("sigdelset removes exactly one signal",
+	      sigismember(&set, SIGTERM) == 0
+	      && sigismember(&set, SIGINT) == 1
+	      && sigismember(&set, SIGUSR1) == 1
+	      && sigismember(&set, SIGCHLD) == 1, "neighbours changed too");
+
+	/* An empty set holds nothing. */
+	bad = -1;
+	sigemptyset(&set);
+	for (i = 0; i < NSIGS; i++)
+		if (sigismember(&set, sigs[i].sig) != 0) {
+			bad = i;
+			break;
+		}
+	if (bad >= 0)
+		sprintf(detail, "%s is in an empty set", sigs[bad].name);
+	check("sigemptyset empties the set", bad < 0, detail);
+
+	/* A full set holds everything. This was the most visible symptom:
+	   sigfillset returned a set naming two signals. */
+	bad = -1;
+	sigfillset(&set);
+	for (i = 0; i < NSIGS; i++)
+		if (sigismember(&set, sigs[i].sig) != 1) {
+			bad = i;
+			break;
+		}
+	if (bad >= 0)
+		sprintf(detail, "%s=%d missing from a full set",
+		        sigs[bad].name, sigs[bad].sig);
+	check("sigfillset fills the set", bad < 0, detail);
+
+	/* Out-of-range signals are still refused. */
+	sigemptyset(&set);
+	errno = 0;
+	check("sigaddset rejects signal 0",
+	      sigaddset(&set, 0) == -1 && errno == EINVAL, "not EINVAL");
+	errno = 0;
+	check("sigaddset rejects a negative signal",
+	      sigaddset(&set, -1) == -1 && errno == EINVAL, "not EINVAL");
+	errno = 0;
+	check("sigaddset rejects a signal above the range",
+	      sigaddset(&set, 1000) == -1 && errno == EINVAL, "not EINVAL");
+
+	/* sigprocmask round-trip: whatever the encoding, a mask set and
+	   read back has to name the same signals. */
+	{
+		sigset_t old, got;
+
+		sigemptyset(&set);
+		sigaddset(&set, SIGTERM);
+		sigaddset(&set, SIGUSR2);
+		if (sigprocmask(SIG_SETMASK, &set, &old) == 0
+		 && sigprocmask(SIG_SETMASK, &set, &got) == 0) {
+			check("sigprocmask round-trips a mask",
+			      sigismember(&got, SIGTERM) == 1
+			      && sigismember(&got, SIGUSR2) == 1
+			      && sigismember(&got, SIGINT) == 0,
+			      "mask came back different");
+			sigprocmask(SIG_SETMASK, &old, NULL);
+		} else
+			check("sigprocmask round-trips a mask", 0,
+			      "sigprocmask failed");
+	}
+
+	if (failures)
+		printf("\n%d failure(s)\n", failures);
+	else
+		printf("\nall ok\n");
+	return failures;
+}

--- a/sys/src/ape/lib/ap/process/execlp.c
+++ b/sys/src/ape/lib/ap/process/execlp.c
@@ -1,26 +1,10 @@
 #include <unistd.h>
-#include <string.h>
-#include <sys/limits.h>
-
-/*
- * BUG: instead of looking at PATH env variable,
- * just try prepending /bin/ if name fails...
- */
 
 extern char **environ;
+extern int _execpath(const char *, const char **, const char **);
 
 int
 execlp(const char *name, const char *arg0, ...)
 {
-	int n;
-	char buf[PATH_MAX];
-
-	if((n=execve(name, &arg0, environ)) < 0){
-		if(strchr("/.", name[0]) != 0 || strlen(name) >= sizeof(buf)-5)
-			return n;
-		strcpy(buf, "/bin/");
-		strcpy(buf+5, name);
-		n = execve(buf, &arg0, environ);
-	}
-	return n;
+	return _execpath(name, &arg0, (const char **)environ);
 }

--- a/sys/src/ape/lib/ap/process/execpath.c
+++ b/sys/src/ape/lib/ap/process/execpath.c
@@ -1,0 +1,117 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/limits.h>
+
+/*
+ * _execpath -- the PATH search behind execvp, execvpe and execlp.
+ *
+ * Those three used to share this instead:
+ *
+ *	BUG: instead of looking at PATH env variable,
+ *	just try prepending /bin/ if name fails...
+ *
+ * which is fine while everything lives in /bin, and wrong the moment it
+ * does not.  Under APExp the APE binaries are in /$objtype/bin/ape,
+ * reached through PATH, so "env foo", "nohup foo", "timeout 5 foo" and
+ * every other coreutils program that ends in execvp() could only run
+ * things in /bin.
+ *
+ * POSIX rules, as far as they apply here:
+ *   - a name containing '/' is used as given, with no search;
+ *   - otherwise each PATH element is tried in turn, an empty element
+ *     meaning the current directory;
+ *   - the errno reported is the most informative of those seen: EACCES
+ *     if some candidate existed but could not be run, else ENOENT.
+ * The ENOEXEC-means-run-it-as-a-shell-script rule is not implemented,
+ * as it was not before.
+ *
+ * Each candidate is checked with access(X_OK) before exec is attempted,
+ * because in APE a failed execve() is not free: it has already done
+ * _RFORK(RFCENVG), rewritten /env/_fdinfo and /env/_sighdlr, and closed
+ * every FD_CLOEXEC descriptor by the time the exec itself is tried.  A
+ * search that blindly exec'd each candidate would pay all of that once
+ * per PATH element.
+ *
+ * If PATH is unset, "/bin" is used -- the same place the old code
+ * looked.  /bin is also tried as a last resort when PATH is set but
+ * yielded nothing, so no caller that worked before stops working.
+ */
+
+extern char **environ;
+
+static int
+tryexec(const char *path, const char **argv, const char **envp, int *saved)
+{
+	if(access(path, X_OK) < 0){
+		if(errno == EACCES)
+			*saved = EACCES;
+		return -1;
+	}
+	execve(path, argv, envp);
+	/* Only reached if the exec failed. */
+	if(errno == EACCES)
+		*saved = EACCES;
+	return -1;
+}
+
+int
+_execpath(const char *file, const char **argv, const char **envp)
+{
+	char buf[PATH_MAX];
+	const char *path, *p, *e;
+	int saved;
+	size_t flen, dlen;
+
+	if(file == NULL || *file == '\0'){
+		errno = ENOENT;
+		return -1;
+	}
+	if(strchr(file, '/') != NULL){
+		execve(file, argv, envp);
+		return -1;
+	}
+
+	flen = strlen(file);
+	saved = ENOENT;
+
+	path = getenv("PATH");
+	if(path == NULL)
+		path = "/bin";
+
+	for(p = path; ; p = e + 1){
+		e = strchr(p, ':');
+		if(e == NULL)
+			e = p + strlen(p);
+		dlen = e - p;
+		if(dlen == 0){
+			/* Empty element: the current directory. */
+			if(flen + 3 > sizeof buf)
+				goto next;
+			memcpy(buf, "./", 2);
+			memcpy(buf + 2, file, flen + 1);
+		}else{
+			if(dlen + 1 + flen + 1 > sizeof buf)
+				goto next;
+			memcpy(buf, p, dlen);
+			if(buf[dlen-1] != '/')
+				buf[dlen++] = '/';
+			memcpy(buf + dlen, file, flen + 1);
+		}
+		tryexec(buf, argv, envp, &saved);
+	next:
+		if(*e == '\0')
+			break;
+	}
+
+	/* Last resort, matching what execvp did before it searched PATH. */
+	if(flen + 6 <= sizeof buf){
+		memcpy(buf, "/bin/", 5);
+		memcpy(buf + 5, file, flen + 1);
+		tryexec(buf, argv, envp, &saved);
+	}
+
+	errno = saved;
+	return -1;
+}

--- a/sys/src/ape/lib/ap/process/execvp.c
+++ b/sys/src/ape/lib/ap/process/execvp.c
@@ -1,24 +1,10 @@
 #include <unistd.h>
-#include <sys/limits.h>
-#include <string.h>
 
 extern char **environ;
-
-/*
- * BUG: instead of looking at PATH env variable,
- * just try prepending /bin/ if name fails...
- */
+extern int _execpath(const char *, const char **, const char **);
 
 int
 execvp(const char *name, const char **argv)
 {
-	int n;
-	char buf[PATH_MAX];
-
-	if((n=execve(name, argv, environ)) < 0){
-		strcpy(buf, "/bin/");
-		strcpy(buf+5, name);
-		n = execve(buf, argv, environ);
-	}
-	return n;
+	return _execpath(name, argv, (const char **)environ);
 }

--- a/sys/src/ape/lib/ap/process/execvpe.c
+++ b/sys/src/ape/lib/ap/process/execvpe.c
@@ -1,20 +1,12 @@
 #include <unistd.h>
-#include <sys/limits.h>
-#include <string.h>
+
+extern int _execpath(const char *, const char **, const char **);
 
 /*
- * execvpe: execvp with explicit environment.
- * GNU extension; equivalent to execvp but uses envp instead of environ.
+ * execvpe: execvp with an explicit environment. GNU extension.
  */
 int
 execvpe(const char *name, char *const argv[], char *const envp[])
 {
-	char buf[PATH_MAX];
-
-	if(execve(name, (const char **)argv, (const char **)envp) < 0){
-		strcpy(buf, "/bin/");
-		strcpy(buf+5, name);
-		execve(buf, (const char **)argv, (const char **)envp);
-	}
-	return -1;
+	return _execpath(name, (const char **)argv, (const char **)envp);
 }

--- a/sys/src/ape/lib/ap/process/mkfile
+++ b/sys/src/ape/lib/ap/process/mkfile
@@ -7,6 +7,7 @@ OFILES=\
 	execle.$O\
 	execlp.$O\
 	execv.$O\
+	execpath.$O\
 	execve.$O\
 	execvp.$O\
 	fork.$O\

--- a/sys/src/ape/lib/ap/process/posix_spawn.c
+++ b/sys/src/ape/lib/ap/process/posix_spawn.c
@@ -30,6 +30,16 @@
  * a failed dup2 or open would look to the caller like a successful spawn
  * followed by a mysterious exit status.
  *
+ * A failed EXEC, though, cannot be reported this way in APE, and shows
+ * up only as the child exiting 127.  APE's execve() closes every
+ * FD_CLOEXEC descriptor (and rewrites /env/_fdinfo, and does
+ * _RFORK(RFCENVG)) BEFORE it attempts the exec, so by the time exec
+ * fails and returns, the report pipe the child would write to is
+ * already gone.  POSIX allows this -- whether posix_spawn() diagnoses
+ * an exec failure in the parent or leaves it as a 127 exit status is
+ * explicitly unspecified -- but it differs from glibc, where both are
+ * reported through the return value.
+ *
  * Returns 0 on success with the child pid in *pid, or an error number
  * directly -- posix_spawn does NOT set errno.
  */
@@ -493,6 +503,10 @@ spawn(pid_t *pid, const char *path,
 			else
 				execv(path, (const char **)argv);
 			err = errno;
+			if(err == 0)
+				err = ENOEXEC;
+			/* The write below is very likely to go nowhere:
+			 * see the note on exec failure at the top. */
 		}
 		write(p[1], &err, sizeof err);
 		_exit(127);

--- a/sys/src/ape/lib/ap/signal/sigset.c
+++ b/sys/src/ape/lib/ap/signal/sigset.c
@@ -2,14 +2,48 @@
 #include <errno.h>
 
 /*
- * sigsets are 32-bit longs.  if the 2<<(i-1) bit is on,
- * the signal #define'd as i in signal.h is inluded.
+ * sigsets are longs.  The signal #define'd as i in signal.h is in the
+ * set when bit i+1 is on, i.e. BITSIG(i).  Signals run 1..NSIG-1, so the
+ * top bit used is NSIG, 28, which fits a 32-bit long with room to spare.
+ *
+ * The set of signals these calls accept used to be
+ *
+ *	static sigset_t stdsigs = SIGHUP|SIGINT|SIGQUIT|...|SIGUSR2;
+ *
+ * which ORs the signal NUMBERS together rather than their bits: 1|2|3|
+ * 4|5|6|7|8|9|10|11|12|13 is 15.  Every one of these functions then
+ * tested BITSIG(signo) against that, so only signals whose bit landed
+ * inside 0xf were accepted -- signals 0, 1 and 2 -- and sigaddset() of
+ * anything else returned -1/EINVAL.  sigfillset() filled in 15, a set
+ * naming SIGHUP and SIGINT and nothing else.
+ *
+ * That was quiet, because almost nothing checks sigaddset's return
+ * value: the caller got an empty set and blocked or defaulted no
+ * signals at all.  Found through posix_spawnattr_setsigdefault, whose
+ * test built a set containing SIGTERM (11) and got back a set
+ * containing nothing.
+ *
+ * Every signal in signal.h is now accepted.  There is no reason to
+ * refuse the ones Plan 9 cannot deliver -- POSIX only requires that the
+ * names exist, and a program that puts SIGCHLD in a mask and gets
+ * EINVAL is worse off than one whose mask simply never fires.
+ *
+ * _psigblocked, the only sigset the rest of libap keeps, is just saved
+ * and restored (sigprocmask, notetramp) and never tested a signal
+ * against, so no stored set changes meaning here.
  */
 
-static sigset_t stdsigs = SIGHUP|SIGINT|SIGQUIT|SIGILL|SIGABRT|SIGFPE|SIGKILL|
-		SIGSEGV|SIGPIPE|SIGALRM|SIGTERM|SIGUSR1|SIGUSR2;
+#define BITSIG(s)	(2<<(s))
 
-#define BITSIG(s) (2<<(s))
+static int
+badsig(int signo)
+{
+	if(signo <= 0 || signo >= NSIG){
+		errno = EINVAL;
+		return 1;
+	}
+	return 0;
+}
 
 int
 sigemptyset(sigset_t *set)
@@ -21,47 +55,38 @@ sigemptyset(sigset_t *set)
 int
 sigfillset(sigset_t *set)
 {
-	*set = stdsigs;
+	sigset_t s;
+	int i;
+
+	s = 0;
+	for(i = 1; i < NSIG; i++)
+		s |= BITSIG(i);
+	*set = s;
 	return 0;
 }
 
 int
 sigaddset(sigset_t *set, int signo)
 {
-	int b;
-
-	b = BITSIG(signo);
-	if(!(b&stdsigs)){
-		errno = EINVAL;
+	if(badsig(signo))
 		return -1;
-	}
-	*set |= b;
+	*set |= BITSIG(signo);
 	return 0;
 }
 
 int
 sigdelset(sigset_t *set, int signo)
 {
-	int b;
-
-	b = BITSIG(signo);
-	if(!(b&stdsigs)){
-		errno = EINVAL;
+	if(badsig(signo))
 		return -1;
-	}
-	*set &= ~b;
+	*set &= ~BITSIG(signo);
 	return 0;
 }
 
 int
-sigismember(sigset_t *set, int signo)
+sigismember(const sigset_t *set, int signo)
 {
-	int b;
-
-	b = BITSIG(signo);
-	if(!(b&stdsigs)){
-		errno = EINVAL;
+	if(badsig(signo))
 		return -1;
-	}
-	return (b&*set)? 1 : 0;
+	return (*set & BITSIG(signo)) ? 1 : 0;
 }

--- a/sys/src/ape/lib/ap/string/strerror.c
+++ b/sys/src/ape/lib/ap/string/strerror.c
@@ -94,6 +94,8 @@ char *sys_errlist[] = {
 	"Owner died",				/* EOWNERDEAD */
 	"Bad message",				/* EBADMSG */
 	"Stale file handle",			/* ESTALE */
+	"Disk quota exceeded",			/* EDQUOT */
+	"No data available",			/* ENODATA */
 };
 #define	_IO_nerr	(sizeof sys_errlist/sizeof sys_errlist[0])
 int sys_nerr = _IO_nerr;


### PR DESCRIPTION
Three findings from the posix-spawn test and the coreutils build.

sigset.c gated every operation on

	static sigset_t stdsigs = SIGHUP|SIGINT|SIGQUIT|...|SIGUSR2;

which ORs the signal NUMBERS together rather than their bits: 1|2|3|...|13 is 15. sigaddset, sigdelset and sigismember all tested BITSIG(signo), 2<<signo, against that, so only signals 0, 1 and 2 were accepted -- everything else returned -1/EINVAL and changed nothing -- and sigfillset() produced a set naming SIGHUP and SIGINT alone.

Quiet, because almost nothing checks sigaddset's return value: the caller just got an empty mask and blocked nothing. Now every signal in signal.h is accepted. _psigblocked is the only sigset the rest of libap keeps and it is only saved and restored, never tested against a signal number, so no stored set changes meaning.

execvp, execvpe and execlp each carried

	BUG: instead of looking at PATH env variable,
	just try prepending /bin/ if name fails...

Fine while everything is in /bin, wrong under APExp where the APE binaries live in /$objtype/bin/ape and are reached through PATH. Every coreutils program that ends in execvp() -- env, nohup, timeout, chroot, stdbuf -- could only run things in /bin. New ap/process/execpath.c holds the shared search: a name with a slash is used as given, otherwise each PATH element is tried, and the errno reported is EACCES if a candidate existed but could not be run, else ENOENT. /bin is the fallback when PATH is unset and is also tried last, so nothing that worked before stops.

Candidates are access(X_OK)-checked before exec, because in APE a failed execve() has already done _RFORK(RFCENVG), rewritten /env/_fdinfo and /env/_sighdlr, and closed every FD_CLOEXEC descriptor by the time the exec itself is attempted.

That last point is also why posix_spawn cannot diagnose a failed exec in the parent: its close-on-exec report pipe is gone before the exec is tried, so an exec failure surfaces only as the child exiting 127. POSIX leaves this unspecified. Documented, and the test now accepts either.

EDQUOT and ENODATA join ESTALE as names portable code tests for without an #ifdef -- coreutils' copy.c and ln.c classify link and copy_file_range failures with EDQUOT, and selinux.c, ls.c and chcon.c with ENODATA. EDEADLOCK is added as glibc's alias for EDEADLK, which getlimits.c prints under a guard requiring the two to be equal. All three get sys_errlist entries.

New test sys/lib/tests/sigset-test.c; both it and the updated posix-spawn-test pass against glibc.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs