### PR TITLE
ape: add POSIX <sys/statvfs.h>

### DIFF
--- a/sys/include/ape/sys/statvfs.h
+++ b/sys/include/ape/sys/statvfs.h
@@ -1,0 +1,63 @@
+#ifndef _SYS_STATVFS_H
+#define _SYS_STATVFS_H
+#pragma lib "/$M/lib/ape/libap.a"
+
+/*
+ * POSIX <sys/statvfs.h>.
+ *
+ * Plan 9 has no equivalent. A file server is reached through the
+ * namespace, not through a mount table, and 9P has no operation that
+ * reports block or inode counts for the file system behind a path --
+ * only the per-file Dir that stat(2) returns. So statvfs() and
+ * fstatvfs() here always fail with ENOSYS.
+ *
+ * The type still has to exist and be complete, because portable code
+ * declares a "struct statvfs" on the stack before it ever calls
+ * anything. coreutils' stat.c is the case in point: it uses statvfs
+ * only for "stat -f", but the declaration and a static_assert on the
+ * struct's alignment are compiled unconditionally --
+ *
+ *   stat.c:259 structure not fully declared statfs
+ *   stat.c:880 _Alignof undefined type
+ *
+ * -- so without this header the whole program is lost, not just the one
+ * option. With it, stat works and "stat -f" reports the error.
+ *
+ * f_type is not POSIX; it is here because it is the member coreutils
+ * and gnulib use to identify a file system, and because a struct with
+ * no way to say "unknown" is worse than one that can. It is always 0.
+ */
+
+#include <sys/types.h>
+#include <alltypes.h>	/* fsblkcnt_t, fsfilcnt_t */
+
+struct statvfs {
+	unsigned long	f_bsize;	/* file system block size */
+	unsigned long	f_frsize;	/* fundamental block size */
+	fsblkcnt_t	f_blocks;	/* blocks, in f_frsize units */
+	fsblkcnt_t	f_bfree;	/* free blocks */
+	fsblkcnt_t	f_bavail;	/* free blocks for unprivileged */
+	fsfilcnt_t	f_files;	/* inodes */
+	fsfilcnt_t	f_ffree;	/* free inodes */
+	fsfilcnt_t	f_favail;	/* free inodes for unprivileged */
+	unsigned long	f_fsid;		/* file system id */
+	unsigned long	f_flag;		/* ST_* below */
+	unsigned long	f_namemax;	/* maximum filename length */
+	unsigned long	f_type;		/* not POSIX; always 0 here */
+};
+
+#define ST_RDONLY	1	/* read-only file system */
+#define ST_NOSUID	2	/* setuid/setgid bits are ignored */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int statvfs(const char *, struct statvfs *);
+extern int fstatvfs(int, struct statvfs *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_STATVFS_H */

--- a/sys/src/ape/cmd/core/mkfile
+++ b/sys/src/ape/cmd/core/mkfile
@@ -17,16 +17,16 @@ APEXPROOT=../../../../..
 # list is upstream saying "only where the platform allows", and here is
 # what each would need, so this does not have to be worked out again:
 #
-#   df            get_fs_usage, from gnulib's fsusage.c. APE has no
-#                 statvfs and no statfs, so none of that file's STAT_*
-#                 arms is selected and it compiles to a function that
-#                 returns 0 having filled nothing in -- df would print
-#                 whatever was on the stack. A stub returning ENOSYS
-#                 would at least be honest, but a df that always fails
-#                 is not worth installing. Its other dependency,
-#                 read_file_system_list, is already stubbed in
-#                 apexp-mountlist.c: Plan 9 has no global mount table,
-#                 only a per-process namespace.
+#   df            get_fs_usage, from gnulib's fsusage.c, which is not in
+#                 OFILES. It would now compile -- APE has a
+#                 <sys/statvfs.h> and config-common.h sets STAT_STATVFS
+#                 -- and would return -1/ENOSYS, since Plan 9 cannot
+#                 report block or inode counts for the file system
+#                 behind a path. read_file_system_list, its other
+#                 dependency, is already stubbed in apexp-mountlist.c:
+#                 there is no global mount table, only a per-process
+#                 namespace. So df would build and then fail on every
+#                 invocation, which is not worth installing.
 #   who,          read_utmp. gnulib compiles its own dummy here (no
 #   users,        HAVE_UTMPX_H, no HAVE_UTMP_H), which sets ENOSYS and
 #   pinky         returns -1, so these three would build and link and

--- a/sys/src/ape/lib/ap/stat/mkfile
+++ b/sys/src/ape/lib/ap/stat/mkfile
@@ -9,6 +9,7 @@ OFILES=\
 	fstat.$O\
 	lstat.$O\
 	stat.$O\
+	statvfs.$O\
 	umask.$O\
 	utime.$O\
 	utimes.$O\

--- a/sys/src/ape/lib/ap/stat/statvfs.c
+++ b/sys/src/ape/lib/ap/stat/statvfs.c
@@ -1,0 +1,34 @@
+#include <sys/statvfs.h>
+#include <errno.h>
+
+/*
+ * statvfs / fstatvfs -- POSIX, and not answerable on Plan 9.
+ *
+ * A file server is reached through the namespace rather than a mount
+ * table, and 9P has no operation that reports block or inode counts for
+ * the file system behind a path: stat(2) returns a per-file Dir and
+ * nothing more. There is no number to give, so these report that
+ * plainly rather than filling the struct with zeros, which a caller
+ * would read as "an empty file system".
+ *
+ * See <sys/statvfs.h> for why the type exists at all when the calls
+ * cannot succeed.
+ */
+
+int
+statvfs(const char *path, struct statvfs *buf)
+{
+	(void)path;
+	(void)buf;
+	errno = ENOSYS;
+	return -1;
+}
+
+int
+fstatvfs(int fd, struct statvfs *buf)
+{
+	(void)fd;
+	(void)buf;
+	errno = ENOSYS;
+	return -1;
+}

--- a/sys/src/external/gnulib/config-common.h
+++ b/sys/src/external/gnulib/config-common.h
@@ -5931,6 +5931,46 @@
 # define HAVE_LCHOWN 0
 #endif
 
+/* APExp: the statvfs answers, now that APE has <sys/statvfs.h>.
+   Plan 9 cannot report block or inode counts -- statvfs() and
+   fstatvfs() are there so the TYPE exists, and always fail with ENOSYS.
+   coreutils' stat.c needs the type whatever it does with the call:
+   it uses statvfs only for "stat -f", but declares a STRUCT_STATVFS and
+   static_asserts on its alignment unconditionally, so an incomplete
+   type loses the whole program --
+
+     stat.c:259 structure not fully declared statfs
+     stat.c:880 _Alignof undefined type
+
+   -- rather than just that one option.
+
+   STAT_STATVFS picks the statvfs arm over the statfs one. Together with
+   HAVE_STRUCT_STATVFS_F_TYPE that makes stat.c's USE_STATVFS true (see
+   the conditional at the top of stat.c, kept in sync with
+   m4/stat-prog.m4). F_FSID_IS_INTEGER is what POSIX says -- f_fsid is
+   an unsigned long -- and skips the block that takes alignof of the
+   struct. F_NAMEMAX names the member POSIX calls f_namemax rather than
+   Linux's f_namelen.
+
+   Deliberately NOT defined: HAVE_STRUCT_STATVFS_F_BASETYPE and
+   HAVE_STRUCT_STATVFS_F_FSTYPENAME, which are Solaris and BSD members
+   this struct does not have. */
+#ifndef HAVE_SYS_STATVFS_H
+# define HAVE_SYS_STATVFS_H 1
+#endif
+#ifndef STAT_STATVFS
+# define STAT_STATVFS 1
+#endif
+#ifndef HAVE_STRUCT_STATVFS_F_TYPE
+# define HAVE_STRUCT_STATVFS_F_TYPE 1
+#endif
+#ifndef HAVE_STRUCT_STATVFS_F_NAMEMAX
+# define HAVE_STRUCT_STATVFS_F_NAMEMAX 1
+#endif
+#ifndef STRUCT_STATVFS_F_FSID_IS_INTEGER
+# define STRUCT_STATVFS_F_FSID_IS_INTEGER 1
+#endif
+
 /* APExp: no non-Gregorian calendars in strftime.
    strftime.c defaults SUPPORT_NON_GREG_CALENDARS_IN_STRFTIME to true and
    then calls gl_locale_name_unsafe to spot th_TH, fa_IR and the like:

--- a/sys/src/external/gnulib/import.sh
+++ b/sys/src/external/gnulib/import.sh
@@ -451,6 +451,30 @@ EOF
 # define HAVE_LCHOWN 0
 #endif
 
+/* APExp: the statvfs answers, now that APE has <sys/statvfs.h>. The
+   calls always fail with ENOSYS -- Plan 9 cannot report block or inode
+   counts -- but the type has to exist, because coreutils' stat.c
+   declares a STRUCT_STATVFS unconditionally even though it only uses it
+   for "stat -f". STAT_STATVFS plus F_TYPE makes stat.c take the statvfs
+   arm; F_FSID_IS_INTEGER is what POSIX says and skips the block that
+   takes alignof of the struct. F_BASETYPE and F_FSTYPENAME are
+   deliberately absent: those are Solaris and BSD members. */
+#ifndef HAVE_SYS_STATVFS_H
+# define HAVE_SYS_STATVFS_H 1
+#endif
+#ifndef STAT_STATVFS
+# define STAT_STATVFS 1
+#endif
+#ifndef HAVE_STRUCT_STATVFS_F_TYPE
+# define HAVE_STRUCT_STATVFS_F_TYPE 1
+#endif
+#ifndef HAVE_STRUCT_STATVFS_F_NAMEMAX
+# define HAVE_STRUCT_STATVFS_F_NAMEMAX 1
+#endif
+#ifndef STRUCT_STATVFS_F_FSID_IS_INTEGER
+# define STRUCT_STATVFS_F_FSID_IS_INTEGER 1
+#endif
+
 /* APExp: no non-Gregorian calendars in strftime. Otherwise strftime.c
    calls gl_locale_name_unsafe, which means gnulib's localename module,
    whose getlocalename_l-unsafe.c ends in "#error Please port ... to


### PR DESCRIPTION
	stat.c:259 structure not fully declared statfs
	stat.c:880 _Alignof undefined type

coreutils' stat.c uses statvfs only for "stat -f", but the declaration and a static_assert on the struct's alignment are compiled unconditionally, so an incomplete type loses the whole program rather than the one option. With no <sys/statvfs.h> and no <sys/vfs.h>, none of stat.c's arms had a complete type to name.

APE now has the POSIX header. statvfs() and fstatvfs() always fail with ENOSYS: a Plan 9 file server is reached through the namespace rather than a mount table, and 9P has no operation reporting block or inode counts for the file system behind a path -- stat(2) returns a per-file Dir and nothing more. Failing is the honest answer; filling the struct with zeros would read as an empty file system.

f_type is not POSIX. It is there because it is the member coreutils and gnulib use to identify a file system, and because a struct with no way to say "unknown" is worse than one that can. Always 0.

config-common.h gains the matching answers: HAVE_SYS_STATVFS_H, STAT_STATVFS, HAVE_STRUCT_STATVFS_F_TYPE, HAVE_STRUCT_STATVFS_F_NAMEMAX and STRUCT_STATVFS_F_FSID_IS_INTEGER. The first three are what make stat.c's USE_STATVFS true; the last is what POSIX says of f_fsid and is what skips the block that takes alignof of the struct. F_BASETYPE and F_FSTYPENAME stay undefined -- those are Solaris and BSD members this struct does not have. In import.sh too.

The note in core/mkfile about df is corrected: its get_fs_usage would now compile and return -1/ENOSYS rather than returning 0 with the struct untouched. It still has no mount list, so it would fail on every invocation and stays out.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs