### PR TITLE
cc: char * against unsigned char * warns rather than refusing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -721,6 +721,39 @@ divide unsigned. `UINTMAX_MAX / 2` came out 0, so GNU tar's
 fired its `#error`. cpp no longer relies on the implicit conversion.
 Any other `signed_lvalue op= (unsigned)x` in the tree is still wrong.
 
+### char * against unsigned char * is a warning, not an error
+
+`char *` and `unsigned char *` are distinct types, so passing one where the
+other is declared is a constraint violation and C requires a diagnostic. gcc
+and clang give a warning — `-Wpointer-sign`, not in `-Werror` by default — so
+portable C is full of it, and there is no spelling that avoids a cast at every
+call. kencc used to refuse:
+
+```
+a_object.c:185 argument prototype mismatch "IND CHAR" for "IND CONST UCHAR":
+  CBB_add_bytes
+```
+
+from LibreSSL's `CBB_add_bytes(cbb, s, n)` with `char s[22]` against
+`int CBB_add_bytes(CBB *, const uint8_t *, size_t)`.
+
+`cc/sub.c` `stcompat()` now calls `charptrsign()` in the `BIND`/`TIND` branch
+and warns instead. **One level only, and only between the two one-byte integer
+types** — `int *` for `char *` is still an error, and so is `char **` for
+`unsigned char **`, which is the case where the difference can actually be
+observed.
+
+This cannot change code generation: `char` and `unsigned char` have the same
+representation, so the only thing that differs is whether a diagnostic is
+fatal. `warn()` is gated on `debug['w']`, so it is quiet unless `-w` is passed.
+
+Note `rsametype()` in `dcl.c` compares `etype` and the `GNORET` bit and
+nothing else — it already ignores `const` and `volatile`, which is why
+`char *` → `const char *` was never the problem here.
+
+Covered by `sys/lib/tests/charptr-test.c`, whose real test is that it
+compiles: every case in it is a constraint violation of that shape.
+
 ### Macro identity includes whether there is white space
 
 C99 6.10.3p2: two definitions of the same macro are the same only if the

--- a/sys/lib/tests/charptr-test.c
+++ b/sys/lib/tests/charptr-test.c
@@ -1,0 +1,154 @@
+/*
+ * charptr-test.c -- char * against unsigned char * across a prototype.
+ *
+ * "char *" and "unsigned char *" are distinct types, so passing one
+ * where the other is declared is a constraint violation and C requires
+ * a diagnostic. gcc and clang give a warning -- -Wpointer-sign, not in
+ * -Werror by default -- and kencc used to give an error:
+ *
+ *   a_object.c:185 argument prototype mismatch "IND CHAR" for
+ *     "IND CONST UCHAR": CBB_add_bytes
+ *
+ * from LibreSSL's
+ *
+ *   char s[22];
+ *   n = snprintf(s, sizeof(s), fmt, arc);
+ *   if (!CBB_add_bytes(cbb, s, n))
+ *
+ * against "int CBB_add_bytes(CBB *, const uint8_t *, size_t)". Portable
+ * C is full of this and there is no spelling that avoids a cast at every
+ * call, so cc/sub.c now warns rather than refusing -- see charptrsign()
+ * there.
+ *
+ * The point of this file is that it has to COMPILE. Everything in it is
+ * a constraint violation of exactly that shape; if the relaxation is
+ * ever lost, this stops building rather than failing at run time. The
+ * value checks confirm the obvious -- that a relaxation which changes
+ * no representation changes no behaviour.
+ *
+ * Deliberately NOT here, because they must stay errors: "char **" for
+ * "unsigned char **", which is the case where the difference can be
+ * observed, and any pointer of a different width.
+ *
+ * Build and run:  pcc -o charptr-test charptr-test.c
+ * Prints "PASS" per case; exit status is the number of failures.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+static int failures;
+
+static void
+check(const char *what, int ok, const char *detail)
+{
+	if (ok)
+		printf("PASS  %s\n", what);
+	else {
+		printf("FAIL  %s%s%s\n", what, detail ? ": " : "",
+		       detail ? detail : "");
+		failures++;
+	}
+}
+
+/* The shape LibreSSL uses: a const unsigned char * parameter. */
+static unsigned long
+sum_u(const unsigned char *p, size_t n)
+{
+	unsigned long t = 0;
+	size_t i;
+
+	for (i = 0; i < n; i++)
+		t += p[i];
+	return t;
+}
+
+/* And the mirror: a plain char * parameter. */
+static unsigned long
+sum_c(const char *p, size_t n)
+{
+	unsigned long t = 0;
+	size_t i;
+
+	for (i = 0; i < n; i++)
+		t += (unsigned char)p[i];
+	return t;
+}
+
+static int
+takes_uchar(unsigned char *p)
+{
+	p[0] = 'z';
+	return p[0];
+}
+
+static int
+takes_char(char *p)
+{
+	p[0] = 'y';
+	return p[0];
+}
+
+int
+main(void)
+{
+	char cbuf[8];
+	unsigned char ubuf[8];
+	char detail[128];
+	unsigned long a, b;
+
+	memcpy(cbuf, "abcdefg", 8);
+	memcpy(ubuf, "abcdefg", 8);
+
+	/* char * for const unsigned char *, which is a_object.c's case. */
+	a = sum_u(cbuf, 7);
+	b = sum_c(cbuf, 7);
+	sprintf(detail, "%lu vs %lu", a, b);
+	check("char * passed as const unsigned char *", a == b && a == 700, detail);
+
+	/* unsigned char * for const char *, the other direction. */
+	a = sum_c(ubuf, 7);
+	sprintf(detail, "%lu", a);
+	check("unsigned char * passed as const char *", a == 700, detail);
+
+	/* Non-const, and written through: the pointee is one byte either
+	   way, so the store lands in the same place. */
+	check("char * passed as unsigned char *",
+	      takes_uchar(cbuf) == 'z' && cbuf[0] == 'z', "store went astray");
+	check("unsigned char * passed as char *",
+	      takes_char(ubuf) == 'y' && ubuf[0] == 'y', "store went astray");
+
+	/* Assignment and initialisation, not just argument passing --
+	   stcompat is reached through tasign for these too. */
+	{
+		unsigned char *up = cbuf;
+		char *cp = ubuf;
+
+		check("unsigned char * = char *", (void *)up == (void *)cbuf, NULL);
+		check("char * = unsigned char *", (void *)cp == (void *)ubuf, NULL);
+	}
+
+	/* uint8_t is what the LibreSSL prototypes actually say. It is
+	   unsigned char here, but go through the typedef in case that
+	   ever stops being true. */
+	{
+		const uint8_t *u8;
+
+		/* takes_uchar above wrote into cbuf; start from a known
+		   state rather than depending on the order of the cases. */
+		memcpy(cbuf, "abcdefg", 8);
+		u8 = cbuf;
+		check("char * to const uint8_t *", sum_u(u8, 7) == 700, NULL);
+	}
+
+	/* Returning one for the other. */
+	check("sizeof(char) == sizeof(unsigned char)",
+	      sizeof(char) == 1 && sizeof(unsigned char) == 1, NULL);
+
+	if (failures)
+		printf("\n%d failure(s)\n", failures);
+	else
+		printf("\nall ok\n");
+	return failures;
+}

--- a/sys/src/cmd/cc/sub.c
+++ b/sys/src/cmd/cc/sub.c
@@ -279,6 +279,50 @@ simplet(long b)
 	return types[TINT];
 }
 
+/*
+ * Do t1 and t2 differ only in the signedness of what they point at?
+ *
+ * "char *" and "unsigned char *" are distinct types, so passing one
+ * where the other is wanted is a constraint violation and C requires a
+ * diagnostic. Every compiler this code is written for makes that a
+ * warning -- gcc and clang call it -Wpointer-sign and it is not in
+ * -Werror by default -- so portable C is full of it. LibreSSL's
+ * asn1/a_object.c is representative:
+ *
+ *	char s[22];
+ *	n = snprintf(s, sizeof(s), fmt, arc);
+ *	if (!CBB_add_bytes(cbb, s, n))
+ *
+ * against "int CBB_add_bytes(CBB *, const uint8_t *, size_t)". There is
+ * nothing wrong with it, and there is no portable spelling that avoids
+ * a cast at every such call.
+ *
+ * Only one level, and only between the two one-byte integer types: an
+ * "int *" for a "char *" is still an error, and so is "char **" for
+ * "unsigned char **", which is the case where the difference can
+ * actually be observed. Signedness of the pointee changes no
+ * representation, so nothing generated differs either way.
+ */
+static int
+charptrsign(Type *t1, Type *t2)
+{
+	Type *p1, *p2;
+
+	if(t1 == T || t2 == T)
+		return 0;
+	if(t1->etype != TIND || t2->etype != TIND)
+		return 0;
+	p1 = t1->link;
+	p2 = t2->link;
+	if(p1 == T || p2 == T)
+		return 0;
+	if(p1->etype != TCHAR && p1->etype != TUCHAR)
+		return 0;
+	if(p2->etype != TCHAR && p2->etype != TUCHAR)
+		return 0;
+	return p1->etype != p2->etype;
+}
+
 int
 stcompat(Node *n, Type *t1, Type *t2, long ttab[])
 {
@@ -312,8 +356,12 @@ stcompat(Node *n, Type *t1, Type *t2, long ttab[])
 					return 1;
 		if(n->op != OCAST)
 		 	if(b == BIND && i == TIND)
-				if(!sametype(t1, t2))
-					return 1;
+				if(!sametype(t1, t2)) {
+					if(!charptrsign(t1, t2))
+						return 1;
+					warn(n, "pointer signedness: \"%T\" and \"%T\"",
+						t1, t2);
+				}
 		return 0;
 	}
 	return 1;


### PR DESCRIPTION
	a_object.c:185 argument prototype mismatch "IND CHAR" for
	  "IND CONST UCHAR": CBB_add_bytes

from LibreSSL's

	char s[22];
	n = snprintf(s, sizeof(s), fmt, arc);
	if (!CBB_add_bytes(cbb, s, n))

against "int CBB_add_bytes(CBB *, const uint8_t *, size_t)".

char * and unsigned char * are distinct types, so this is a constraint violation and C does require a diagnostic. But gcc and clang give a warning -- -Wpointer-sign, not in -Werror by default -- which is what the code is written against. There is no portable spelling that avoids a cast at every such call, and OpenSSL-family code has hundreds of them. Patching them one at a time in vendored source is not the answer; this is the compiler being stricter than the world it is meant to compile.

stcompat()'s BIND/TIND branch now asks charptrsign() before giving up, and warns instead. One level, and only between the two one-byte integer types: "int *" for "char *" is still an error, and so is "char **" for "unsigned char **" -- that is the case where the difference can actually be observed, since the pointed-to pointers would then be read back at the wrong signedness.

This cannot miscompile anything. char and unsigned char have the same representation, so the relaxation changes only whether a diagnostic is fatal, never what is generated. warn() is gated on debug['w'], so it stays quiet unless -w is passed.

Worth recording while looking at this: rsametype() in dcl.c compares etype and the GNORET bit and nothing else. It already ignores const and volatile, which is why "char *" for "const char *" was never the problem, only the signedness half of that error message.

New test sys/lib/tests/charptr-test.c, whose real assertion is that it compiles at all -- every case in it is a constraint violation of exactly this shape, so if the relaxation is lost it stops building rather than failing quietly. gcc reports seven -Wpointer-sign warnings for it and runs it clean.

Rebuild cc, then the arch compilers, per the note in CLAUDE.md.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs