### PR TITLE
ape: locale.h declared two of musl's file-local helpers

### DIFF
--- a/sys/include/ape/locale.h
+++ b/sys/include/ape/locale.h
@@ -52,11 +52,31 @@ extern struct lconv *localeconv(void);
 /* from gnulib */
 #define LC_MESSAGES 1729
 
-/* from musl */
+/* from musl.
+
+   Two declarations that used to be here were file-local helpers inside
+   musl's own sources, hoisted into this header along with the real
+   entry points:
+
+     extern int cmp(void,void);
+     static ssize_t vstrfmon_l(char *, size_t, locale_t, const char *, va_list);
+
+   cmp is the static bsearch comparator in locale/catgets.c, and
+   vstrfmon_l is the static worker in locale/strfmon.c. Neither belongs
+   in a public header, and cmp was actively harmful: <locale.h> is
+   included by almost everything, cmp is an ordinary name for a local
+   comparison function, and any program that defines its own gets
+
+     seq.c:439 external redeclaration of: cmp
+       STATIC FUNC(IND CONST CHAR, VLONG, IND CONST CHAR, VLONG) INT
+       EXTERN FUNC(VOID, VOID) INT  /sys/include/ape/locale.h:57
+     seq.c:439 function inconsistently declared: cmp
+
+   It was not a valid declaration either -- "(void,void)" is two void
+   parameters -- and vstrfmon_l named va_list without <stdarg.h>, so
+   anything that had actually used it would not have compiled. */
 #include <nl_types.h> /* catgets catclose catopen */
-extern int cmp(void,void);
 extern void freelocale(locale_t);
-static ssize_t vstrfmon_l(char *, size_t, locale_t, const char *, va_list);
 extern ssize_t strfmon_l(char *, size_t, locale_t, const char *, ...);
 extern ssize_t strfmon(char *, size_t, const char *, ...);
 extern float strtof_l(const char *, char **, locale_t);


### PR DESCRIPTION
	seq.c:439 external redeclaration of: cmp
	  STATIC FUNC(IND CONST CHAR, VLONG, IND CONST CHAR, VLONG) INT
	  EXTERN FUNC(VOID, VOID) INT  /sys/include/ape/locale.h:57
	seq.c:439 function inconsistently declared: cmp

<locale.h> carried

	extern int cmp(void,void);
	static ssize_t vstrfmon_l(char *, size_t, locale_t, const char *, va_list);

cmp is the static bsearch comparator in libap's locale/catgets.c, and vstrfmon_l the static worker in locale/strfmon.c. Both were hoisted into the header along with the real entry points when this block was written "from musl".

cmp was the harmful one. <locale.h> is included by almost everything, cmp is an ordinary name for a local comparison function, and any program that defines its own collides -- seq.c is simply the first to do so. It was not a valid declaration either: "(void,void)" is two void parameters. vstrfmon_l was a static prototype in a public header naming va_list without <stdarg.h>, so anything that had used it would not have compiled.

Both removed. Checked the other short common names APE declares -- error in <error.h>, warn in <err.h>, log in <math.h>, min and max in <libv.h>, new in <c++/new.h> -- and they are all in headers a program includes deliberately, unlike <locale.h>.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs