### PR TITLE
gnulib: build execute and spawn-pipe after all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,10 +435,15 @@ pointer. Covered by `sys/lib/tests/posix-spawn-test.c`.
 Missing before, and the reason gnulib's own spawn replacement got pulled in:
 `posix_spawnattr_setsigdefault`/`getsigdefault`, `setpgroup`/`getpgroup`,
 `setschedparam`/`setschedpolicy` and their getters were declared in
-`spawn.h` but undefined in libap. **Do not build gnulib's `spawn*.c` or
-`execute.c`/`spawn-pipe.c` into the shared archive** — gnulib's
-`posix_spawnattr_t` has glibc's `_sd`/`_ss` members and does not compile
-against APE's `<spawn.h>`.
+`spawn.h` but undefined in libap. **Do not build gnulib's `spawn*.c` into the
+shared archive** — gnulib's `posix_spawnattr_t` has glibc's `_sd`/`_ss`
+members and does not compile against APE's `<spawn.h>`.
+
+`execute.c` and `spawn-pipe.c` *are* built, and are the reason libap's
+implementation has to be real rather than a stub: bison and m4 both link the
+shared `libgnu.a` rather than a `lib/` of their own (`libbison.a` is two
+objects, `main` and `yyerror`), and they reach `create_pipe_bidi` and
+`execute`, which wire up a child entirely through file actions.
 
 ### aio/ — async I/O on pthreads
 

--- a/sys/src/ape/cmd/gnulib/mkfile
+++ b/sys/src/ape/cmd/gnulib/mkfile
@@ -96,20 +96,25 @@ GNUSRC=$APEXPROOT/sys/src/external/gnulib
 #                                     selinux/*.h, which this tree keeps,
 #                                     and copy.c calls lgetfilecon_raw
 #                                     with no guard at all.
-#   execute, spawn-pipe,              These build gnulib's own posix_spawn
-#   spawnattr_setdefault              replacement, whose posix_spawnattr_t
-#                                     has glibc's _sd/_ss members. APE's
-#                                     <spawn.h> declares the type itself
-#                                     (__def/__mask), so spawnattr_setdefault.c
-#                                     does not compile against it, and libap
-#                                     implements the whole API in
-#                                     ap/process/posix_spawn.c. Nothing in
-#                                     the shared tree calls execute() or
-#                                     create_pipe_*; bison and m4 do, but
-#                                     from their own lib/ copies. If they
-#                                     ever move here, build execute.c and
-#                                     spawn-pipe.c and let them use libap's
-#                                     posix_spawn -- do not build gnulib's.
+#   spawnattr_setdefault, and the     gnulib's own posix_spawn replacement.
+#   rest of gnulib's spawn*.c         Its posix_spawnattr_t has glibc's
+#                                     _sd/_ss members, while APE's <spawn.h>
+#                                     declares the type itself with
+#                                     __def/__mask, so spawnattr_setdefault.c
+#                                     does not compile against it. It does not
+#                                     need to: libap implements the whole API
+#                                     in ap/process/posix_spawn.c, file
+#                                     actions and attributes included.
+#
+#                                     execute.$O and spawn-pipe.$O ARE built,
+#                                     and call that API. bison and m4 both
+#                                     link this archive rather than a lib/ of
+#                                     their own -- libbison.a is two objects,
+#                                     main and yyerror -- so leaving them out
+#                                     cost:
+#                                       output_skeleton: undefined:
+#                                         create_pipe_bidi
+#                                       print_html: undefined: execute
 #   hash-triple-simple                The old name for hashcode-named-file:
 #                                     same triple_hash, triple_compare_ino_str
 #                                     and triple_free, and hash-triple.h is
@@ -187,6 +192,7 @@ OFILES=\
 	error.$O\
 	euidaccess.$O\
 	exclude.$O\
+	execute.$O\
 	fadvise.$O\
 	fatal-signal.$O\
 	fd-reopen.$O\
@@ -340,6 +346,7 @@ OFILES=\
 	sigsegv.$O\
 	sm3.$O\
 	sm3-stream.$O\
+	spawn-pipe.$O\
 	stat-time.$O\
 	stdbit.$O\
 	stdlib.$O\


### PR DESCRIPTION
	output_skeleton: undefined: create_pipe_bidi in output_skeleton
	print_html: undefined: execute in print_html

I took both out when libap's posix_spawn was rewritten, on the grounds that "bison and m4 do call these, but from their own lib/ copies". That is not true. Both link this archive: bison's LIB is

	libbison.a$O ../gnulib/libgnu.a$O

and libbison.a is two objects, liby_a-main and liby_a-yyerror. m4 links the shared archive directly.

The reason they were removed does not apply to them anyway. It applies to gnulib's own posix_spawn replacement -- spawnattr_setdefault.c and the other spawn*.c, whose posix_spawnattr_t has glibc's _sd and _ss members and does not compile against APE's <spawn.h>. execute.c and spawn-pipe.c only CALL the API, and every entry point they use exists in libap: posix_spawn, posix_spawnp, file_actions_init/destroy/addclose/ adddup2/addopen/addchdir, and spawnattr_init/destroy/setflags/ setpgroup/setsigmask. That set is exactly what ap/process/posix_spawn.c was made real for -- create_pipe_bidi wires up its child entirely through file actions, which is the case a stub cannot fake.

Their other dependencies were already here: find_in_given_path from findprog-in.$O, canonicalize, fatal-signal and wait-process all built, unistd-safer.h header-only with dup-safer, fd-safer and pipe-safer built, and windows-path guarded to _WIN32.

The note in the mkfile now says which half stays out and why, with the two undefined symbols recorded so the next person does not repeat the reasoning.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs