### PR TITLE
ape: add the C99/C11 float.h macros

### DIFF
--- a/sys/include/ape/float.h
+++ b/sys/include/ape/float.h
@@ -1,7 +1,72 @@
 #ifndef _FLOAT_H
+#define _FLOAT_H
 
 #include <float_arch.h>
 
+/*
+ * C99 and C11 additions to <float.h>.
+ *
+ * They live here rather than in <float_arch.h> because they are the same
+ * on every target kencc has: all eleven float_arch.h define LDBL_MANT_DIG
+ * as DBL_MANT_DIG, so long double is double throughout, and the FLT and
+ * DBL values are IEEE 754 binary32 and binary64 everywhere. An
+ * architecture that ever grows a wider long double can define its own in
+ * float_arch.h; each name below is guarded.
+ *
+ * gnulib's dtimespec-bound.h is what asked, for sleep, tail and timeout:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * TRUE_MIN is the smallest positive subnormal, where MIN is the smallest
+ * positive normal. Plan 9 amd64 does support subnormals -- main9.s sets
+ * MXCSR to 0x1f80, which leaves both FTZ (bit 15) and DAZ (bit 6) clear
+ * -- so HAS_SUBNORM is 1 rather than 0 or -1. Note that _RESEARCH_SOURCE
+ * still sets Sudden_Underflow for the old dtoa, which is a separate and
+ * older assumption.
+ */
+
+/* Spelled as hex floats: these are subnormal, and a decimal literal
+   would have to be rounded into the subnormal range by the compiler's
+   own strtod, where 0x1p-1074 is just an exponent. Decimal equivalents
+   are 1.40129846e-45 and 4.9406564584124654e-324. */
+#ifndef FLT_TRUE_MIN
+#define FLT_TRUE_MIN	0x1p-149F	/* 2**-149 */
+#endif
+#ifndef DBL_TRUE_MIN
+#define DBL_TRUE_MIN	0x1p-1074	/* 2**-1074 */
+#endif
+#ifndef LDBL_TRUE_MIN
+#define LDBL_TRUE_MIN	DBL_TRUE_MIN
+#endif
+
+#ifndef FLT_HAS_SUBNORM
+#define FLT_HAS_SUBNORM		1
+#endif
+#ifndef DBL_HAS_SUBNORM
+#define DBL_HAS_SUBNORM		1
+#endif
+#ifndef LDBL_HAS_SUBNORM
+#define LDBL_HAS_SUBNORM	1
+#endif
+
+/* Digits needed to round-trip through decimal and back. */
+#ifndef FLT_DECIMAL_DIG
+#define FLT_DECIMAL_DIG		9
+#endif
+#ifndef DBL_DECIMAL_DIG
+#define DBL_DECIMAL_DIG		17
+#endif
+#ifndef LDBL_DECIMAL_DIG
+#define LDBL_DECIMAL_DIG	DBL_DECIMAL_DIG
+#endif
+#ifndef DECIMAL_DIG
+#define DECIMAL_DIG		LDBL_DECIMAL_DIG
+#endif
+
+/* 0: all operations and constants are evaluated in their own type.
+   That is what kencc does, having no wider intermediate format. */
+#ifndef FLT_EVAL_METHOD
+#define FLT_EVAL_METHOD		0
+#endif
+
 #endif /* _FLOAT_H */
-
-


### PR DESCRIPTION
	dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN

<float.h> stopped at C89. Added TRUE_MIN, HAS_SUBNORM, DECIMAL_DIG and FLT_EVAL_METHOD for all three float types.

They go in <float.h> rather than <float_arch.h> because they are the same on every target: all eleven float_arch.h define LDBL_MANT_DIG as DBL_MANT_DIG, so long double is double throughout, and the FLT and DBL values are IEEE 754 binary32 and binary64 everywhere. Each name is guarded, so an architecture that ever grows a wider long double can still define its own. DECIMAL_DIG is 17 rather than glibc's 21 for exactly that reason.

TRUE_MIN is the smallest positive subnormal, spelled as a hex float: these values are subnormal, and a decimal literal would have to be rounded into the subnormal range by the compiler's own strtod, whereas 0x1p-1074 is just an exponent. HAS_SUBNORM is 1 because the hardware does support them -- main9.s sets MXCSR to 0x1f80, which leaves FTZ (bit 15) and DAZ (bit 6) clear. (_RESEARCH_SOURCE still sets Sudden_Underflow for the old dtoa; that is a separate, older assumption, and the comment says so.)

While here: <float.h> tested #ifndef _FLOAT_H and never defined it, so it had no include guard of its own and was relying on float_arch.h's __FLOAT. Defined now.

Noted but not fixed: sparc, sparc64 and spim have no float_arch.h at all, so <float.h> cannot work there. Those three are not being built.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs