### PR TITLE
gnulib: declare eleven more functions from the pruned wrappers

### DIFF
--- a/sys/src/external/gnulib/apexp-decls.h
+++ b/sys/src/external/gnulib/apexp-decls.h
@@ -16,6 +16,15 @@
  * _GL_FUNCDECL_RPL names in the deleted *.in.h templates, keeping the
  * ones a module in OFILES actually calls, and dropping the ones APE
  * already declares. Signatures are copied from each defining .c file.
+ * Re-run that sweep whenever modules are added to OFILES: the coreutils
+ * batch brought in eleven more, and the one that surfaced it was
+ * numfmt.c returning mbschr's char * through an implicit int --
+ *
+ *   numfmt.c:1403 incompatible types: "INT" and "IND CHAR" for op "LIST"
+ *
+ * which is the loud version. mbsstr and memset_explicit in the same
+ * batch also return pointers, and would have truncated silently
+ * wherever the result was simply stored.
  *
  * Not included, having turned out to be dead code under this config.h:
  * timespec_get (gettime.c takes the clock_gettime branch, since
@@ -45,9 +54,28 @@ typedef off_t off64_t;
 /* string.h wrapper */
 extern size_t mbslen(const char *);
 extern const char *strerrorname_np(int);
+extern char *mbschr(const char *, int);
+extern char *mbsstr(const char *, const char *);
+extern void *memset_explicit(void *, int, size_t);
+
+/* sys/stat.h wrapper */
+extern int lchmod(const char *, mode_t);
+extern int mkfifoat(int, const char *, mode_t);
+
+/* unistd.h wrapper */
+extern int euidaccess(const char *, int);
+extern int fdatasync(int);
+extern int group_member(gid_t);
+extern int lchown(const char *, uid_t, gid_t);
+
+/* uchar.h wrapper. wint_t is a macro in APE's <wchar.h> rather than a
+   typedef, so that header has to come first. wc.c is the caller. */
+#include <wchar.h>
+extern wint_t btoc32(int);
 
 /* stdlib.h wrapper */
 extern char *secure_getenv(char const *);
+extern int rpmatch(const char *);
 
 /* signal.h wrapper.
    sig2str.c is in the archive, but SIG2STR_MAX and the two prototypes


### PR DESCRIPTION
	numfmt.c:1403 incompatible types: "INT" and "IND CHAR" for op "LIST"

numfmt.c's mbsmbchr ends in

	return *(c + 1) == '\0' ? mbschr (s, uc) : (char *) mbsstr (s, c);

and mbschr is declared only in the generated string.h, which is pruned. With no prototype kencc gives it the implicit int return, and the two arms of the conditional no longer agree.

apexp-decls.h already had mbslen, the same family; its header says the list came from sweeping _GL_FUNCDECL_* in the deleted wrappers for names a module in OFILES actually calls. That sweep predates the 92 coreutils modules. Re-ran it: eleven names, now declared, and the note says to re-run it whenever OFILES grows.

Three of them return pointers -- mbschr, mbsstr and memset_explicit -- so numfmt was the loud case and the others would have truncated to 32 bits silently wherever the result was just stored. The rest return int (euidaccess, fdatasync, group_member, lchmod, lchown, mkfifoat, rpmatch), where the implicit declaration happens to be right, and btoc32 returns wint_t, which is why <wchar.h> now comes in: APE spells wint_t as a macro for Rune rather than a typedef, so the header has to be there first.

wmempcpy is deliberately left out although wmempcpy.$O is built: its only caller is fnmatch.c, which is not.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs