### PR TITLE
ape: define the O_ flags Plan 9 lacks, as 0

### DIFF
--- a/sys/include/ape/fcntl.h
+++ b/sys/include/ape/fcntl.h
@@ -72,6 +72,28 @@ extern int creat(const char *, mode_t);
 #define O_BINARY	0		/* no CRLF translation (Windows); no-op */
 #define O_TEXT		0		/* CRLF translation (Windows); no-op */
 
+/* Flags other systems have and Plan 9 does not. gnulib's fcntl.in.h
+ * defines this same set to 0, but that is a generated wrapper over
+ * <fcntl.h> and the shared gnulib tree prunes it, so the definitions
+ * have to live here. coreutils' dd.c is what asks: it ORs the whole lot
+ * together to find a bit no O_ value uses, then names its own flags in
+ * what is left, and only O_CIO carries a fallback of its own.
+ *
+ * 0 is the right answer for each: they are hints (O_DIRECT, O_NOATIME)
+ * or Hurd/AIX-isms, and dd tests each with "if (O_NOATIME)" before
+ * offering the corresponding conv= keyword, so a zero means the keyword
+ * is simply not offered rather than accepted and ignored. */
+#define O_DIRECT	0		/* bypass the buffer cache (Linux) */
+#define O_CIO		0		/* concurrent I/O (AIX) */
+#define O_NOATIME	0		/* do not update st_atime (Linux) */
+#define O_NOLINKS	0		/* fail if link count > 1 (AIX) */
+#define O_NOLINK	0		/* do not follow the final link (Hurd) */
+#define O_NOTRANS	0		/* do not run the translator (Hurd) */
+#define O_IGNORE_CTTY	0		/* no controlling-tty magic (Hurd) */
+#define O_TTY_INIT	0		/* termios initialised on open (POSIX) */
+#define O_NDELAY	O_NONBLOCK	/* the pre-POSIX name */
+#define O_EXEC		O_RDONLY	/* open for execute only; close enough */
+
 /* F_DUPFD_CLOEXEC: dup fd to >= arg and set FD_CLOEXEC on result */
 #define F_DUPFD_CLOEXEC	8
 


### PR DESCRIPTION
dd.c ORs a fixed list of O_ values together to find a bit that no open flag uses, then names its own private flags in what is left:

	v = ~(0 | O_APPEND | O_BINARY | O_CIO | O_DIRECT | O_DIRECTORY
	        | O_DSYNC | O_EXCL | O_NOATIME | O_NOCTTY | O_NOFOLLOW
	        | O_NOLINKS | O_NONBLOCK | O_SYNC | O_TEXT),
	O_FULLBLOCK = FFS_MASK (v),

so every name in that list has to exist. Only O_CIO carries a fallback of its own; the rest normally come from gnulib's generated fcntl.h, which the shared tree prunes. Same class as HAVE_LCHOWN.

Defined here rather than in config-common.h because APE's <fcntl.h> already carries O_BINARY, O_TEXT and O_SEARCH for exactly this reason, and because every future port wants them, not just coreutils.

0 is the right value for each: they are hints (O_DIRECT, O_NOATIME) or Hurd/AIX-isms, and dd guards each with "if (O_NOATIME)" before offering the matching iflag= keyword, so zero means the keyword is not offered rather than accepted and quietly ignored. O_NDELAY and O_EXEC get real aliases instead.

Checked the rest of the class: of the O_ names coreutils and gnulib mention, the only others APE lacks are in modules this tree does not build (spawni.c, fcntl.c) or in their Windows arms.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs