### PR TITLE
ape: SIZE_MAX was 32-bit on amd64, and that is what killed GNU ls

### DIFF
--- a/sys/include/ape/stdint.h
+++ b/sys/include/ape/stdint.h
@@ -21,6 +21,45 @@ typedef unsigned int _uintptr_t;
 # endif
 #endif
 
+/*
+ * INTPTR_WIDTH decides SIZE_MAX, UINTPTR_MAX and PTRDIFF_MAX below, and
+ * it used to come only from <stdint_arch.h>, with a silent fall back to
+ * 32 if that header had not been read. Silent is the problem: it is not
+ * a conservative default but a wrong answer, and the failure it produces
+ * is remote from its cause.
+ *
+ * It produced this. SIZE_MAX came out 0xffffffff on amd64 while size_t
+ * stayed 8 bytes, so gnulib's
+ *
+ *	for (size_t i = 0;
+ *	     ! (argsize == SIZE_MAX ? arg[i] == '\0' : i == argsize);
+ *	     i++)
+ *
+ * -- with argsize passed as (size_t)-1 to mean "find the NUL" -- never
+ * matched, never tested for the NUL, and counted towards 2**64 instead.
+ * GNU ls faulted reading past the end of the heap, several thousand
+ * bytes beyond a perfectly well-formed filename.
+ *
+ * _BITS64 is the signal the rest of this tree already uses: <alltypes.h>,
+ * <stddef.h>, <unistd.h>, <bsd.h> and <pthread.h> all key off it, and it
+ * is what makes size_t 64-bit in the first place. Deriving the width
+ * from it as well means the two cannot disagree quietly -- if they do,
+ * that is the #error below, not a bad SIZE_MAX.
+ */
+#if defined(_BITS64) && !defined(_STDINT_ARCH_H_)
+# undef INTPTR_WIDTH
+# undef UINTPTR_WIDTH
+# define INTPTR_WIDTH 64
+# define UINTPTR_WIDTH 64
+#endif
+
+#if defined(_BITS64) && INTPTR_WIDTH != 64
+# error "stdint.h: _BITS64 is set but INTPTR_WIDTH is not 64"
+#endif
+#if !defined(_BITS64) && INTPTR_WIDTH == 64
+# error "stdint.h: INTPTR_WIDTH is 64 but _BITS64 is not set"
+#endif
+
 typedef char s8;
 typedef short s16;
 typedef long s32;
@@ -205,9 +244,17 @@ typedef _uintptr_t uintptr_t;
 #define INTMAX_WIDTH       64
 #define UINTMAX_WIDTH      64
 
-/* 
- * Right now, all of our size_t types are 32 bit, even on
- * 64 bit architectures.
+/*
+ * size_t follows the pointer width. It has done since 2026-04; the
+ * comment that used to sit here said the opposite -- "Right now, all of
+ * our size_t types are 32 bit, even on 64 bit architectures" -- which
+ * was the state of things when SIZE_MAX was written, and stopped being
+ * true when amd64/include/ape/stddef_arch.h gained
+ *
+ *	typedef unsigned long long _size_t;
+ *
+ * A SIZE_MAX that does not match size_t is not a cosmetic mismatch: see
+ * the note on INTPTR_WIDTH above.
  */
 #ifndef SIZE_MIN
 #define SIZE_MIN	0

--- a/sys/lib/tests/limits-test.c
+++ b/sys/lib/tests/limits-test.c
@@ -71,6 +71,34 @@ main(void)
 	printf("PTRDIFF_MAX %llx\n", (unsigned long long)PTRDIFF_MAX);
 	printf("UINTMAX_MAX %llx\n", (unsigned long long)UINTMAX_MAX);
 	printf("ULONG_MAX   %llx\n", (unsigned long long)ULONG_MAX);
+
+	/* Which headers actually got read, and what they decided. When
+	   SIZE_MAX is wrong these say why: SIZE_MAX comes from
+	   "#if INTPTR_WIDTH == 64" in <stdint.h>, INTPTR_WIDTH comes from
+	   <stdint_arch.h>, and _BITS64 comes from <_apetypes.h>. Any of
+	   the three can be missing if a header is shadowed -- pcc searches
+	   -I/$objtype/include/ape before -I/sys/include/ape, so the host's
+	   stock APE wins there unless this tree has a file of that name. */
+#ifdef _STDINT_GENERIC_H_
+	printf("stdint.h:       APExp's (_STDINT_GENERIC_H_ set)\n");
+#else
+	printf("stdint.h:       NOT APExp's -- _STDINT_GENERIC_H_ unset\n");
+#endif
+#ifdef _STDINT_ARCH_H_
+	printf("stdint_arch.h:  read\n");
+#else
+	printf("stdint_arch.h:  NOT read\n");
+#endif
+#ifdef INTPTR_WIDTH
+	printf("INTPTR_WIDTH:   %d\n", (int)INTPTR_WIDTH);
+#else
+	printf("INTPTR_WIDTH:   undefined\n");
+#endif
+#ifdef _BITS64
+	printf("_BITS64:        set\n");
+#else
+	printf("_BITS64:        unset\n");
+#endif
 	printf("\n");
 
 	/* The one quotearg depends on. Written exactly as it uses it. */


### PR DESCRIPTION
limits-test on the build machine:

	sizeof: void* 8, size_t 8, ptrdiff_t 8
	SIZE_MAX    ffffffff
	UINTPTR_MAX ffffffff
	FAIL  (size_t)-1 == SIZE_MAX
	FAIL  SIZE_MAX is as wide as size_t
	FAIL  SIZE_WIDTH matches sizeof(size_t)
	FAIL  (uintptr_t)-1 == UINTPTR_MAX

size_t is 8 bytes and SIZE_MAX describes 4. Portable code uses SIZE_MAX as the sentinel for "no length given, go and find the NUL", so gnulib's

	for (size_t i = 0;
	     ! (argsize == SIZE_MAX ? arg[i] == '\0' : i == argsize);
	     i++)

called with argsize = (size_t)-1 never matched, never reached the NUL test, and counted towards 2**64 instead. ls read past the end of the heap with i at 0xa8d0 -- several thousand bytes beyond a filename that was, as dirent-test confirms, perfectly well terminated.

SIZE_MAX came from "#if INTPTR_WIDTH == 64", and INTPTR_WIDTH came only from <stdint_arch.h>, falling silently back to 32 when that header had not been read. A silent fall back to the wrong answer, a long way from where it hurts. Note the failing set is exactly the macros behind that one #if: the TYPES were right, because those come from typedefs rather than from the width macro, which is why sizeof(uintptr_t) passed while UINTPTR_MAX failed.

INTPTR_WIDTH is now also derived from _BITS64, which is the signal the rest of this tree already uses -- <alltypes.h>, <stddef.h>, <unistd.h>, <bsd.h> and <pthread.h> all key off it, and it is what makes size_t 64-bit in the first place. And the two can no longer disagree quietly: either direction is now an #error.

The comment above SIZE_MAX read "Right now, all of our size_t types are 32 bit, even on 64 bit architectures", which was true when SIZE_MAX was written and stopped being true with the 2026-04 size_t fix. Replaced with what is actually the case.

limits-test now reports which headers were read and what INTPTR_WIDTH and _BITS64 came out as, so if this recurs the output names the mechanism rather than the symptom.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs