### PR TITLE
gnulib: do not pull <wchar.h> into every translation unit

### DIFF
--- a/sys/include/ape/features.h
+++ b/sys/include/ape/features.h
@@ -38,9 +38,17 @@
 #define __REDIR(x,y) __typeof__(x) x __asm__(#y)
 
 /* Plan9 kencc has no weak symbol support; weak_alias is a no-op here.
- * Explicit strong forwarders are provided in network/res_aliases.c. */
+ * Explicit strong forwarders are provided in network/res_aliases.c.
+ *
+ * The parameter names are glibc's, and gnulib's libc-config.h:204 uses
+ * the same ones. That matters: libc-config.h defines weak_alias with no
+ * guard of its own, so whenever a header pulls this one in first, cpp
+ * sees a second definition -- and comparetokens() in cpp/macro.c
+ * compares the parameter lists as well as the bodies, so "(old, new)"
+ * would be a redefinition error where "(name, aliasname)" is the
+ * identical definition C allows. */
 #ifndef weak_alias
-#define weak_alias(old, new) /* no weak alias on Plan9 */
+#define weak_alias(name, aliasname) /* no weak alias on Plan9 */
 #endif
 
 #ifndef hidden

--- a/sys/include/ape/resolv.h
+++ b/sys/include/ape/resolv.h
@@ -93,8 +93,13 @@ struct __res_state {
 
 typedef struct __res_state *res_state;
 
-/* Plan9 kencc has no weak symbol support; aliases are provided explicitly */
-#define weak_alias(old, new) /* no weak alias on Plan9 */
+/* Plan9 kencc has no weak symbol support; aliases are provided
+ * explicitly. Guarded, and with glibc's parameter names, for the reason
+ * given in <features.h>: gnulib's libc-config.h defines this too, with
+ * no guard, and cpp compares parameter lists as well as bodies. */
+#ifndef weak_alias
+#define weak_alias(name, aliasname) /* no weak alias on Plan9 */
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/src/external/gnulib/apexp-decls.h
+++ b/sys/src/external/gnulib/apexp-decls.h
@@ -68,10 +68,22 @@ extern int fdatasync(int);
 extern int group_member(gid_t);
 extern int lchown(const char *, uid_t, gid_t);
 
-/* uchar.h wrapper. wint_t is a macro in APE's <wchar.h> rather than a
-   typedef, so that header has to come first. wc.c is the caller. */
-#include <wchar.h>
-extern wint_t btoc32(int);
+/* uchar.h wrapper. wc.c is the caller.
+
+   Spelled "unsigned int" rather than wint_t on purpose. APE has
+   "#define wint_t Rune" in <wchar.h> and "typedef unsigned int Rune" in
+   <utf.h>, so the two are the same type -- but including <wchar.h> here
+   would reach <langinfo.h> and through it <features.h>, whose
+   weak_alias then collides with the one gnulib's libc-config.h defines
+   unguarded at line 204:
+
+     libc-config.h:204 strftime.c:36 fprintftime.c:20
+       Macro redefinition of weak_alias
+
+   Nothing that every gnulib and coreutils translation unit includes
+   should be dragging system headers in behind it. Keep this file to
+   declarations. */
+extern unsigned int btoc32(int);
 
 /* stdlib.h wrapper */
 extern char *secure_getenv(char const *);


### PR DESCRIPTION
	libc-config.h:204 strftime.c:36 fprintftime.c:20
	  Macro redefinition of weak_alias

Mine, from the previous commit. btoc32 returns wint_t, so I included <wchar.h> in apexp-decls.h to have the type -- and apexp-decls.h is included by config-common.h, which is the first thing every gnulib and coreutils translation unit reads. <wchar.h> reaches <langinfo.h> and through it <features.h>, which defines weak_alias; gnulib's libc-config.h then defines it again with no guard of its own.

btoc32 is now declared as "unsigned int", which is exactly what wint_t is here -- <wchar.h> has "#define wint_t Rune" and <utf.h> has "typedef unsigned int Rune" -- with the reason recorded, since the obvious tidy-up is to put wint_t back.

Defused the underlying collision as well, because the next header to reach <features.h> would hit it again. cpp/macro.c's comparetokens() compares macro parameter lists as well as bodies, so two definitions that expand to nothing are still a redefinition error if one says "(old, new)" and the other "(name, aliasname)". features.h now uses glibc's names, which is what libc-config.h uses, making the second definition the identical one C allows.

resolv.h had the same macro with no guard at all, which would have been an error rather than a silent shadow the moment anything included it after features.h. Guarded, with the same names.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs