### PR TITLE
gnulib: regenerate the stub selinux headers; add hashcode-file-inode

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -73,6 +73,13 @@ GNUSRC=$APEXPROOT/sys/src/external/gnulib
 #                                     ever move here, build execute.c and
 #                                     spawn-pipe.c and let them use libap's
 #                                     posix_spawn -- do not build gnulib's.
+#   hash-triple-simple                The old name for hashcode-named-file:
+#                                     same triple_hash, triple_compare_ino_str
+#                                     and triple_free, and hash-triple.h is
+#                                     three lines that include
+#                                     hashcode-file.h and #warning that it
+#                                     is deprecated. Building both would
+#                                     define each of those twice.
 #   progreloc, relocatable            An artefact: safe-read.c defines
 #                                     safe_rw and renames it, so a scanner
 #                                     looking for safe_read finds only
@@ -180,6 +187,7 @@ OFILES=\
 	group-member.$O\
 	hard-locale.$O\
 	hash.$O\
+	hashcode-file-inode.$O\
 	hashcode-named-file.$O\
 	hashcode-string1.$O\
 	hashcode-string2.$O\

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -124,6 +124,48 @@ if [ -f "$DEST/fts.in.h" ]; then
 	echo "generated fts_.h from fts.in.h"
 fi
 
+# Regenerate the stub selinux/*.h from their templates.
+#
+# Same shape as fts_.h above: the copy loop takes these as pre-generated
+# headers from whichever package shipped one, and the one in the tree was
+# generated from a 2022 gnulib. coreutils' copy.c calls the "_raw"
+# variants unconditionally --
+#
+#   if (0 <= lgetfilecon_raw (src_name, &con_raw))
+#     if (setfscreatecon_raw (con_raw) < 0)
+#
+# -- and the 2022 stub declares only the non-raw ones, so cp, mv and
+# ginstall failed to link:
+#   set_process_security_ctx: undefined: lgetfilecon_raw
+#   set_process_security_ctx: undefined: setfscreatecon_raw
+# The current se-selinux.in.h has all of them.
+#
+# The substitutions: USE_SELINUX_SELINUX_H is 0 here (no libselinux, so
+# the stub arm is the one that compiles), which makes INCLUDE_NEXT and
+# NEXT_SELINUX_SELINUX_H dead but they still have to go somewhere.
+# PRAGMA_SYSTEM_HEADER and PRAGMA_COLUMNS are empty for the same reason
+# they are empty everywhere else in this tree: they are GCC pragmas.
+for t in se-selinux se-context se-label; do
+	case $t in
+	se-selinux) out=selinux/selinux.h ;;
+	se-context) out=selinux/context.h ;;
+	se-label)   out=selinux/label.h ;;
+	esac
+	[ -f "$DEST/$t.in.h" ] || continue
+	mkdir -p "$DEST/selinux"
+	{
+		echo "/* DO NOT EDIT! GENERATED AUTOMATICALLY from $t.in.h */"
+		sed -e 's|@PRAGMA_SYSTEM_HEADER@||g' \
+		    -e 's|@PRAGMA_COLUMNS@||g' \
+		    -e 's|@USE_SELINUX_SELINUX_H@|0|g' \
+		    -e 's|@INCLUDE_NEXT@|include_next|g' \
+		    -e 's|@NEXT_SELINUX_SELINUX_H@|<selinux/selinux.h>|g' \
+		    -e 's|@GUARD_PREFIX@|GL|g' \
+		    "$DEST/$t.in.h"
+	} > "$DEST/$out"
+	echo "generated $out from $t.in.h"
+done
+
 # Generate gmp.h, the wrapper over mini-gmp.
 #
 # coreutils' src/basenc.c and src/factor.c include <gmp.h> with no

--- a/sys/src/external/gnulib/selinux/context.h
+++ b/sys/src/external/gnulib/selinux/context.h
@@ -1,6 +1,6 @@
-/* DO NOT EDIT! GENERATED AUTOMATICALLY! */
+/* DO NOT EDIT! GENERATED AUTOMATICALLY from se-context.in.h */
 /* SELinux-related headers.
-   Copyright (C) 2007-2022 Free Software Foundation, Inc.
+   Copyright (C) 2007-2026 Free Software Foundation, Inc.
 
    This file is free software: you can redistribute it and/or modify
    it under the terms of the GNU Lesser General Public License as
@@ -18,68 +18,73 @@
 /* Written by Jim Meyering, 2007.  */
 
 #ifndef SELINUX_CONTEXT_H
-# define SELINUX_CONTEXT_H
+#define SELINUX_CONTEXT_H
 
-# include <errno.h>
-
-#ifndef _GL_INLINE_HEADER_BEGIN
+/* This file uses _GL_INLINE_HEADER_BEGIN, _GL_INLINE, _GL_UNNAMED.  */
+#if !_GL_CONFIG_H_INCLUDED
  #error "Please include config.h first."
 #endif
+
+#include <errno.h>
+
 _GL_INLINE_HEADER_BEGIN
 #ifndef SE_CONTEXT_INLINE
 # define SE_CONTEXT_INLINE _GL_INLINE
 #endif
 
-/* _GL_ATTRIBUTE_MAYBE_UNUSED declares that it is not a programming mistake if
-   the entity is not used.  The compiler should not warn if the entity is not
-   used.  */
-#ifndef _GL_ATTRIBUTE_MAYBE_UNUSED
-# if 0 /* no GCC or clang version supports this yet */
-#  define _GL_ATTRIBUTE_MAYBE_UNUSED [[__maybe_unused__]]
-# elif defined __GNUC__ || defined __clang__
-#  define _GL_ATTRIBUTE_MAYBE_UNUSED __attribute__ ((__unused__))
+/* _GL_UNNAMED (ID) is the "name" of an unnamed function parameter.  */
+#ifndef _GL_UNNAMED
+# if ((defined __STDC_VERSION__ ? __STDC_VERSION__ : 0) < 202311 \
+      && !defined __cplusplus)
+#  define _GL_UNNAMED(id) unnamed_##id _GL_ATTRIBUTE_UNUSED
 # else
-#  define _GL_ATTRIBUTE_MAYBE_UNUSED
+#  define _GL_UNNAMED(id)
 # endif
 #endif
 
-typedef int context_t;
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+typedef struct selinux_context_t *context_t;
 SE_CONTEXT_INLINE context_t
-context_new (_GL_ATTRIBUTE_MAYBE_UNUSED char const *s)
-  { errno = ENOTSUP; return 0; }
+context_new (char const *_GL_UNNAMED (s))
+  { errno = ENOTSUP; return (context_t) 0; }
 SE_CONTEXT_INLINE char *
-context_str (_GL_ATTRIBUTE_MAYBE_UNUSED context_t con)
-  { errno = ENOTSUP; return (void *) 0; }
-SE_CONTEXT_INLINE void context_free (_GL_ATTRIBUTE_MAYBE_UNUSED context_t c) {}
+context_str (context_t _GL_UNNAMED (con))
+  { errno = ENOTSUP; return (char *) 0; }
+SE_CONTEXT_INLINE void context_free (context_t _GL_UNNAMED (c)) {}
 
 SE_CONTEXT_INLINE int
-context_user_set (_GL_ATTRIBUTE_MAYBE_UNUSED context_t sc,
-                  _GL_ATTRIBUTE_MAYBE_UNUSED char const *s)
+context_user_set (context_t _GL_UNNAMED (sc), char const *_GL_UNNAMED (s))
   { errno = ENOTSUP; return -1; }
 SE_CONTEXT_INLINE int
-context_role_set (_GL_ATTRIBUTE_MAYBE_UNUSED context_t sc,
-                  _GL_ATTRIBUTE_MAYBE_UNUSED char const *s)
+context_role_set (context_t _GL_UNNAMED (sc), char const *_GL_UNNAMED (s))
   { errno = ENOTSUP; return -1; }
 SE_CONTEXT_INLINE int
-context_range_set (_GL_ATTRIBUTE_MAYBE_UNUSED context_t sc,
-                   _GL_ATTRIBUTE_MAYBE_UNUSED char const *s)
+context_range_set (context_t _GL_UNNAMED (sc), char const *_GL_UNNAMED (s))
   { errno = ENOTSUP; return -1; }
 SE_CONTEXT_INLINE int
-context_type_set (_GL_ATTRIBUTE_MAYBE_UNUSED context_t sc,
-                  _GL_ATTRIBUTE_MAYBE_UNUSED char const *s)
+context_type_set (context_t _GL_UNNAMED (sc), char const *_GL_UNNAMED (s))
   { errno = ENOTSUP; return -1; }
 SE_CONTEXT_INLINE char *
-context_type_get (_GL_ATTRIBUTE_MAYBE_UNUSED context_t sc)
-  { errno = ENOTSUP; return (void *) 0; }
+context_type_get (context_t _GL_UNNAMED (sc))
+  { errno = ENOTSUP; return (char *) 0; }
 SE_CONTEXT_INLINE char *
-context_range_get (_GL_ATTRIBUTE_MAYBE_UNUSED context_t sc)
-  { errno = ENOTSUP; return (void *) 0; }
+context_range_get (context_t _GL_UNNAMED (sc))
+  { errno = ENOTSUP; return (char *) 0; }
 SE_CONTEXT_INLINE char *
-context_role_get (_GL_ATTRIBUTE_MAYBE_UNUSED context_t sc)
-  { errno = ENOTSUP; return (void *) 0; }
+context_role_get (context_t _GL_UNNAMED (sc))
+  { errno = ENOTSUP; return (char *) 0; }
 SE_CONTEXT_INLINE char *
-context_user_get (_GL_ATTRIBUTE_MAYBE_UNUSED context_t sc)
-  { errno = ENOTSUP; return (void *) 0; }
+context_user_get (context_t _GL_UNNAMED (sc))
+  { errno = ENOTSUP; return (char *) 0; }
+
+
+#ifdef __cplusplus
+}
+#endif
 
 _GL_INLINE_HEADER_END
 

--- a/sys/src/external/gnulib/selinux/label.h
+++ b/sys/src/external/gnulib/selinux/label.h
@@ -1,6 +1,6 @@
-/* DO NOT EDIT! GENERATED AUTOMATICALLY! */
+/* DO NOT EDIT! GENERATED AUTOMATICALLY from se-label.in.h */
 /* Replacement <selinux/label.h> for platforms that lack it.
-   Copyright 2020-2022 Free Software Foundation, Inc.
+   Copyright 2020-2026 Free Software Foundation, Inc.
 
    This file is free software: you can redistribute it and/or modify
    it under the terms of the GNU Lesser General Public License as
@@ -18,53 +18,68 @@
 /* Written by Paul Eggert.  */
 
 #ifndef SELINUX_LABEL_H
-
 #define SELINUX_LABEL_H
+
+/* This file uses _GL_INLINE_HEADER_BEGIN, _GL_INLINE, _GL_UNNAMED.  */
+#if !_GL_CONFIG_H_INCLUDED
+ #error "Please include config.h first."
+#endif
 
 #include <selinux/selinux.h>
 #include <errno.h>
 
-#ifndef _GL_INLINE_HEADER_BEGIN
- #error "Please include config.h first."
-#endif
 _GL_INLINE_HEADER_BEGIN
 #ifndef SE_LABEL_INLINE
 # define SE_LABEL_INLINE _GL_INLINE
 #endif
 
-/* _GL_ATTRIBUTE_MAYBE_UNUSED declares that it is not a programming mistake if
-   the entity is not used.  The compiler should not warn if the entity is not
-   used.  */
-#ifndef _GL_ATTRIBUTE_MAYBE_UNUSED
-# if 0 /* no GCC or clang version supports this yet */
-#  define _GL_ATTRIBUTE_MAYBE_UNUSED [[__maybe_unused__]]
-# elif defined __GNUC__ || defined __clang__
-#  define _GL_ATTRIBUTE_MAYBE_UNUSED __attribute__ ((__unused__))
+/* _GL_UNNAMED (ID) is the "name" of an unnamed function parameter.  */
+#ifndef _GL_UNNAMED
+# if ((defined __STDC_VERSION__ ? __STDC_VERSION__ : 0) < 202311 \
+      && !defined __cplusplus)
+#  define _GL_UNNAMED(id) unnamed_##id _GL_ATTRIBUTE_UNUSED
 # else
-#  define _GL_ATTRIBUTE_MAYBE_UNUSED
+#  define _GL_UNNAMED(id)
 # endif
 #endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 #define SELABEL_CTX_FILE 0
 
 struct selabel_handle;
 
 SE_LABEL_INLINE int
-selabel_lookup (_GL_ATTRIBUTE_MAYBE_UNUSED struct selabel_handle *hnd,
-                _GL_ATTRIBUTE_MAYBE_UNUSED char **context,
-                _GL_ATTRIBUTE_MAYBE_UNUSED char const *key,
-                _GL_ATTRIBUTE_MAYBE_UNUSED int type)
+selabel_lookup (struct selabel_handle *_GL_UNNAMED (hnd),
+                char **_GL_UNNAMED (context),
+                char const *_GL_UNNAMED (key),
+                int _GL_UNNAMED (type))
+{ errno = ENOTSUP; return -1; }
+
+SE_LABEL_INLINE int
+selabel_lookup_raw (struct selabel_handle *_GL_UNNAMED (hnd),
+                    char **_GL_UNNAMED (context),
+                    char const *_GL_UNNAMED (key),
+                    int _GL_UNNAMED (type))
 { errno = ENOTSUP; return -1; }
 
 SE_LABEL_INLINE struct selabel_handle *
-selabel_open (_GL_ATTRIBUTE_MAYBE_UNUSED int backend,
-              _GL_ATTRIBUTE_MAYBE_UNUSED struct selinux_opt *options,
-              _GL_ATTRIBUTE_MAYBE_UNUSED unsigned nopt)
-{ errno = ENOTSUP; return 0; }
+selabel_open (int _GL_UNNAMED (backend),
+              struct selinux_opt *_GL_UNNAMED (options),
+              unsigned _GL_UNNAMED (nopt))
+{ errno = ENOTSUP; return (struct selabel_handle *) 0; }
 
 SE_LABEL_INLINE void
-selabel_close (_GL_ATTRIBUTE_MAYBE_UNUSED struct selabel_handle *hnd)
+selabel_close (struct selabel_handle *_GL_UNNAMED (hnd))
 { errno = ENOTSUP; }
+
+
+#ifdef __cplusplus
+}
+#endif
 
 _GL_INLINE_HEADER_END
 

--- a/sys/src/external/gnulib/selinux/selinux.h
+++ b/sys/src/external/gnulib/selinux/selinux.h
@@ -1,6 +1,6 @@
-/* DO NOT EDIT! GENERATED AUTOMATICALLY! */
+/* DO NOT EDIT! GENERATED AUTOMATICALLY from se-selinux.in.h */
 /* Replacement <selinux/selinux.h> for platforms that lack it.
-   Copyright (C) 2008-2022 Free Software Foundation, Inc.
+   Copyright (C) 2008-2026 Free Software Foundation, Inc.
 
    This file is free software: you can redistribute it and/or modify
    it under the terms of the GNU Lesser General Public License as
@@ -20,37 +20,41 @@
 #endif
 
 
-#if HAVE_SELINUX_SELINUX_H
+#if 0
 
-#include_next 
+#include_next <selinux/selinux.h>
 
 #else
 # if !defined _GL_SELINUX_SELINUX_H
 #  define _GL_SELINUX_SELINUX_H
 
-#  include <sys/types.h>
+/* This file uses _GL_INLINE_HEADER_BEGIN, _GL_INLINE, _GL_UNNAMED.  */
+#  if !_GL_CONFIG_H_INCLUDED
+#   error "Please include config.h first."
+#  endif
+
+#  include <sys/types.h> /* for mode_t */
 #  include <errno.h>
 
-#  ifndef _GL_INLINE_HEADER_BEGIN
-    #error "Please include config.h first."
-#  endif
 _GL_INLINE_HEADER_BEGIN
 #  ifndef SE_SELINUX_INLINE
 #   define SE_SELINUX_INLINE _GL_INLINE
 #  endif
 
-/* _GL_ATTRIBUTE_MAYBE_UNUSED declares that it is not a programming mistake if
-   the entity is not used.  The compiler should not warn if the entity is not
-   used.  */
-#  ifndef _GL_ATTRIBUTE_MAYBE_UNUSED
-#   if 0 /* no GCC or clang version supports this yet */
-#    define _GL_ATTRIBUTE_MAYBE_UNUSED [[__maybe_unused__]]
-#   elif defined __GNUC__ || defined __clang__
-#    define _GL_ATTRIBUTE_MAYBE_UNUSED __attribute__ ((__unused__))
+/* _GL_UNNAMED (ID) is the "name" of an unnamed function parameter.  */
+#  ifndef _GL_UNNAMED
+#   if ((defined __STDC_VERSION__ ? __STDC_VERSION__ : 0) < 202311 \
+        && !defined __cplusplus)
+#    define _GL_UNNAMED(id) unnamed_##id _GL_ATTRIBUTE_UNUSED
 #   else
-#    define _GL_ATTRIBUTE_MAYBE_UNUSED
+#    define _GL_UNNAMED(id)
 #   endif
 #  endif
+
+#  ifdef __cplusplus
+extern "C" {
+#  endif
+
 
 #  if !GNULIB_defined_security_types
 
@@ -59,73 +63,108 @@ struct selinux_opt;
 #   define is_selinux_enabled() 0
 
 SE_SELINUX_INLINE int
-getcon (_GL_ATTRIBUTE_MAYBE_UNUSED char **con)
+getcon (char **_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+getcon_raw (char **_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE void
-freecon (_GL_ATTRIBUTE_MAYBE_UNUSED char *con) {}
+freecon (char *_GL_UNNAMED (con)) {}
 
 SE_SELINUX_INLINE int
-getfscreatecon (_GL_ATTRIBUTE_MAYBE_UNUSED char **con)
+getfscreatecon (char **_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-setfscreatecon (_GL_ATTRIBUTE_MAYBE_UNUSED char const *con)
+getfscreatecon_raw (char **_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-matchpathcon (_GL_ATTRIBUTE_MAYBE_UNUSED char const *file,
-              _GL_ATTRIBUTE_MAYBE_UNUSED mode_t m,
-              _GL_ATTRIBUTE_MAYBE_UNUSED char **con)
+setfscreatecon (char const *_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-getfilecon (_GL_ATTRIBUTE_MAYBE_UNUSED char const *file,
-            _GL_ATTRIBUTE_MAYBE_UNUSED char **con)
+setfscreatecon_raw (char const *_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-lgetfilecon (_GL_ATTRIBUTE_MAYBE_UNUSED char const *file,
-             _GL_ATTRIBUTE_MAYBE_UNUSED char **con)
+matchpathcon (char const *_GL_UNNAMED (file), mode_t _GL_UNNAMED (m),
+              char **_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-fgetfilecon (int fd,_GL_ATTRIBUTE_MAYBE_UNUSED char **con)
+getfilecon (char const *_GL_UNNAMED (file), char **_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-setfilecon (_GL_ATTRIBUTE_MAYBE_UNUSED char const *file,
-            _GL_ATTRIBUTE_MAYBE_UNUSED char const *con)
+getfilecon_raw (char const *_GL_UNNAMED (file), char **_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-lsetfilecon (_GL_ATTRIBUTE_MAYBE_UNUSED char const *file,
-             _GL_ATTRIBUTE_MAYBE_UNUSED char const *con)
+lgetfilecon (char const *_GL_UNNAMED (file), char **_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-fsetfilecon (_GL_ATTRIBUTE_MAYBE_UNUSED int fd,
-             _GL_ATTRIBUTE_MAYBE_UNUSED char const *con)
+lgetfilecon_raw (char const *_GL_UNNAMED (file), char **_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+fgetfilecon (int _GL_UNNAMED (fd), char **_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+fgetfilecon_raw (int _GL_UNNAMED (fd), char **_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+setfilecon (char const *_GL_UNNAMED (file), char const *_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+setfilecon_raw (char const *_GL_UNNAMED (file), char const *_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+lsetfilecon (char const *_GL_UNNAMED (file), char const *_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+lsetfilecon_raw (char const *_GL_UNNAMED (file), char const *_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+fsetfilecon (int _GL_UNNAMED (fd), char const *_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+fsetfilecon_raw (int _GL_UNNAMED (fd), char const *_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 
 SE_SELINUX_INLINE int
-security_check_context (_GL_ATTRIBUTE_MAYBE_UNUSED char const *con)
+security_check_context (char const *_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-security_check_context_raw (_GL_ATTRIBUTE_MAYBE_UNUSED char const *con)
+security_check_context_raw (char const *_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-setexeccon (_GL_ATTRIBUTE_MAYBE_UNUSED char const *con)
+setexeccon (char const *_GL_UNNAMED (con))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE int
-security_compute_create (_GL_ATTRIBUTE_MAYBE_UNUSED char const *scon,
-                         _GL_ATTRIBUTE_MAYBE_UNUSED char const *tcon,
-                         _GL_ATTRIBUTE_MAYBE_UNUSED security_class_t tclass,
-                         _GL_ATTRIBUTE_MAYBE_UNUSED char **newcon)
+setexeccon_raw (char const *_GL_UNNAMED (con))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+security_compute_create (char const *_GL_UNNAMED (scon),
+                         char const *_GL_UNNAMED (tcon),
+                         security_class_t _GL_UNNAMED (tclass),
+                         char **_GL_UNNAMED (newcon))
+  { errno = ENOTSUP; return -1; }
+SE_SELINUX_INLINE int
+security_compute_create_raw (char const *_GL_UNNAMED (scon),
+                             char const *_GL_UNNAMED (tcon),
+                             security_class_t _GL_UNNAMED (tclass),
+                             char **_GL_UNNAMED (newcon))
   { errno = ENOTSUP; return -1; }
 SE_SELINUX_INLINE security_class_t
-string_to_security_class (char const *name)
+string_to_security_class (char const *_GL_UNNAMED (name))
   { errno = ENOTSUP; return 0; }
 SE_SELINUX_INLINE int
-matchpathcon_init_prefix (_GL_ATTRIBUTE_MAYBE_UNUSED char const *path,
-                          _GL_ATTRIBUTE_MAYBE_UNUSED char const *prefix)
+matchpathcon_init_prefix (char const *_GL_UNNAMED (path),
+                          char const *_GL_UNNAMED (prefix))
   { errno = ENOTSUP; return -1; }
 
 #   define GNULIB_defined_security_types 1
 #  endif
 
+
+#  ifdef __cplusplus
+}
+#  endif
+
 _GL_INLINE_HEADER_END
 
-# endif
+# endif /* _GL_SELINUX_SELINUX_H */
 #endif


### PR DESCRIPTION
Two link failures in cp (and so also mv and ginstall).

The selinux/*.h in the tree were generated by a 2022 gnulib -- the same shape of problem as fts_.h, where the copy loop takes a pre-generated header from whichever package happened to ship one and it then outlives the sources around it. coreutils' copy.c calls the "_raw" variants with no guard at all,

	if (0 <= lgetfilecon_raw (src_name, &con_raw))
	  if (setfscreatecon_raw (con_raw) < 0)

and the 2022 stub declares only the non-raw ones:

	set_process_security_ctx: undefined: lgetfilecon_raw
	set_process_security_ctx: undefined: setfscreatecon_raw

The current se-selinux.in.h has all of them, so all three headers are now generated from their templates, and import.sh does it too. Six substitutions, of which only USE_SELINUX_SELINUX_H (0, no libselinux) selects anything.

triple_hash_no_name and triple_compare moved to hashcode-file-inode.c when gnulib renamed the hash-triple modules; only hashcode-named-file.c, which has triple_hash and triple_free, was in OFILES, which is why triple_hash linked and its two neighbours did not. hash-triple-simple.c is the old name for hashcode-named-file.c and must stay out -- building both would define the same three functions twice. Recorded with the other deliberate omissions.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs