### PR TITLE
gnulib: define HAVE_LCHOWN, which lived in the pruned unistd.h

### DIFF
--- a/sys/src/external/gnulib/config-common.h
+++ b/sys/src/external/gnulib/config-common.h
@@ -5912,6 +5912,25 @@
 # define HAVE_STRUCT_STAT_ST_BLKSIZE 1
 #endif
 
+/* APExp: HAVE_LCHOWN, which lives in the generated unistd.h rather than
+   in config.h -- it is @HAVE_LCHOWN@ in unistd.in.h, and that wrapper is
+   pruned here. coreutils' copy.c reads it as a C value, not with #ifdef:
+
+     if (HAVE_LCHOWN && (lchownat (dst_dirfd, dst_relname, ...) != 0)
+
+   so an absent definition is a compile error rather than a silently
+   disabled feature. 0 is the truthful answer: APE has no lchown, and
+   gnulib's lchown.c -- which this archive does build -- then compiles
+   its !HAVE_LCHOWN arm, the one that refuses to chown a symlink.
+
+   Every other @-substituted name the built sources read as a C
+   expression is either in a comment (LOCALENAME_ENHANCE_LOCALE_FUNCS,
+   strftime.c:70) or in a module not built here (REPLACE_FCHDIR,
+   fdopendir.c). */
+#ifndef HAVE_LCHOWN
+# define HAVE_LCHOWN 0
+#endif
+
 /* APExp: no non-Gregorian calendars in strftime.
    strftime.c defaults SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME to true and
    then calls gl_locale_name_unsafe to spot th_TH, fa_IR and the like:

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -352,6 +352,25 @@ EOF
 # define HAVE_STRUCT_STAT_ST_BLKSIZE 1
 #endif
 
+/* APExp: HAVE_LCHOWN, which lives in the generated unistd.h rather than
+   in config.h -- it is @HAVE_LCHOWN@ in unistd.in.h, and that wrapper is
+   pruned here. coreutils' copy.c reads it as a C value, not with #ifdef:
+
+     if (HAVE_LCHOWN && (lchownat (dst_dirfd, dst_relname, ...) != 0)
+
+   so an absent definition is a compile error rather than a silently
+   disabled feature. 0 is the truthful answer: APE has no lchown, and
+   gnulib's lchown.c -- which this archive does build -- then compiles
+   its !HAVE_LCHOWN arm, the one that refuses to chown a symlink.
+
+   Every other @-substituted name the built sources read as a C
+   expression is either in a comment (LOCALENAME_ENHANCE_LOCALE_FUNCS,
+   strftime.c:70) or in a module not built here (REPLACE_FCHDIR,
+   fdopendir.c). */
+#ifndef HAVE_LCHOWN
+# define HAVE_LCHOWN 0
+#endif
+
 /* APExp: no non-Gregorian calendars in strftime. Otherwise strftime.c
    calls gl_locale_name_unsafe, which means gnulib's localename module,
    whose getlocalename_l-unsafe.c ends in "#error Please port ... to


### PR DESCRIPTION
HAVE_LCHOWN is @HAVE_LCHOWN@ in unistd.in.h, so it reaches a normal build through the generated unistd.h rather than through config.h -- and that wrapper is one of the 23 shadowing headers import.sh prunes.

coreutils' copy.c reads it as a C value rather than with #ifdef:

	if (HAVE_LCHOWN && (lchownat (dst_dirfd, dst_relname, ...) != 0)

so its absence is a compile error, not a quietly disabled feature. 0 is the truthful answer: APE has no lchown, and gnulib's lchown.c, which the archive does build, then compiles its !HAVE_LCHOWN arm -- the one that refuses to chown a symlink.

Checked the rest of that class while here: of the 1828 @-substituted names in the pruned *.in.h wrappers, 26 are referenced by sources this tree compiles, and HAVE_LCHOWN is the only one read as a C expression. LOCALENAME_ENHANCE_LOCALE_FUNCS appears in a comment in strftime.c, and REPLACE_FCHDIR only in fdopendir.c, which is not in OFILES. The others are all #if-tested, where undefined already means 0.

In import.sh too, so a re-import keeps it.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs