### PR TITLE
ape: __BYTE_ORDER was never defined on any architecture

### DIFF
--- a/386/include/ape/_apetypes.h
+++ b/386/include/ape/_apetypes.h
@@ -1,9 +1,54 @@
-#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
 #define	__BYTE_ORDER	__LITTLE_ENDIAN
 #endif
 
-#if !defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
-#define	BYTE_ORDER	LITTLE_ENDIAN
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
 #endif
 
 #ifndef __i386__

--- a/68020/include/ape/_apetypes.h
+++ b/68020/include/ape/_apetypes.h
@@ -1,9 +1,54 @@
-#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
 #define	__BYTE_ORDER	__BIG_ENDIAN
 #endif
 
-#if !defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
-#define	BYTE_ORDER	BIG_ENDIAN
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
 #endif
 
 #ifndef __m68k__

--- a/amd64/include/ape/_apetypes.h
+++ b/amd64/include/ape/_apetypes.h
@@ -2,12 +2,57 @@
 #define _BITS64
 #endif
 
-#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
 #define	__BYTE_ORDER	__LITTLE_ENDIAN
 #endif
 
-#if !defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
-#define	BYTE_ORDER	LITTLE_ENDIAN
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
 #endif
 
 #ifndef __x86_64__

--- a/arm/include/ape/_apetypes.h
+++ b/arm/include/ape/_apetypes.h
@@ -1,3 +1,56 @@
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
+#define	__BYTE_ORDER	__LITTLE_ENDIAN
+#endif
+
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
+#endif
+
 #ifndef __arm__
 #define __arm__ 1
 #endif

--- a/arm64/include/ape/_apetypes.h
+++ b/arm64/include/ape/_apetypes.h
@@ -2,6 +2,59 @@
 #define _BITS64
 #endif
 
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
+#define	__BYTE_ORDER	__LITTLE_ENDIAN
+#endif
+
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
+#endif
+
 #ifndef __arm64__
 #define __arm64__ 1
 #endif

--- a/mips/include/ape/_apetypes.h
+++ b/mips/include/ape/_apetypes.h
@@ -1,3 +1,56 @@
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
+#define	__BYTE_ORDER	__BIG_ENDIAN
+#endif
+
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
+#endif
+
 #ifndef __mips__
 #define __mips__ 1
 #endif

--- a/power/include/ape/_apetypes.h
+++ b/power/include/ape/_apetypes.h
@@ -1,9 +1,54 @@
-#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
 #define	__BYTE_ORDER	__BIG_ENDIAN
 #endif
 
-#if !defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
-#define	BYTE_ORDER	BIG_ENDIAN
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
 #endif
 
 #ifndef __powerpc__

--- a/power64/include/ape/_apetypes.h
+++ b/power64/include/ape/_apetypes.h
@@ -2,6 +2,59 @@
 #define _BITS64
 #endif
 
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
+#define	__BYTE_ORDER	__BIG_ENDIAN
+#endif
+
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
+#endif
+
 #ifndef __powerpc64__
 #define __powerpc64__ 1
 #endif

--- a/sparc/include/ape/_apetypes.h
+++ b/sparc/include/ape/_apetypes.h
@@ -1,9 +1,54 @@
-#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
 #define	__BYTE_ORDER	__BIG_ENDIAN
 #endif
 
-#if !defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
-#define	BYTE_ORDER	BIG_ENDIAN
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
 #endif
 
 #ifndef __sparc__

--- a/sparc64/include/ape/_apetypes.h
+++ b/sparc64/include/ape/_apetypes.h
@@ -1,13 +1,58 @@
-#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+#ifndef _BITS64
+#define _BITS64
+#endif
+
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
 #define	__BYTE_ORDER	__BIG_ENDIAN
 #endif
 
-#if !defined(BYTE_ORDER) && defined(LITTLE_ENDIAN)
-#define	BYTE_ORDER	BIG_ENDIAN
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
 #endif
-
-#ifndef _BITS64
-#define _BITS64
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
 #endif
 
 #ifndef __sparc64__

--- a/spim/include/ape/_apetypes.h
+++ b/spim/include/ape/_apetypes.h
@@ -1,3 +1,56 @@
+/*
+ * Byte order. The constants are musl's and glibc's. This header is
+ * per-architecture and is the thing that knows the answer, so it is
+ * defined here rather than guessed in <endian.h>.
+ *
+ * Six of the eleven architectures carried a version of this that could
+ * never fire:
+ *
+ *   #if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
+ *   #define __BYTE_ORDER __LITTLE_ENDIAN
+ *   #endif
+ *
+ * Nothing anywhere defined __LITTLE_ENDIAN, so the guard was always
+ * false. The other five had nothing at all. Either way __BYTE_ORDER
+ * stayed undefined, and every "#if __BYTE_ORDER == __LITTLE_ENDIAN" in
+ * <endian.h> compared 0 to 0 and took the little-endian arm -- correct
+ * here by accident, wrong on every big-endian architecture in the tree.
+ * (The big-endian copies had a second bug of their own: the guard said
+ * LITTLE and the body said BIG.)
+ *
+ * It surfaced as a compile error rather than as wrong bytes because
+ * coreutils' od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values,
+ * not only in #if:
+ *
+ *   od.c:1798 name not declared: __BYTE_ORDER
+ *   od.c:1798 name not declared: __BIG_ENDIAN
+ */
+#ifndef __LITTLE_ENDIAN
+#define	__LITTLE_ENDIAN	1234
+#endif
+#ifndef __BIG_ENDIAN
+#define	__BIG_ENDIAN	4321
+#endif
+#ifndef __PDP_ENDIAN
+#define	__PDP_ENDIAN	3412
+#endif
+#ifndef __BYTE_ORDER
+#define	__BYTE_ORDER	__LITTLE_ENDIAN
+#endif
+
+#ifndef LITTLE_ENDIAN
+#define	LITTLE_ENDIAN	__LITTLE_ENDIAN
+#endif
+#ifndef BIG_ENDIAN
+#define	BIG_ENDIAN	__BIG_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
+#define	PDP_ENDIAN	__PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
+#define	BYTE_ORDER	__BYTE_ORDER
+#endif
+
 #ifndef __mipsn32__
 #define __mipsn32__ 1
 #endif

--- a/sys/include/ape/endian.h
+++ b/sys/include/ape/endian.h
@@ -4,12 +4,28 @@
 #include <features.h>
 #include <stdint.h>
 
-#define __PDP_ENDIAN 3412
+/* __LITTLE_ENDIAN, __BIG_ENDIAN, __PDP_ENDIAN and __BYTE_ORDER all come
+   from <_apetypes.h>, which <stdint.h> above pulls in: it is the
+   per-architecture header, and the only one that knows the answer.
+   Until they were defined there, "#if __BYTE_ORDER == __LITTLE_ENDIAN"
+   below was comparing 0 to 0 and taking the little-endian arm on every
+   architecture.
 
+   Guarded because <machine/endian.h> defines the unprefixed four as
+   plain numbers; whichever header a program reaches first, the other
+   must not redefine them. */
+#ifndef BIG_ENDIAN
 #define BIG_ENDIAN __BIG_ENDIAN
+#endif
+#ifndef LITTLE_ENDIAN
 #define LITTLE_ENDIAN __LITTLE_ENDIAN
+#endif
+#ifndef PDP_ENDIAN
 #define PDP_ENDIAN __PDP_ENDIAN
+#endif
+#ifndef BYTE_ORDER
 #define BYTE_ORDER __BYTE_ORDER
+#endif
 
 static uint16_t __bswap16(uint16_t __x)
 {


### PR DESCRIPTION
	od.c:1798 name not declared: __BYTE_ORDER
	od.c:1798 name not declared: __BIG_ENDIAN

Six of the eleven per-architecture _apetypes.h carried

	#if !defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN)
	#define __BYTE_ORDER __LITTLE_ENDIAN
	#endif

which could never fire, because nothing anywhere defined __LITTLE_ENDIAN. The other five -- arm, arm64, mips, power64, spim -- had nothing at all. The big-endian copies had a second bug on top: the guard tested LITTLE and the body said BIG.

So __BYTE_ORDER was undefined everywhere, and every

	#if __BYTE_ORDER == __LITTLE_ENDIAN

in <endian.h> was comparing 0 to 0. It took the little-endian arm on all eleven architectures: right on amd64, 386, arm, arm64 and spim by accident, and wrong on 68020, mips, power, power64, sparc and sparc64, where htobe16 and friends were byte-swapping when they should have been no-ops and the reverse. Nobody noticed because the little-endian architectures are the ones being built.

It surfaced as a compile error, not as wrong bytes, only because od.c reads BYTE_ORDER and BIG_ENDIAN as ordinary C values rather than just in #if.

Each _apetypes.h now defines __LITTLE_ENDIAN, __BIG_ENDIAN, __PDP_ENDIAN and __BYTE_ORDER outright, along with the four unprefixed names, and says which architecture it is. That file is the right home: it is per-architecture and <stdint.h>, <stddef.h> and <sys/types.h> all pull it in, so <endian.h> already has the values by the time it tests them.

<endian.h>'s own four defines are now guarded. They were plain #defines of __BIG_ENDIAN and friends, while <machine/endian.h> defines the same four as literal numbers, so a program reaching machine/endian.h first and endian.h second would have got a redefinition error.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs