### PR TITLE
gnulib: add freopen-safer and opendir-safer

### DIFF
--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -18,6 +18,21 @@ APEXPROOT=../../../../..
 # backslash on a comment line sits inside the comment, so whether the
 # list survives past it depends on whether mk strips comments before or
 # after joining continued lines.
+#
+# When working out what is missing, remember that gnulib's "--" headers
+# rename functions with plain macros: stdio--.h has
+#
+#	#define freopen freopen_safer
+#
+# and dirent--.h, fcntl--.h and unistd--.h do the same for opendir,
+# open, creat, dup and pipe. A source that includes one of those calls
+# freopen and needs freopen-safer.$O, so scanning the sources for the
+# symbol the linker will actually want finds nothing. Both freopen-safer
+# and opendir-safer were missed exactly that way.
+#
+# The rpl_* renames are the opposite case and can be ignored: they live
+# in "#if @REPLACE_FOO@" arms of the *.in.h wrappers, and those wrappers
+# are pruned here, so the rename never happens.
 
 GNUSRC=$APEXPROOT/sys/src/external/gnulib
 
@@ -165,6 +180,7 @@ OFILES=\
 	fprintftime.$O\
 	fpurge.$O\
 	free.$O\
+	freopen-safer.$O\
 	fstrcmp.$O\
 	ftoastr.$O\
 	fts.$O\
@@ -240,6 +256,7 @@ OFILES=\
 	open-safer.$O\
 	openat-die.$O\
 	openat-proc.$O\
+	opendir-safer.$O\
 	openat-safer.$O\
 	opendirat.$O\
 	parse-datetime.$O\


### PR DESCRIPTION
	dc_parse_file: undefined: freopen_safer in dc_parse_file

dircolors.c does not mention freopen_safer. It includes stdio--.h, which is

	#define freopen freopen_safer

so the source says freopen and the linker wants freopen_safer. That is why the closure I ran last time did not catch it: it scanned the sources for the symbol names, and this whole family is hidden behind plain macros in gnulib's "--" headers.

Re-ran it with those renames resolved. Two modules were missing: freopen-safer, for dircolors, and opendir-safer, which savedir.c needs for the same reason -- it calls opendir and includes dirent--.h. opendir-safer.c compiles its GNULIB_FDOPENDIR arm and so calls fdopendir, which libap has for real (ap/dirent/fdopendir.c), not as a stub. creat-safer stays out: nothing in the tree calls creat.

The rpl_* renames the same scan turns up are the opposite case and can be ignored -- they are in "#if @REPLACE_FOO@" arms of the *.in.h wrappers, and those wrappers are pruned here, so the rename never happens. Both facts are now in the mkfile's header so the next scan starts from them.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs