### PR TITLE
ape: shadow the stock per-architecture stdint.h, as float.h already does

### DIFF
--- a/386/include/ape/stdint.h
+++ b/386/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for 386
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/386/include/ape/stdint_arch.h
+++ b/386/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned int _uintptr_t;
 #define INTPTR_WIDTH 32
 #define UINTPTR_WIDTH 32
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/68020/include/ape/stdint.h
+++ b/68020/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for 68020
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/68020/include/ape/stdint_arch.h
+++ b/68020/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned int _uintptr_t;
 #define INTPTR_WIDTH 32
 #define UINTPTR_WIDTH 32
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,6 +548,8 @@ POSIX FP environment before executing any floating-point code.
 
 ### Header search order: the architecture directory wins
 
+**This has now cost two bugs. Read it before adding a header.**
+
 `pcc.c:234-235` passes
 
 ```
@@ -583,6 +585,40 @@ harmless — but it is the same trap.
 **Note:** `mount-include` is a no-op if `/sys/include/ape/THIS_IS_APExp`
 already exists, so a shell that mounted before this change keeps the old
 namespace. Start a fresh `apexp-sh`.
+
+The second bug was `<stdint.h>`, and it was worse than being ignored. Stock
+APE keeps a `stdint.h` in the architecture directory too, and that file takes
+the guard name `_STDINT_ARCH_H_` — which is the guard on APExp's own
+`stdint_arch.h`. So the stock header won the search, defined the guard, and
+APExp's arch header then compiled to **nothing**: the typedefs came from the
+stock file (right, by luck, on amd64) and `INTPTR_WIDTH` was never defined at
+all. `SIZE_MAX` is chosen by `#if INTPTR_WIDTH == 64`, so it came out
+`0xffffffff` while `size_t` stayed 8 bytes, and gnulib's
+
+```c
+argsize == SIZE_MAX ? arg[i] == '\0' : i == argsize
+```
+
+never looked for the NUL. GNU `ls` read its way off the end of the heap.
+
+**Fix, and the shape to copy for any header stock APE keeps per-architecture:**
+
+- every architecture directory has a real `stdint.h`, so the stock one is
+  never reached;
+- the content lives in `sys/include/ape/stdint_generic.h`, because none of
+  those copies could reach "the other stdint.h" by that name — the search
+  would find itself;
+- `INTPTR_WIDTH` is derived from `_BITS64` as well, and overrides rather than
+  defers, so a shadowed or neutralised arch header cannot produce a wrong
+  width — only `#error`.
+
+Known so far to be kept per-architecture by stock APE: `float.h`, `stdarg.h`,
+`stdint.h`. `sys/include/ape/stdarg.h` is a pure wrapper that adds nothing, so
+it is currently harmless — but it is the same trap.
+
+`sys/lib/tests/limits-test.c` checks `(size_t)-1 == SIZE_MAX` and the same
+identity for the other types, and prints which of these headers were actually
+read.
 
 ### Build order for compiler changes
 ```

--- a/amd64/include/ape/stdint.h
+++ b/amd64/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for amd64
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/amd64/include/ape/stdint_arch.h
+++ b/amd64/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned long long _uintptr_t;
 #define INTPTR_WIDTH 64
 #define UINTPTR_WIDTH 64
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/arm/include/ape/stdint.h
+++ b/arm/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for arm
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/arm/include/ape/stdint_arch.h
+++ b/arm/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned int _uintptr_t;
 #define INTPTR_WIDTH 32
 #define UINTPTR_WIDTH 32
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/arm64/include/ape/stdint.h
+++ b/arm64/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for arm64
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/arm64/include/ape/stdint_arch.h
+++ b/arm64/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned long long _uintptr_t;
 #define INTPTR_WIDTH 64
 #define UINTPTR_WIDTH 64
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/mips/include/ape/stdint.h
+++ b/mips/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for mips
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/mips/include/ape/stdint_arch.h
+++ b/mips/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned int _uintptr_t;
 #define INTPTR_WIDTH 32
 #define UINTPTR_WIDTH 32
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/power/include/ape/stdint.h
+++ b/power/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for power
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/power/include/ape/stdint_arch.h
+++ b/power/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned int _uintptr_t;
 #define INTPTR_WIDTH 32
 #define UINTPTR_WIDTH 32
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/power64/include/ape/stdint.h
+++ b/power64/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for power64
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/power64/include/ape/stdint_arch.h
+++ b/power64/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned long long _uintptr_t;
 #define INTPTR_WIDTH 64
 #define UINTPTR_WIDTH 64
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/sparc/include/ape/stdint.h
+++ b/sparc/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for sparc
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/sparc/include/ape/stdint_arch.h
+++ b/sparc/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned int _uintptr_t;
 #define INTPTR_WIDTH 32
 #define UINTPTR_WIDTH 32
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/sparc64/include/ape/stdint.h
+++ b/sparc64/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for sparc64
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/sparc64/include/ape/stdint_arch.h
+++ b/sparc64/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned long long _uintptr_t;
 #define INTPTR_WIDTH 64
 #define UINTPTR_WIDTH 64
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/spim/include/ape/stdint.h
+++ b/spim/include/ape/stdint.h
@@ -2,7 +2,7 @@
 #define _APEXP_STDINT_H_
 
 /*
- * <stdint.h>
+ * <stdint.h> for spim
  *
  * Two lines, because the content cannot live under this name. pcc passes
  *

--- a/spim/include/ape/stdint_arch.h
+++ b/spim/include/ape/stdint_arch.h
@@ -6,6 +6,8 @@ typedef unsigned int _uintptr_t;
 #define INTPTR_WIDTH 32
 #define UINTPTR_WIDTH 32
 
-#include <stdint.h>
+/* Not <stdint.h>: that would find the wrapper beside this
+   file and stop at its guard. */
+#include <stdint_generic.h>
 
 #endif

--- a/sys/include/ape/stdint_generic.h
+++ b/sys/include/ape/stdint_generic.h
@@ -1,0 +1,301 @@
+#ifndef _STDINT_GENERIC_H_
+#define _STDINT_GENERIC_H_ 1
+
+/*
+ * The arch-independent half of <stdint.h>. Reached through the <stdint.h>
+ * in this directory and in each architecture directory, never by that
+ * name itself -- see the comment in either of them for why it cannot be
+ * called stdint.h.
+ */
+#include <_apetypes.h>
+#include <stdint_arch.h>
+
+/*
+ * Default for architectures that don't define width/types in stdint_arch.h
+ */
+#ifndef _STDINT_ARCH_H_
+# ifndef INTPTR_WIDTH
+#  define INTPTR_WIDTH 32
+#  define UINTPTR_WIDTH 32
+# endif
+# if INTPTR_WIDTH == 64
+typedef long long _intptr_t;
+typedef unsigned long long _uintptr_t;
+# else
+typedef int _intptr_t;
+typedef unsigned int _uintptr_t;
+# endif
+#endif
+
+/*
+ * INTPTR_WIDTH decides SIZE_MAX, UINTPTR_MAX and PTRDIFF_MAX below, and
+ * it used to come only from <stdint_arch.h>, with a silent fall back to
+ * 32 if that header had not been read. Silent is the problem: it is not
+ * a conservative default but a wrong answer, and the failure it produces
+ * is remote from its cause.
+ *
+ * It produced this. SIZE_MAX came out 0xffffffff on amd64 while size_t
+ * stayed 8 bytes, so gnulib's
+ *
+ *	for (size_t i = 0;
+ *	     ! (argsize == SIZE_MAX ? arg[i] == '\0' : i == argsize);
+ *	     i++)
+ *
+ * -- with argsize passed as (size_t)-1 to mean "find the NUL" -- never
+ * matched, never tested for the NUL, and counted towards 2**64 instead.
+ * GNU ls faulted reading past the end of the heap, several thousand
+ * bytes beyond a perfectly well-formed filename.
+ *
+ * _BITS64 is the signal the rest of this tree already uses: <alltypes.h>,
+ * <stddef.h>, <unistd.h>, <bsd.h> and <pthread.h> all key off it, and it
+ * is what makes size_t 64-bit in the first place. So it decides here
+ * too, and overrides rather than defers: the stock arch stdint.h that
+ * caused this shares stdint_arch.h's guard, which left INTPTR_WIDTH
+ * undefined rather than wrong, and deferring to that is how the bug
+ * survived. The #error below is only for the reverse -- a width of 64
+ * where nothing said 64-bit -- which would mean the two headers had come
+ * from different architectures.
+ */
+#ifdef _BITS64
+# undef INTPTR_WIDTH
+# undef UINTPTR_WIDTH
+# define INTPTR_WIDTH 64
+# define UINTPTR_WIDTH 64
+#endif
+
+#ifndef INTPTR_WIDTH
+# define INTPTR_WIDTH 32
+# define UINTPTR_WIDTH 32
+#endif
+
+#if !defined(_BITS64) && INTPTR_WIDTH == 64
+# error "stdint_generic.h: INTPTR_WIDTH is 64 but _BITS64 is not set"
+#endif
+
+typedef char s8;
+typedef short s16;
+typedef long s32;
+typedef long long s64;
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned long u32;
+typedef unsigned long long u64;
+
+typedef char int8_t;
+typedef short int16_t;
+typedef int int32_t;
+typedef long long int64_t;
+typedef long long intmax_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef unsigned long long uintmax_t;
+
+typedef int8_t	int_fast8_t;
+typedef int16_t	int_fast16_t;
+typedef int32_t	int_fast32_t;
+typedef int64_t	int_fast64_t;
+
+typedef int8_t	int_least8_t;
+typedef int16_t	int_least16_t;
+typedef int32_t	int_least32_t;
+typedef int64_t	int_least64_t;
+
+typedef uint8_t		uint_fast8_t;
+typedef uint16_t	uint_fast16_t;
+typedef uint32_t	uint_fast32_t;
+typedef uint64_t	uint_fast64_t;
+
+typedef uint8_t		uint_least8_t;
+typedef uint16_t	uint_least16_t;
+typedef uint32_t	uint_least32_t;
+typedef uint64_t	uint_least64_t;
+
+typedef _intptr_t intptr_t;
+typedef _uintptr_t uintptr_t;
+
+/* C99 integer constant macros. Plan9 is LLP64: int=long=32-bit, long long=64-bit. */
+#define INT8_C(c)    c
+#define INT16_C(c)   c
+#define INT32_C(c)   c##L
+#define INT64_C(c)   c##LL
+#define UINT8_C(c)   c##U
+#define UINT16_C(c)  c##U
+#define UINT32_C(c)  c##UL
+#define UINT64_C(c)  c##ULL
+#define INTMAX_C(c)  c##LL
+#define UINTMAX_C(c) c##ULL
+
+/*
+ * C99 7.18: these macros must be usable in #if. A cast is not allowed
+ * there -- the type name is not a macro, so cpp reads it as 0 and the
+ * expression falls apart. They were spelled ((int64_t)0x8000...LL) and
+ * so on, which cost GNU tar:
+ *
+ *   list.c:744 Syntax error in #if/#elif
+ *
+ * on "#if ! (INTMAX_MAX <= UINTMAX_MAX && - (INTMAX_MIN + 1) <= UINTMAX_MAX)".
+ *
+ * -MAX-1 is the usual spelling and is well defined besides: 0x80000000
+ * has type unsigned int, since it does not fit in int, so casting it to
+ * int32_t was implementation-defined where negating the maximum is not.
+ */
+#define INT8_MIN	(-INT8_MAX-1)
+#define INT16_MIN	(-INT16_MAX-1)
+#define INT32_MIN	(-INT32_MAX-1)
+#define INT64_MIN	(-INT64_MAX-1)
+#define INTMAX_MIN	INT64_MIN
+
+#define UINT8_MIN	0
+#define UINT16_MIN	0 
+#define UINT32_MIN	0 
+#define UINT64_MIN	0
+#define UINTMAX_MIN	UINT64_MIN
+
+#define INT_FAST8_MIN	INT8_MIN
+#define INT_FAST16_MIN	INT16_MIN
+#define INT_FAST32_MIN	INT32_MIN
+#define INT_FAST64_MIN	INT64_MIN
+
+#define UINT_FAST8_MIN	UINT8_MIN
+#define UINT_FAST16_MIN	UINT16_MIN
+#define UINT_FAST32_MIN	UINT32_MIN
+#define UINT_FAST64_MIN	UINT64_MIN
+
+#define INT_LEAST8_MIN	INT8_MIN
+#define INT_LEAST16_MIN	INT16_MIN
+#define INT_LEAST32_MIN	INT32_MIN
+#define INT_LEAST64_MIN	INT64_MIN
+
+#define UINT_LEAST8_MIN		UINT8_MIN
+#define UINT_LEAST16_MIN	UINT16_MIN
+#define UINT_LEAST32_MIN	UINT32_MIN
+#define UINT_LEAST64_MIN	UINT64_MIN
+
+#define INT8_MAX	0x7f
+#define INT16_MAX	0x7fff
+#define INT32_MAX	0x7fffffff
+#define INT64_MAX	0x7fffffffffffffffLL
+#define INTMAX_MAX	INT64_MAX
+
+#define UINT8_MAX	0xff
+#define UINT16_MAX	0xffff
+#define UINT32_MAX	0xffffffffL
+#define UINT64_MAX	0xffffffffffffffffULL
+#define UINTMAX_MAX	UINT64_MAX
+
+#define INT_FAST8_MAX	INT8_MAX
+#define INT_FAST16_MAX	INT16_MAX
+#define INT_FAST32_MAX	INT32_MAX
+#define INT_FAST64_MAX	INT64_MAX
+
+#define UINT_FAST8_MAX	UINT8_MAX
+#define UINT_FAST16_MAX	UINT16_MAX
+#define UINT_FAST32_MAX	UINT32_MAX
+#define UINT_FAST64_MAX	UINT64_MAX
+
+#define INT_LEAST8_MAX	INT8_MAX
+#define INT_LEAST16_MAX	INT16_MAX
+#define INT_LEAST32_MAX	INT32_MAX
+#define INT_LEAST64_MAX	INT64_MAX
+
+#define UINT_LEAST8_MAX		UINT8_MAX
+#define UINT_LEAST16_MAX	UINT16_MAX
+#define UINT_LEAST32_MAX	UINT32_MAX
+#define UINT_LEAST64_MAX	UINT64_MAX
+
+#ifndef INTPTR_WIDTH
+#define INTPTR_WIDTH 32
+#define UINTPTR_WIDTH 32
+#endif
+
+#if INTPTR_WIDTH == 64
+#define INTPTR_MIN	INT64_MIN
+#define INTPTR_MAX	INT64_MAX
+#define UINTPTR_MAX	UINT64_MAX
+#define PTRDIFF_MAX	INT64_MAX
+#define PTRDIFF_MIN	INT64_MIN
+#define PTRDIFF_WIDTH	64
+#else
+#define INTPTR_MIN	INT32_MIN
+#define INTPTR_MAX	INT32_MAX
+#define UINTPTR_MAX	UINT32_MAX
+#define PTRDIFF_MAX	INT32_MAX
+#define PTRDIFF_MIN	INT32_MIN
+#define PTRDIFF_WIDTH	32
+#endif
+
+#define INT8_WIDTH         8
+#define UINT8_WIDTH        8
+#define INT16_WIDTH        16
+#define UINT16_WIDTH       16
+#define INT32_WIDTH        32
+#define UINT32_WIDTH       32
+#define INT64_WIDTH        64
+#define UINT64_WIDTH       64
+
+#define INT_LEAST8_WIDTH   8
+#define UINT_LEAST8_WIDTH  8
+#define INT_LEAST16_WIDTH  16
+#define UINT_LEAST16_WIDTH 16
+#define INT_LEAST32_WIDTH  32
+#define UINT_LEAST32_WIDTH 32
+#define INT_LEAST64_WIDTH  64
+#define UINT_LEAST64_WIDTH 64
+
+#define INT_FAST8_WIDTH    8
+#define UINT_FAST8_WIDTH   8
+#define INT_FAST16_WIDTH   16
+#define UINT_FAST16_WIDTH  16
+#define INT_FAST32_WIDTH   32
+#define UINT_FAST32_WIDTH  32
+#define INT_FAST64_WIDTH   64
+#define UINT_FAST64_WIDTH  64
+
+#define INTMAX_WIDTH       64
+#define UINTMAX_WIDTH      64
+
+/*
+ * size_t follows the pointer width. It has done since 2026-04; the
+ * comment that used to sit here said the opposite -- "Right now, all of
+ * our size_t types are 32 bit, even on 64 bit architectures" -- which
+ * was the state of things when SIZE_MAX was written, and stopped being
+ * true when amd64/include/ape/stddef_arch.h gained
+ *
+ *	typedef unsigned long long _size_t;
+ *
+ * A SIZE_MAX that does not match size_t is not a cosmetic mismatch: see
+ * the note on INTPTR_WIDTH above.
+ */
+#ifndef SIZE_MIN
+#define SIZE_MIN	0
+#endif
+#if INTPTR_WIDTH == 64
+#define SIZE_MAX	UINT64_MAX
+#define SIZE_WIDTH	64
+#else
+#define SIZE_MAX	UINT32_MAX
+#define SIZE_WIDTH	32
+#endif
+
+/*
+ * wchar_t is 32 bits and equals Rune; see the note in <stddef.h>. This
+ * said 16 while <wchar.h> said WCHAR_MAX was Runemax, 0x10FFFF.
+ *
+ * C99 7.18.3 puts WCHAR_MIN and WCHAR_MAX in this header as well as in
+ * <wchar.h>, and gnulib reads them from here. Spelled numerically because
+ * Runemax comes from <utf.h>, which this header does not pull in; the
+ * guards let the two headers agree in either include order.
+ */
+#define WCHAR_WIDTH	32
+#ifndef WCHAR_MIN
+#define WCHAR_MIN	0
+#endif
+#ifndef WCHAR_MAX
+#define WCHAR_MAX	0x10FFFF
+#endif
+#define WINT_WIDTH	32
+#define SIG_ATOMIC_WIDTH	32
+
+#endif


### PR DESCRIPTION
The #error added in the last commit fired during the libap rebuild, and its include stack is the whole story:

	/sys/include/ape/stdint.h:57  /amd64/include/ape/stdint.h:7
	  #error "stdint.h: _BITS64 is set but INTPTR_WIDTH is not 64"

There is a /amd64/include/ape/stdint.h, and it is not this tree's. Stock 9front APE keeps stdint.h in the architecture directory, pcc searches that directory first (pcc.c:234-235), and this tree had nothing of that name there to shadow it -- the same trap as float.h, two commits ago.

Worse than being ignored, though: the stock header takes the guard name _STDINT_ARCH_H_, which is the guard on APExp's own stdint_arch.h. So the stock file won the search, set the guard, chained into APExp's generic header, and APExp's arch header then compiled to nothing. The typedefs came from the stock file -- right by luck on amd64, which is why sizeof(uintptr_t) was 8 -- and INTPTR_WIDTH was never defined at all. SIZE_MAX is chosen by "#if INTPTR_WIDTH == 64", hence 0xffffffff against an 8-byte size_t, hence ls walking off the heap.

Fixed the way float.h was:

  - every architecture directory gets a real stdint.h, so the stock one is never reached;
  - the content moves to sys/include/ape/stdint_generic.h, because none of those twelve copies can reach "the other stdint.h" by that name -- the search would find itself. stdint_arch.h's trailing include follows;
  - INTPTR_WIDTH now derives from _BITS64 and OVERRIDES rather than defers. Deferring is what let this survive: the stock header left INTPTR_WIDTH undefined rather than wrong, and the previous commit's guard on !defined(_STDINT_ARCH_H_) declined to correct it. The remaining #error is only for a width of 64 where nothing said 64-bit, which would mean two headers from different architectures.

Checked by preprocessing the real headers in a mock search path, in all three arrangements: the normal one, the broken one where a stock header wins and neutralises stdint_arch.h, and a 32-bit architecture. 64, 64 and 32.

CLAUDE.md's note on this search order now says it has cost two bugs, lists the three headers stock APE keeps per architecture -- float.h, stdarg.h, stdint.h -- and records that stdarg.h is the same trap, still armed, and harmless only because APExp's copy adds nothing.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs