### PR TITLE
ape: spell S_IXUGO the way everyone else spells it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -711,6 +711,38 @@ divide unsigned. `UINTMAX_MAX / 2` came out 0, so GNU tar's
 fired its `#error`. cpp no longer relies on the implicit conversion.
 Any other `signed_lvalue op= (unsigned)x` in the tree is still wrong.
 
+### Macro identity includes whether there is white space
+
+C99 6.10.3p2: two definitions of the same macro are the same only if the
+*presence* of white-space separation matches at every point (the amount does
+not matter). `cpp/macro.c`'s `comparetokens()` implements exactly that:
+
+```c
+(tp1->wslen==0) != (tp2->wslen==0)
+```
+
+So a definition differing only in spacing is a **redefinition error**, not a
+harmless repetition. This has now bitten twice, and both times the other
+definition was unguarded, so APExp's spelling is the one that had to move:
+
+- `weak_alias` — `<features.h>` said `(old, new)`, gnulib's `libc-config.h`
+  says `(name, aliasname)`. Parameter names count as tokens.
+- `S_IXUGO` — APE said `(S_IXUSR|S_IXGRP|S_IXOTH)`, and gnulib, gtar,
+  diffutils, bison and readline all say `(S_IXUSR | S_IXGRP | S_IXOTH)`.
+  readline's `posixstat.h:160` has no guard, so the two met on a full rebuild.
+
+**Rule:** when adding a macro to an APE header that portable code also
+defines, copy the upstream spelling character for character, and guard it.
+Guarding alone is not enough — it only helps when APExp's header is read
+second.
+
+`/tmp`-style one-off check, if this is suspected again: compare token
+sequences *with* leading-whitespace flags between APE's headers and unguarded
+`#define`s under `sys/src/external`. The only other whitespace-only pairs
+today are inert — `.in.h` templates that are never compiled, and per-package
+vendored copies (bison's own `obstack.h`, tk's `MIN`/`MAX`) that never meet
+APE's headers.
+
 ### Unsigned 64-bit to floating point (FIXED)
 
 Both halves of this conversion were wrong, and neither mattered until

--- a/sys/include/ape/sys/stat.h
+++ b/sys/include/ape/sys/stat.h
@@ -80,12 +80,29 @@ struct	stat {
  * header, so define them as gnulib does:
  *
  *   extract.c:429 name not declared: S_IXUGO
+ *
+ * Spelled with spaces around the bars, exactly as gnulib, gtar,
+ * diffutils, bison and readline all spell them. That is not cosmetic:
+ * C99 6.10.3p2 makes the PRESENCE of white-space separation part of a
+ * macro's identity, and cpp/macro.c's comparetokens() implements it --
+ *
+ *	(tp1->wslen==0) != (tp2->wslen==0)
+ *
+ * -- so a definition that differs only in spacing is a redefinition
+ * rather than a repetition. readline's posixstat.h:160 defines S_IXUGO
+ * with no guard of its own, so the two meet:
+ *
+ *	readline/posixstat.h:160 Macro redefinition of S_IXUGO
+ *
+ * Written the way everyone else writes it, both definitions are
+ * identical and cpp accepts the second silently. Same reasoning as the
+ * weak_alias parameter names in <features.h>.
  */
 #ifndef S_IXUGO
-#define S_IXUGO		(S_IXUSR|S_IXGRP|S_IXOTH)
+#define S_IXUGO		(S_IXUSR | S_IXGRP | S_IXOTH)
 #endif
 #ifndef S_IRWXUGO
-#define S_IRWXUGO	(S_IRWXU|S_IRWXG|S_IRWXO)
+#define S_IRWXUGO	(S_IRWXU | S_IRWXG | S_IRWXO)
 #endif
 
 #ifndef S_ISDOOR		/* Solaris 2.5 and up */


### PR DESCRIPTION
	readline/posixstat.h:160 Macro redefinition of S_IXUGO

APE had

	#define S_IXUGO		(S_IXUSR|S_IXGRP|S_IXOTH)

and gnulib, gtar, diffutils, bison and readline all have

	#define S_IXUGO		(S_IXUSR | S_IXGRP | S_IXOTH)

That is not cosmetic. C99 6.10.3p2 makes the PRESENCE of white-space separation part of a macro's identity, and cpp/macro.c's comparetokens() implements it:

	(tp1->wslen==0) != (tp2->wslen==0)

so a definition differing only in spacing is a redefinition rather than a repetition, and cpp is right to say so. readline's posixstat.h defines S_IXUGO with no guard of its own, so on a full rebuild the two met. APE's guard does not help: it only fires when APE's header is read second.

Written the way everyone else writes it, both definitions are identical and cpp accepts the second silently. S_IRWXUGO gets the same treatment before it does the same thing.

Second time this shape of bug has appeared -- weak_alias in <features.h> was the first, where the parameter names differed -- so CLAUDE.md now carries the rule: copy the upstream spelling character for character, and guard as well.

Swept for the rest of the class, comparing token sequences with their leading-whitespace flags between APE's headers and every unguarded #define under sys/src/external. Nothing else is live: the remaining whitespace-only pairs are in *.in.h templates, which are never compiled, or in per-package vendored copies -- bison's own obstack.h, tk's MIN and MAX -- which never meet APE's headers in a build that works today.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs