### PR TITLE
ape: shadow the stock stdarg.h too; drop -V from four mkfiles

### DIFF
--- a/386/include/ape/stdarg.h
+++ b/386/include/ape/stdarg.h
@@ -1,0 +1,23 @@
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
+
+/*
+ * <stdarg.h> for 386.
+ *
+ * This file has to exist, for the reason spelled out in the stdint.h
+ * beside it: pcc searches -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE keeps its
+ * stdarg.h in the architecture directory. APExp renamed that file to
+ * stdarg_arch.h and put a wrapper in /sys/include/ape, so with nothing
+ * named stdarg.h here, #include <stdarg.h> found the HOST's copy and
+ * the wrapper was never read.
+ *
+ * Worse, as with stdint.h, the stock header takes the same guard --
+ * __STDARG -- that stdarg_arch.h uses, so it did not merely win the
+ * search, it disabled APExp's file. va_copy is APExp's addition to
+ * these headers; whether any of it reached a compile depended entirely
+ * on whether the host had a stdarg.h of its own.
+ */
+#include <stdarg_arch.h>
+
+#endif /* _APEXP_STDARG_H_ */

--- a/68020/include/ape/stdarg.h
+++ b/68020/include/ape/stdarg.h
@@ -1,0 +1,23 @@
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
+
+/*
+ * <stdarg.h> for 68020.
+ *
+ * This file has to exist, for the reason spelled out in the stdint.h
+ * beside it: pcc searches -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE keeps its
+ * stdarg.h in the architecture directory. APExp renamed that file to
+ * stdarg_arch.h and put a wrapper in /sys/include/ape, so with nothing
+ * named stdarg.h here, #include <stdarg.h> found the HOST's copy and
+ * the wrapper was never read.
+ *
+ * Worse, as with stdint.h, the stock header takes the same guard --
+ * __STDARG -- that stdarg_arch.h uses, so it did not merely win the
+ * search, it disabled APExp's file. va_copy is APExp's addition to
+ * these headers; whether any of it reached a compile depended entirely
+ * on whether the host had a stdarg.h of its own.
+ */
+#include <stdarg_arch.h>
+
+#endif /* _APEXP_STDARG_H_ */

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,9 +617,14 @@ never looked for the NUL. GNU `ls` read its way off the end of the heap.
   defers, so a shadowed or neutralised arch header cannot produce a wrong
   width — only `#error`.
 
-Known so far to be kept per-architecture by stock APE: `float.h`, `stdarg.h`,
-`stdint.h`. `sys/include/ape/stdarg.h` is a pure wrapper that adds nothing, so
-it is currently harmless — but it is the same trap.
+Known to be kept per-architecture by stock APE: `float.h`, `stdarg.h`,
+`stdint.h`. **All three are now shadowed** by a real file in each architecture
+directory. `stdarg.h` was the same trap twice over: its content is in
+`stdarg_arch.h` under the guard `__STDARG`, which is the guard the stock
+header uses too, so the stock copy did not merely win the search — it
+disabled APExp's. `va_copy` is APExp's addition to those headers, and whether
+any of it reached a compile depended entirely on what the host happened to
+ship.
 
 `sys/lib/tests/limits-test.c` checks `(size_t)-1 == SIZE_MAX` and the same
 identity for the other types, and prints which of these headers were actually

--- a/amd64/include/ape/stdarg.h
+++ b/amd64/include/ape/stdarg.h
@@ -1,0 +1,23 @@
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
+
+/*
+ * <stdarg.h> for amd64.
+ *
+ * This file has to exist, for the reason spelled out in the stdint.h
+ * beside it: pcc searches -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE keeps its
+ * stdarg.h in the architecture directory. APExp renamed that file to
+ * stdarg_arch.h and put a wrapper in /sys/include/ape, so with nothing
+ * named stdarg.h here, #include <stdarg.h> found the HOST's copy and
+ * the wrapper was never read.
+ *
+ * Worse, as with stdint.h, the stock header takes the same guard --
+ * __STDARG -- that stdarg_arch.h uses, so it did not merely win the
+ * search, it disabled APExp's file. va_copy is APExp's addition to
+ * these headers; whether any of it reached a compile depended entirely
+ * on whether the host had a stdarg.h of its own.
+ */
+#include <stdarg_arch.h>
+
+#endif /* _APEXP_STDARG_H_ */

--- a/arm/include/ape/stdarg.h
+++ b/arm/include/ape/stdarg.h
@@ -1,0 +1,23 @@
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
+
+/*
+ * <stdarg.h> for arm.
+ *
+ * This file has to exist, for the reason spelled out in the stdint.h
+ * beside it: pcc searches -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE keeps its
+ * stdarg.h in the architecture directory. APExp renamed that file to
+ * stdarg_arch.h and put a wrapper in /sys/include/ape, so with nothing
+ * named stdarg.h here, #include <stdarg.h> found the HOST's copy and
+ * the wrapper was never read.
+ *
+ * Worse, as with stdint.h, the stock header takes the same guard --
+ * __STDARG -- that stdarg_arch.h uses, so it did not merely win the
+ * search, it disabled APExp's file. va_copy is APExp's addition to
+ * these headers; whether any of it reached a compile depended entirely
+ * on whether the host had a stdarg.h of its own.
+ */
+#include <stdarg_arch.h>
+
+#endif /* _APEXP_STDARG_H_ */

--- a/arm64/include/ape/stdarg.h
+++ b/arm64/include/ape/stdarg.h
@@ -1,0 +1,23 @@
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
+
+/*
+ * <stdarg.h> for arm64.
+ *
+ * This file has to exist, for the reason spelled out in the stdint.h
+ * beside it: pcc searches -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE keeps its
+ * stdarg.h in the architecture directory. APExp renamed that file to
+ * stdarg_arch.h and put a wrapper in /sys/include/ape, so with nothing
+ * named stdarg.h here, #include <stdarg.h> found the HOST's copy and
+ * the wrapper was never read.
+ *
+ * Worse, as with stdint.h, the stock header takes the same guard --
+ * __STDARG -- that stdarg_arch.h uses, so it did not merely win the
+ * search, it disabled APExp's file. va_copy is APExp's addition to
+ * these headers; whether any of it reached a compile depended entirely
+ * on whether the host had a stdarg.h of its own.
+ */
+#include <stdarg_arch.h>
+
+#endif /* _APEXP_STDARG_H_ */

--- a/mips/include/ape/stdarg.h
+++ b/mips/include/ape/stdarg.h
@@ -1,0 +1,23 @@
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
+
+/*
+ * <stdarg.h> for mips.
+ *
+ * This file has to exist, for the reason spelled out in the stdint.h
+ * beside it: pcc searches -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE keeps its
+ * stdarg.h in the architecture directory. APExp renamed that file to
+ * stdarg_arch.h and put a wrapper in /sys/include/ape, so with nothing
+ * named stdarg.h here, #include <stdarg.h> found the HOST's copy and
+ * the wrapper was never read.
+ *
+ * Worse, as with stdint.h, the stock header takes the same guard --
+ * __STDARG -- that stdarg_arch.h uses, so it did not merely win the
+ * search, it disabled APExp's file. va_copy is APExp's addition to
+ * these headers; whether any of it reached a compile depended entirely
+ * on whether the host had a stdarg.h of its own.
+ */
+#include <stdarg_arch.h>
+
+#endif /* _APEXP_STDARG_H_ */

--- a/power/include/ape/stdarg.h
+++ b/power/include/ape/stdarg.h
@@ -1,0 +1,23 @@
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
+
+/*
+ * <stdarg.h> for power.
+ *
+ * This file has to exist, for the reason spelled out in the stdint.h
+ * beside it: pcc searches -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE keeps its
+ * stdarg.h in the architecture directory. APExp renamed that file to
+ * stdarg_arch.h and put a wrapper in /sys/include/ape, so with nothing
+ * named stdarg.h here, #include <stdarg.h> found the HOST's copy and
+ * the wrapper was never read.
+ *
+ * Worse, as with stdint.h, the stock header takes the same guard --
+ * __STDARG -- that stdarg_arch.h uses, so it did not merely win the
+ * search, it disabled APExp's file. va_copy is APExp's addition to
+ * these headers; whether any of it reached a compile depended entirely
+ * on whether the host had a stdarg.h of its own.
+ */
+#include <stdarg_arch.h>
+
+#endif /* _APEXP_STDARG_H_ */

--- a/power64/include/ape/stdarg.h
+++ b/power64/include/ape/stdarg.h
@@ -1,0 +1,23 @@
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
+
+/*
+ * <stdarg.h> for power64.
+ *
+ * This file has to exist, for the reason spelled out in the stdint.h
+ * beside it: pcc searches -I/$objtype/include/ape before
+ * -I/sys/include/ape (pcc.c:234-235), and stock 9front APE keeps its
+ * stdarg.h in the architecture directory. APExp renamed that file to
+ * stdarg_arch.h and put a wrapper in /sys/include/ape, so with nothing
+ * named stdarg.h here, #include <stdarg.h> found the HOST's copy and
+ * the wrapper was never read.
+ *
+ * Worse, as with stdint.h, the stock header takes the same guard --
+ * __STDARG -- that stdarg_arch.h uses, so it did not merely win the
+ * search, it disabled APExp's file. va_copy is APExp's addition to
+ * these headers; whether any of it reached a compile depended entirely
+ * on whether the host had a stdarg.h of its own.
+ */
+#include <stdarg_arch.h>
+
+#endif /* _APEXP_STDARG_H_ */

--- a/power64/include/ape/stdarg_arch.h
+++ b/power64/include/ape/stdarg_arch.h
@@ -8,4 +8,11 @@ typedef char *va_list;
 #define va_arg(list, mode) (sizeof(mode)==1 ? ((mode *) (list += 4))[-4] : \
 sizeof(mode)==2 ? ((mode *) (list += 4))[-2] : ((mode *) (list += sizeof(mode)))[-1])
 
+/* va_copy is C99. Plan 9's va_list is a plain char *, so copying the
+   object is the whole of it. */
+#ifndef va_copy
+#define va_copy(dst, src) \
+	((dst) = (src))
+#endif
+
 #endif /* __STDARG */

--- a/sparc/include/ape/stdarg.h
+++ b/sparc/include/ape/stdarg.h
@@ -8,4 +8,11 @@ typedef char *va_list;
 #define va_arg(list, mode) (sizeof(mode)==1 ? ((mode *) (list += 4))[-4] : \
 sizeof(mode)==2 ? ((mode *) (list += 4))[-2] : ((mode *) (list += sizeof(mode)))[-1])
 
+/* va_copy is C99. Plan 9's va_list is a plain char *, so copying the
+   object is the whole of it. */
+#ifndef va_copy
+#define va_copy(dst, src) \
+	((dst) = (src))
+#endif
+
 #endif /* __STDARG */

--- a/sys/include/ape/stdarg.h
+++ b/sys/include/ape/stdarg.h
@@ -1,6 +1,15 @@
-#ifndef _STDARG_H
+#ifndef _APEXP_STDARG_H_
+#define _APEXP_STDARG_H_
 
+/*
+ * The generic <stdarg.h>, for anything reaching /sys/include/ape without
+ * an architecture directory ahead of it. pcc normally does not get here:
+ * every architecture now has its own, which is what shadows the host's
+ * stock copy. Both chain to stdarg_arch.h.
+ *
+ * This used to test _STDARG_H and never define it, so it had no include
+ * guard at all and leaned on stdarg_arch.h's __STDARG.
+ */
 #include <stdarg_arch.h>
 
-#endif /* _STDARG_H */
-
+#endif /* _APEXP_STDARG_H_ */

--- a/sys/src/ape/cmd/libtool/mkfile
+++ b/sys/src/ape/cmd/libtool/mkfile
@@ -94,7 +94,7 @@ LIB=
 
 <$APEXPROOT/sys/src/cmd/mkone
 
-CFLAGS=-FVp -c -I$LTSRC/include -I$LTSRC/src/internal -I$LTSRC/build\
+CFLAGS=-Fp -c -I$LTSRC/include -I$LTSRC/src/internal -I$LTSRC/build\
 	-D_POSIX_SOURCE -D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE\
 	-D_BSD_SOURCE -DSLBT_PACKAGE_DATADIR="/sys/lib/ape/libtool"\
 	-DSLBT_PACKAGE_M4DIR="/sys/lib/ape/m4"\

--- a/sys/src/ape/cmd/pkgconf/mkfile
+++ b/sys/src/ape/cmd/pkgconf/mkfile
@@ -26,7 +26,7 @@ LIB= libpkgconf.a$O
 
 <$APEXPROOT/sys/src/cmd/mkmany
 
-CFLAGS=-FVp -c -I$PCSRC -I$PCSRC/libpkgconf\
+CFLAGS=-Fp -c -I$PCSRC -I$PCSRC/libpkgconf\
 		 -I$PCSRC/cli -I$PCSRC/cli/bomtool\
 		-DHAVE_CONFIG_H -DPKGCONFIG_IS_STATIC\
 		-DSYSTEM_INCLUDEDIR="/sys/include/ape"\

--- a/sys/src/ape/cmd/samurai/mkfile
+++ b/sys/src/ape/cmd/samurai/mkfile
@@ -23,7 +23,7 @@ OFILES=\
 
 <$APEXPROOT/sys/src/cmd/mkone
 
-CFLAGS=-FVp -c -I$SAMUSRC
+CFLAGS=-Fp -c -I$SAMUSRC
 
 %.$O: $SAMUSRC/%.c
 	$CC $CFLAGS $SAMUSRC/$stem.c

--- a/sys/src/ape/cmd/tclsh/mkfile
+++ b/sys/src/ape/cmd/tclsh/mkfile
@@ -12,7 +12,7 @@ LIB=$APEXPROOT/$objtype/lib/ape/libtcl.a $APEXPROOT/$objtype/lib/ape/libz.a
 
 <$APEXPROOT/sys/src/cmd/mkone
 
-CFLAGS=-FVp -c -I$APEXPROOT/sys/src/ape/lib/tcl\
+CFLAGS=-Fp -c -I$APEXPROOT/sys/src/ape/lib/tcl\
 	-I$TCLSRC/plan9 -I$TCLSRC/generic\
 	-I$TCLSRC/unix -I$TCLSRC/libtommath\
 	-DHAVE_TCL_CONFIG_H -DPLAN9

--- a/sys/src/cmd/pcc.c
+++ b/sys/src/cmd/pcc.c
@@ -178,6 +178,16 @@ main(int argc, char *argv[])
 		case 'S':
 			Sflag = 1;
 			break;
+		/*
+		 * -V and -+ belong to cpp, not here: cpp/nlist.c has -V
+		 * for verbose and -+ ignored for compatibility. Four
+		 * mkfiles used to say "-FVp", which meant one
+		 *
+		 *   cc: flag -V ignored
+		 *
+		 * per source file and nothing else. Pass cpp flags with
+		 * -Wp, if they are actually wanted.
+		 */
 		default:
 			fprint(2, "cc: flag -%c ignored\n", ARGC());
 			break;


### PR DESCRIPTION
stdarg.h is the third and last of the headers stock APE keeps in the architecture directory, after float.h and stdint.h, and it had both of stdint.h's problems.

pcc searches -I/$objtype/include/ape before -I/sys/include/ape, and eight of the eleven architectures had only stdarg_arch.h, nothing named stdarg.h. So #include <stdarg.h> found the host's copy. And stdarg_arch.h is guarded with __STDARG, which is the guard the stock header uses as well -- sparc, sparc64 and spim still hold the unrenamed stock content and show it -- so the stock copy did not merely win the search, it disabled APExp's file.

va_copy is APExp's addition to these headers. Whether any of it reached a compile depended entirely on what the host shipped. Every architecture now has a stdarg.h that chains to stdarg_arch.h.

Two gaps found while checking: power64's stdarg_arch.h had no va_copy at all, and neither did sparc's. Added, guarded. sys/include/ape/stdarg.h tested _STDARG_H and never defined it, so it had no include guard of its own either.

Separately, four mkfiles said CFLAGS=-FVp. -V is cpp's verbose flag (cpp/nlist.c:144), not one of pcc's, so it fell to pcc's default case and printed

	cc: flag -V ignored

once per source file in libtool, pkgconf, samurai and tclsh, and did nothing else. Now -Fp. pcc's default case says where -V and -+ actually live and that -Wp, is the way to reach them.

-p stays. It is a documented no-op in pcc -- it asks for the ANSI cpp, which is already what pcc does -- and the comment there explains why forwarding it was fatal. Keeping it states the intent.

sys/src/ape/9src/cc.c is one line, "#include ../../cmd/pcc.c", so there is nothing left of the pcc/cc split to unpick: APE's cc is pcc.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs