### PR TITLE
gnulib: declare SIG2STR_MAX, sig2str and str2sig

### DIFF
--- a/sys/src/external/gnulib/apexp-decls.h
+++ b/sys/src/external/gnulib/apexp-decls.h
@@ -49,6 +49,22 @@ extern const char *strerrorname_np(int);
 /* stdlib.h wrapper */
 extern char *secure_getenv(char const *);
 
+/* signal.h wrapper.
+   sig2str.c is in the archive, but SIG2STR_MAX and the two prototypes
+   live in the generated signal.h, not in sig2str.h -- that header kept
+   only SIGNUM_BOUND when gnulib moved the rest. env.c, kill.c, split.c
+   and operand2sig.c all declare "char signame[SIG2STR_MAX]":
+
+     env.c:621 name not declared: SIG2STR_MAX
+
+   The value is gnulib's own, from signal.in.h:153: "RTMAX", a sign, up
+   to ten digits, a NUL, and two spare. */
+#ifndef SIG2STR_MAX
+#define SIG2STR_MAX (5 + 1 + 10 + 1 + 2)
+#endif
+extern int sig2str(int, char *);
+extern int str2sig(const char *, int *);
+
 /* stdio.h wrapper */
 extern ptrdiff_t vaszprintf(char **, const char *, va_list);
 extern off64_t vfzprintf(FILE *, const char *, va_list);


### PR DESCRIPTION
	env.c:621 name not declared: SIG2STR_MAX

sig2str.$O is in the archive, but gnulib moved SIG2STR_MAX and the two prototypes out of sig2str.h and into the generated signal.h -- sig2str.h now holds nothing but SIGNUM_BOUND. That wrapper is pruned here, so env.c, kill.c, split.c and operand2sig.c, all of which write

	char signame[SIG2STR_MAX];

had no value for it. apexp-decls.h is where the rest of that class already lives. The value is gnulib's own from signal.in.h:153.

Swept the whole class while here: every object-like macro the pruned *.in.h wrappers define, against what the built sources use and what APE and config-common.h already provide. SIG2STR_MAX was the only real gap. The rest either exist already (SA_RESTART, SA_NODEFER, SA_RESETHAND, PTHREAD_CANCEL_*, max_align_t, timezone_t), are self-guarded by their caller (FNM_EXTMATCH, which exclude.c defines to 0 if absent), sit in modules not built here (THOUSANDS_SEP and GROUPING in strtol.c and nl_langinfo.c, WCOREDUMP in timeout.c), or are only ever #if-tested, where undefined already means 0 (_GL_WCHAR_T_IS_UCS4 in btoc32.c, AT_NO_AUTOMOUNT inside the HAVE_STATX arms of ls.c and stat.c).


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs