### PR TITLE
core: expr.c asserted that size_t fits in unsigned long

### DIFF
--- a/sys/src/ape/cmd/core/mkfile
+++ b/sys/src/ape/cmd/core/mkfile
@@ -57,6 +57,24 @@ APEXPROOT=../../../../..
 # ginstall installs under that name, not as install, which is what
 # upstream's transform does. Rename it here if that matters.
 
+# Local changes to the vendored coreutils sources, to be reapplied on a
+# re-import. Keep this list complete; it is the only record.
+#
+#   src/expr.c   The assert
+#
+#                  static_assert (SIZE_MAX <= ULONG_MAX);
+#
+#                is removed. kencc's long is 32-bit on amd64 while
+#                size_t is 64-bit, so it does not hold -- it passed
+#                until 2026-08 only because SIZE_MAX was itself wrong.
+#                Every size_t this file gives to or takes from GMP is a
+#                string length or an offset into an argv string, so
+#                nothing can reach the 4 GiB where it would matter. The
+#                reasoning is written out where the assert was.
+#
+# Everything else about this port lives outside the package: this
+# mkfile, config.h, and the shared gnulib tree.
+
 CORESRC=$APEXPROOT/sys/src/external/coreutils
 GNUSRC=$APEXPROOT/sys/src/external/gnulib
 

--- a/sys/src/external/coreutils/src/expr.c
+++ b/sys/src/external/coreutils/src/expr.c
@@ -42,8 +42,34 @@
 #include "xstrtol.h"
 
 /* Various parts of this code assume size_t fits into unsigned long
-   int, the widest unsigned type that GMP supports.  */
-static_assert (SIZE_MAX <= ULONG_MAX);
+   int, the widest unsigned type that GMP supports.
+
+   APExp: that does not hold on Plan 9 amd64, and this was
+
+     static_assert (SIZE_MAX <= ULONG_MAX);
+
+   kencc's long is 32-bit on amd64 while pointers and size_t are 64-bit,
+   so ULONG_MAX is 0xffffffff and SIZE_MAX is 0xffffffffffffffff. The
+   assert did pass until 2026-08, but only because SIZE_MAX was itself
+   wrong -- see sys/include/ape/stdint_generic.h.
+
+   Removed rather than worked around, because every size_t this file
+   actually hands to or takes from GMP is a string length or an offset
+   into a string, and expr's strings come from argv:
+
+     int_value (mbslen (r->u.s))          for "length"
+     int_value (mbs_logical_cspn (...))   for "index"
+     getsize (), which reads a value back out with mpz_get_ui ()
+
+   The first two would need an argument of 4 GiB to truncate, which
+   ARG_MAX forbids. getsize is safe in the other direction by
+   construction: a value too big for unsigned long fails
+   mpz_fits_ulong_p and it returns SIZE_MAX - 1, its "too large" answer,
+   which mbs_logical_substr already treats as past the end of the string
+   -- the same result a true 64-bit value would have produced.
+
+   If coreutils is re-imported, this is the one local change to
+   src/expr.c.  */
 
 /* The official name of this program (e.g., no 'g' prefix).  */
 #define PROGRAM_NAME "expr"


### PR DESCRIPTION
	expr.c:46 _Static_assert failed

	static_assert (SIZE_MAX <= ULONG_MAX);

kencc's long is 32-bit on amd64 while pointers and size_t are 64-bit, so ULONG_MAX is 0xffffffff against a SIZE_MAX of 0xffffffffffffffff. The assert has been failing all along in principle; it passed until the previous commit only because SIZE_MAX was itself 32-bit -- the same bug that killed ls. Fixing SIZE_MAX is what let this one speak up.

The assert is right about the platform and wrong about the danger. Removed, with the reasoning where it was: every size_t this file hands to or takes from GMP is a string length or an offset into a string, and expr's strings come from argv.

	int_value (mbslen (r->u.s))           for "length"
	int_value (mbs_logical_cspn (...))    for "index"
	getsize (), which reads back with mpz_get_ui

The first two would need a 4 GiB argument to truncate, which ARG_MAX forbids. getsize is safe in the other direction by construction: a value too big for unsigned long fails mpz_fits_ulong_p, so it returns SIZE_MAX - 1 -- its "too large" answer -- and mbs_logical_substr already treats that as past the end of the string, which is what a true 64-bit value would have produced anyway.

Swept the rest of the built sources for asserts of the same shape. Only this one is affected: parse-datetime.c's two are about time_t against intmax_t, and strtoimax.c is not built.

There was no record of local changes to the vendored coreutils, so core/mkfile now carries one, with this as its only entry.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs