### PR TITLE
libtool: drop -DESTALE=EDEADLK, now that APE has ESTALE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,10 +736,28 @@ definition was unguarded, so APExp's spelling is the one that had to move:
   diffutils, bison and readline all say `(S_IXUSR | S_IXGRP | S_IXOTH)`.
   readline's `posixstat.h:160` has no guard, so the two met on a full rebuild.
 
+Only *interior* white space counts. `tokens.c` `normtokenrow()` ends with
+
+```c
+if (ntrp->lp > ntrp->bp)
+        ntrp->bp->wslen = 0;
+```
+
+so the first body token's leading space is discarded for both `#define` and
+`-D`. That is why `-DO_BINARY=0` on a command line coexists with
+`#define O_BINARY	0` in `<fcntl.h>`, while `S_IXUGO`'s spacing *between*
+its tokens did not.
+
 **Rule:** when adding a macro to an APE header that portable code also
 defines, copy the upstream spelling character for character, and guard it.
 Guarding alone is not enough — it only helps when APExp's header is read
 second.
+
+**Corollary for `-D` workarounds.** A `-DNAME=VALUE` in a mkfile that exists
+only because APE lacked `NAME` becomes a redefinition error the moment APE
+gains it. `sys/src/ape/cmd/libtool/mkfile` carried `-DESTALE=EDEADLK` for
+exactly that reason and had to lose it when `<errno.h>` gained `ESTALE`. When
+adding a name to an APE header, grep the mkfiles for `-D<name>=`.
 
 `/tmp`-style one-off check, if this is suspected again: compare token
 sequences *with* leading-whitespace flags between APE's headers and unguarded

--- a/sys/src/ape/cmd/libtool/mkfile
+++ b/sys/src/ape/cmd/libtool/mkfile
@@ -102,8 +102,16 @@ CFLAGS=-FVp -c -I$LTSRC/include -I$LTSRC/src/internal -I$LTSRC/build\
 	-DSLBT_PREFERRED_HOST_AS="/bin/as"\
 	-DSLBT_PREFERRED_HOST_NM="/bin/nm"\
 	-DSLBT_PREFERRED_HOST_RANLIB="/bin/ranlib"\
-	-DSLBT_MACHINE="$objtype"\
-	-DESTALE=EDEADLK
+	-DSLBT_MACHINE="$objtype"
+
+# -DESTALE=EDEADLK used to be on that list. It was there because APE had
+# no ESTALE and slbt_dump_machine.c does "errno = ESTALE;". <errno.h>
+# defines it now, as 72, so the two collide:
+#
+#   errno.h:109 ... slbt_archive_ctx.c:10 Macro redefinition of ESTALE
+#
+# and the real value is the better one to use anyway. Nothing else in
+# slibtool mentions ESTALE.
 
 %.$O: $LTSRC/src/%.c
 	$CC $CFLAGS $LTSRC/src/$stem.c


### PR DESCRIPTION
	errno.h:109 ... slbt_archive_ctx.c:10 Macro redefinition of ESTALE

slibtool's mkfile defined ESTALE on the command line because APE had none and slbt_dump_machine.c does "errno = ESTALE;". <errno.h> defines it now, as a value of its own rather than an alias of EDEADLK, so the two met on the fresh rebuild. The real value is the better one anyway, and ESTALE appears nowhere else in slibtool.

Checked the rest of the -D flags in the tree against what APE defines. Only this one conflicts. The near miss is instructive: several mkfiles pass -DO_BINARY=0 while <fcntl.h> has an unguarded

	#define O_BINARY	0

and that is fine, because cpp's normtokenrow() ends with

	if (ntrp->lp > ntrp->bp)
		ntrp->bp->wslen = 0;

which discards the first body token's leading space for both #define and -D. Only white space BETWEEN tokens is part of a macro's identity -- which is exactly why S_IXUGO's interior spacing was a redefinition and this is not. -DSETLOCALE_NULL_MAX=257 is likewise safe, since <locale.h> guards its own 256+1.

CLAUDE.md's note on macro identity now records the normtokenrow detail and the corollary: adding a name to an APE header means grepping the mkfiles for -D<name>=.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs