### PR TITLE
ape: APExp's <float.h> was never read on any architecture

### DIFF
--- a/386/include/ape/float.h
+++ b/386/include/ape/float.h
@@ -1,0 +1,24 @@
+#ifndef _FLOAT_H
+#define _FLOAT_H
+
+/*
+ * <float.h> for 386.
+ *
+ * This file has to exist. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE ships its
+ * float.h in the architecture directory. APExp renamed that file to
+ * float_arch.h and put a wrapper in /sys/include/ape -- but with
+ * nothing named float.h here, #include <float.h> found the HOST's stock
+ * copy from the union mount underneath, and the wrapper was never read.
+ * Silent, because the stock copy has everything C89 asks for; it
+ * surfaced only when something wanted a C99 name:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * float_arch.h is the stock content, unchanged. float_ext.h is the
+ * C99/C11 additions, which are the same for every architecture.
+ */
+#include <float_arch.h>
+#include <float_ext.h>
+
+#endif /* _FLOAT_H */

--- a/68020/include/ape/float.h
+++ b/68020/include/ape/float.h
@@ -1,0 +1,24 @@
+#ifndef _FLOAT_H
+#define _FLOAT_H
+
+/*
+ * <float.h> for 68020.
+ *
+ * This file has to exist. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE ships its
+ * float.h in the architecture directory. APExp renamed that file to
+ * float_arch.h and put a wrapper in /sys/include/ape -- but with
+ * nothing named float.h here, #include <float.h> found the HOST's stock
+ * copy from the union mount underneath, and the wrapper was never read.
+ * Silent, because the stock copy has everything C89 asks for; it
+ * surfaced only when something wanted a C99 name:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * float_arch.h is the stock content, unchanged. float_ext.h is the
+ * C99/C11 additions, which are the same for every architecture.
+ */
+#include <float_arch.h>
+#include <float_ext.h>
+
+#endif /* _FLOAT_H */

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,6 +546,44 @@ Without correction, any early FP call in Tcl/Tk (e.g. `log(2.)` in
 **Invariant:** Any new APE startup path that bypasses `main9.s` MUST set the
 POSIX FP environment before executing any floating-point code.
 
+### Header search order: the architecture directory wins
+
+`pcc.c:234-235` passes
+
+```
+-I/$objtype/include/ape
+-I/sys/include/ape
+```
+
+in that order, so **anything the host's stock APE keeps in the architecture
+directory shadows everything in this tree**. Stock APE keeps `float.h` and
+`stdarg.h` there.
+
+`mount-include` used to bind the repo's `$objtype/include/ape` onto
+`/sys/include/ape` and nowhere else, which only makes those files visible on
+the path pcc searches *second*. So APExp's `<float.h>` — a wrapper over the
+renamed `float_arch.h` — was never read on any architecture, and
+`#include <float.h>` silently got the host's stock copy. Invisible until
+something wanted a C99 name:
+
+```
+dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+```
+
+**Fix:** `mount-include` also does `bind -b $cputype/include/ape
+/$cputype/include/ape`, and every architecture has a real `float.h` that
+chains to `float_arch.h` plus the shared `float_ext.h`.
+
+The rename was only half-applied, which is worth knowing: eight architectures
+have `float_arch.h`, while sparc, sparc64 and spim still call theirs
+`float.h`; same for `stdarg_arch.h` vs sparc's `stdarg.h`. `sys/include/ape/
+stdarg.h` is a pure wrapper that adds nothing, so that one is currently
+harmless — but it is the same trap.
+
+**Note:** `mount-include` is a no-op if `/sys/include/ape/THIS_IS_APExp`
+already exists, so a shell that mounted before this change keeps the old
+namespace. Start a fresh `apexp-sh`.
+
 ### Build order for compiler changes
 ```
 cd sys/src/cmd/cc && mk nuke && mk install   # regenerates y.tab.h

--- a/amd64/include/ape/float.h
+++ b/amd64/include/ape/float.h
@@ -1,0 +1,24 @@
+#ifndef _FLOAT_H
+#define _FLOAT_H
+
+/*
+ * <float.h> for amd64.
+ *
+ * This file has to exist. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE ships its
+ * float.h in the architecture directory. APExp renamed that file to
+ * float_arch.h and put a wrapper in /sys/include/ape -- but with
+ * nothing named float.h here, #include <float.h> found the HOST's stock
+ * copy from the union mount underneath, and the wrapper was never read.
+ * Silent, because the stock copy has everything C89 asks for; it
+ * surfaced only when something wanted a C99 name:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * float_arch.h is the stock content, unchanged. float_ext.h is the
+ * C99/C11 additions, which are the same for every architecture.
+ */
+#include <float_arch.h>
+#include <float_ext.h>
+
+#endif /* _FLOAT_H */

--- a/arm/include/ape/float.h
+++ b/arm/include/ape/float.h
@@ -1,0 +1,24 @@
+#ifndef _FLOAT_H
+#define _FLOAT_H
+
+/*
+ * <float.h> for arm.
+ *
+ * This file has to exist. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE ships its
+ * float.h in the architecture directory. APExp renamed that file to
+ * float_arch.h and put a wrapper in /sys/include/ape -- but with
+ * nothing named float.h here, #include <float.h> found the HOST's stock
+ * copy from the union mount underneath, and the wrapper was never read.
+ * Silent, because the stock copy has everything C89 asks for; it
+ * surfaced only when something wanted a C99 name:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * float_arch.h is the stock content, unchanged. float_ext.h is the
+ * C99/C11 additions, which are the same for every architecture.
+ */
+#include <float_arch.h>
+#include <float_ext.h>
+
+#endif /* _FLOAT_H */

--- a/arm64/include/ape/float.h
+++ b/arm64/include/ape/float.h
@@ -1,0 +1,24 @@
+#ifndef _FLOAT_H
+#define _FLOAT_H
+
+/*
+ * <float.h> for arm64.
+ *
+ * This file has to exist. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE ships its
+ * float.h in the architecture directory. APExp renamed that file to
+ * float_arch.h and put a wrapper in /sys/include/ape -- but with
+ * nothing named float.h here, #include <float.h> found the HOST's stock
+ * copy from the union mount underneath, and the wrapper was never read.
+ * Silent, because the stock copy has everything C89 asks for; it
+ * surfaced only when something wanted a C99 name:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * float_arch.h is the stock content, unchanged. float_ext.h is the
+ * C99/C11 additions, which are the same for every architecture.
+ */
+#include <float_arch.h>
+#include <float_ext.h>
+
+#endif /* _FLOAT_H */

--- a/mips/include/ape/float.h
+++ b/mips/include/ape/float.h
@@ -1,0 +1,24 @@
+#ifndef _FLOAT_H
+#define _FLOAT_H
+
+/*
+ * <float.h> for mips.
+ *
+ * This file has to exist. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE ships its
+ * float.h in the architecture directory. APExp renamed that file to
+ * float_arch.h and put a wrapper in /sys/include/ape -- but with
+ * nothing named float.h here, #include <float.h> found the HOST's stock
+ * copy from the union mount underneath, and the wrapper was never read.
+ * Silent, because the stock copy has everything C89 asks for; it
+ * surfaced only when something wanted a C99 name:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * float_arch.h is the stock content, unchanged. float_ext.h is the
+ * C99/C11 additions, which are the same for every architecture.
+ */
+#include <float_arch.h>
+#include <float_ext.h>
+
+#endif /* _FLOAT_H */

--- a/mount-include
+++ b/mount-include
@@ -5,6 +5,17 @@ if(! test -e /sys/include/ape/THIS_IS_APExp) {
     bind -b $cputype/include/ape /sys/include/ape
     bind -b $cputype/lib/ape /$cputype/lib/ape
     bind -b sys/include/ape /sys/include/ape
+    # And over the architecture include directory itself. pcc passes
+    #   -I/$objtype/include/ape   before   -I/sys/include/ape
+    # (pcc.c:234-235), so anything the host's stock APE keeps in the
+    # architecture directory wins over everything in this tree --
+    # binding the same directory onto /sys/include/ape, as the line
+    # above does, only makes it visible on the path pcc searches
+    # SECOND. Stock APE keeps float.h and stdarg.h there, so APExp's
+    # <float.h> was never read on any architecture:
+    #   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+    # even though /sys/include/ape/float.h had defined DBL_TRUE_MIN.
+    bind -b $cputype/include/ape /$cputype/include/ape
     # Overlay locally-built compilers/linkers/assemblers over /bin so
     # pcc (which hardcodes /bin/6c, /bin/6l, /bin/6a etc.) picks up
     # THIS tree's freshly-built compiler with all its C99/C11/C23

--- a/power/include/ape/float.h
+++ b/power/include/ape/float.h
@@ -1,0 +1,24 @@
+#ifndef _FLOAT_H
+#define _FLOAT_H
+
+/*
+ * <float.h> for power.
+ *
+ * This file has to exist. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE ships its
+ * float.h in the architecture directory. APExp renamed that file to
+ * float_arch.h and put a wrapper in /sys/include/ape -- but with
+ * nothing named float.h here, #include <float.h> found the HOST's stock
+ * copy from the union mount underneath, and the wrapper was never read.
+ * Silent, because the stock copy has everything C89 asks for; it
+ * surfaced only when something wanted a C99 name:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * float_arch.h is the stock content, unchanged. float_ext.h is the
+ * C99/C11 additions, which are the same for every architecture.
+ */
+#include <float_arch.h>
+#include <float_ext.h>
+
+#endif /* _FLOAT_H */

--- a/power64/include/ape/float.h
+++ b/power64/include/ape/float.h
@@ -1,0 +1,24 @@
+#ifndef _FLOAT_H
+#define _FLOAT_H
+
+/*
+ * <float.h> for power64.
+ *
+ * This file has to exist. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE ships its
+ * float.h in the architecture directory. APExp renamed that file to
+ * float_arch.h and put a wrapper in /sys/include/ape -- but with
+ * nothing named float.h here, #include <float.h> found the HOST's stock
+ * copy from the union mount underneath, and the wrapper was never read.
+ * Silent, because the stock copy has everything C89 asks for; it
+ * surfaced only when something wanted a C99 name:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * float_arch.h is the stock content, unchanged. float_ext.h is the
+ * C99/C11 additions, which are the same for every architecture.
+ */
+#include <float_arch.h>
+#include <float_ext.h>
+
+#endif /* _FLOAT_H */

--- a/sparc/include/ape/float.h
+++ b/sparc/include/ape/float.h
@@ -72,4 +72,10 @@ union FPdbleword
 #define	FPAOVFL	(1<<8)
 #define	FPAINVAL	(1<<9)
 #endif
+
+/* The C99/C11 additions, shared with every other architecture. Unlike
+   the other eight, this file was never renamed to float_arch.h with a
+   wrapper above it, so it includes them itself. */
+#include <float_ext.h>
+
 #endif /* __FLOAT */

--- a/sparc64/include/ape/float.h
+++ b/sparc64/include/ape/float.h
@@ -72,4 +72,10 @@ union FPdbleword
 #define	FPAOVFL	(1<<8)
 #define	FPAINVAL	(1<<9)
 #endif
+
+/* The C99/C11 additions, shared with every other architecture. Unlike
+   the other eight, this file was never renamed to float_arch.h with a
+   wrapper above it, so it includes them itself. */
+#include <float_ext.h>
+
 #endif /* __FLOAT */

--- a/spim/include/ape/float.h
+++ b/spim/include/ape/float.h
@@ -72,4 +72,10 @@ union FPdbleword
 #define	FPAZDIV	(1<<5)
 #define	FPAINVAL	(1<<6)
 #endif
+
+/* The C99/C11 additions, shared with every other architecture. Unlike
+   the other eight, this file was never renamed to float_arch.h with a
+   wrapper above it, so it includes them itself. */
+#include <float_ext.h>
+
 #endif /* __FLOAT */

--- a/sys/include/ape/float.h
+++ b/sys/include/ape/float.h
@@ -1,72 +1,16 @@
 #ifndef _FLOAT_H
 #define _FLOAT_H
 
-#include <float_arch.h>
-
 /*
- * C99 and C11 additions to <float.h>.
+ * The generic <float.h>, for anything that reaches /sys/include/ape
+ * without an architecture directory ahead of it.
  *
- * They live here rather than in <float_arch.h> because they are the same
- * on every target kencc has: all eleven float_arch.h define LDBL_MANT_DIG
- * as DBL_MANT_DIG, so long double is double throughout, and the FLT and
- * DBL values are IEEE 754 binary32 and binary64 everywhere. An
- * architecture that ever grows a wider long double can define its own in
- * float_arch.h; each name below is guarded.
- *
- * gnulib's dtimespec-bound.h is what asked, for sleep, tail and timeout:
- *
- *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
- *
- * TRUE_MIN is the smallest positive subnormal, where MIN is the smallest
- * positive normal. Plan 9 amd64 does support subnormals -- main9.s sets
- * MXCSR to 0x1f80, which leaves both FTZ (bit 15) and DAZ (bit 6) clear
- * -- so HAS_SUBNORM is 1 rather than 0 or -1. Note that _RESEARCH_SOURCE
- * still sets Sudden_Underflow for the old dtoa, which is a separate and
- * older assumption.
+ * Note that pcc normally does NOT get here: pcc.c:234-235 passes
+ * -I/$objtype/include/ape before -I/sys/include/ape, and every
+ * architecture in this tree now has its own float.h, so that one is
+ * found first. Both chain to the same two headers.
  */
-
-/* Spelled as hex floats: these are subnormal, and a decimal literal
-   would have to be rounded into the subnormal range by the compiler's
-   own strtod, where 0x1p-1074 is just an exponent. Decimal equivalents
-   are 1.40129846e-45 and 4.9406564584124654e-324. */
-#ifndef FLT_TRUE_MIN
-#define FLT_TRUE_MIN	0x1p-149F	/* 2**-149 */
-#endif
-#ifndef DBL_TRUE_MIN
-#define DBL_TRUE_MIN	0x1p-1074	/* 2**-1074 */
-#endif
-#ifndef LDBL_TRUE_MIN
-#define LDBL_TRUE_MIN	DBL_TRUE_MIN
-#endif
-
-#ifndef FLT_HAS_SUBNORM
-#define FLT_HAS_SUBNORM		1
-#endif
-#ifndef DBL_HAS_SUBNORM
-#define DBL_HAS_SUBNORM		1
-#endif
-#ifndef LDBL_HAS_SUBNORM
-#define LDBL_HAS_SUBNORM	1
-#endif
-
-/* Digits needed to round-trip through decimal and back. */
-#ifndef FLT_DECIMAL_DIG
-#define FLT_DECIMAL_DIG		9
-#endif
-#ifndef DBL_DECIMAL_DIG
-#define DBL_DECIMAL_DIG		17
-#endif
-#ifndef LDBL_DECIMAL_DIG
-#define LDBL_DECIMAL_DIG	DBL_DECIMAL_DIG
-#endif
-#ifndef DECIMAL_DIG
-#define DECIMAL_DIG		LDBL_DECIMAL_DIG
-#endif
-
-/* 0: all operations and constants are evaluated in their own type.
-   That is what kencc does, having no wider intermediate format. */
-#ifndef FLT_EVAL_METHOD
-#define FLT_EVAL_METHOD		0
-#endif
+#include <float_arch.h>
+#include <float_ext.h>
 
 #endif /* _FLOAT_H */

--- a/sys/include/ape/float_ext.h
+++ b/sys/include/ape/float_ext.h
@@ -1,0 +1,76 @@
+#ifndef _FLOAT_EXT_H
+#define _FLOAT_EXT_H
+
+/*
+ * C99 and C11 additions to <float.h>.
+ *
+ * They live in their own arch-independent header because they are the
+ * same on every target kencc has: every arch float header defines
+ * LDBL_MANT_DIG as DBL_MANT_DIG, so long double is double throughout,
+ * and the FLT and DBL values are IEEE 754 binary32 and binary64
+ * everywhere. An architecture that ever grows a wider long double can
+ * define its own first; each name below is guarded.
+ *
+ * Included from every <float.h> in the tree -- the per-architecture ones
+ * as well as the generic one. pcc passes -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234), and stock 9front APE keeps its float.h
+ * in the architecture directory, so <float.h> resolves there first and a
+ * generic header alone would never be read.
+ *
+ * gnulib's dtimespec-bound.h is what asked, for sleep, tail and timeout:
+ *
+ *   dtimespec-bound.h:61 name not declared: DBL_TRUE_MIN
+ *
+ * TRUE_MIN is the smallest positive subnormal, where MIN is the smallest
+ * positive normal. Plan 9 amd64 does support subnormals -- main9.s sets
+ * MXCSR to 0x1f80, which leaves both FTZ (bit 15) and DAZ (bit 6) clear
+ * -- so HAS_SUBNORM is 1 rather than 0 or -1. Note that _RESEARCH_SOURCE
+ * still sets Sudden_Underflow for the old dtoa, which is a separate and
+ * older assumption.
+ */
+
+/* Spelled as hex floats: these are subnormal, and a decimal literal
+   would have to be rounded into the subnormal range by the compiler's
+   own strtod, where 0x1p-1074 is just an exponent. Decimal equivalents
+   are 1.40129846e-45 and 4.9406564584124654e-324. */
+#ifndef FLT_TRUE_MIN
+#define FLT_TRUE_MIN	0x1p-149F	/* 2**-149 */
+#endif
+#ifndef DBL_TRUE_MIN
+#define DBL_TRUE_MIN	0x1p-1074	/* 2**-1074 */
+#endif
+#ifndef LDBL_TRUE_MIN
+#define LDBL_TRUE_MIN	DBL_TRUE_MIN
+#endif
+
+#ifndef FLT_HAS_SUBNORM
+#define FLT_HAS_SUBNORM		1
+#endif
+#ifndef DBL_HAS_SUBNORM
+#define DBL_HAS_SUBNORM		1
+#endif
+#ifndef LDBL_HAS_SUBNORM
+#define LDBL_HAS_SUBNORM	1
+#endif
+
+/* Digits needed to round-trip through decimal and back. */
+#ifndef FLT_DECIMAL_DIG
+#define FLT_DECIMAL_DIG		9
+#endif
+#ifndef DBL_DECIMAL_DIG
+#define DBL_DECIMAL_DIG		17
+#endif
+#ifndef LDBL_DECIMAL_DIG
+#define LDBL_DECIMAL_DIG	DBL_DECIMAL_DIG
+#endif
+#ifndef DECIMAL_DIG
+#define DECIMAL_DIG		LDBL_DECIMAL_DIG
+#endif
+
+/* 0: all operations and constants are evaluated in their own type.
+   That is what kencc does, having no wider intermediate format. */
+#ifndef FLT_EVAL_METHOD
+#define FLT_EVAL_METHOD		0
+#endif
+
+#endif /* _FLOAT_EXT_H */


### PR DESCRIPTION
Same DBL_TRUE_MIN error after adding the macros, because the header they went into is not the one pcc finds. pcc.c:234-235:

	append(&cpp, smprint("-I/%s/include/ape", ot->name));
	append(&cpp, "-I/sys/include/ape");

The architecture directory is searched first, and stock 9front APE keeps float.h and stdarg.h there. mount-include bound the repo's $cputype/include/ape onto /sys/include/ape and nowhere else, which only makes those files visible on the path pcc searches SECOND -- so #include <float.h> resolved to the HOST's stock copy, and /sys/include/ape/float.h, the wrapper over the renamed float_arch.h, was never read at all.

Silent for as long as nothing wanted more than C89, since the stock copy has all of that. DBL_EPSILON on dtimespec-bound.h:71 resolved while DBL_TRUE_MIN ten lines above it did not, which is what gave it away.

mount-include now also binds $cputype/include/ape over /$cputype/include/ape, and every architecture gets a real float.h that chains to float_arch.h and to the new shared float_ext.h, which is where the C99/C11 additions from the previous commit now live.

The rename behind this was only half-applied and still is: eight architectures have float_arch.h with the wrapper above it, while sparc, sparc64 and spim never got renamed and keep the stock content in float.h -- those three now include float_ext.h directly. stdarg.h is in the same position, but sys/include/ape/stdarg.h is a pure wrapper that adds nothing, so it is harmless today. Both facts are in CLAUDE.md now.

mount-include does nothing if /sys/include/ape/THIS_IS_APExp exists, so this needs a fresh apexp-sh rather than a rebuild in the current one.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs