### PR TITLE
cpp: raise the #include nesting limit from 20 to 200

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -721,6 +721,29 @@ divide unsigned. `UINTMAX_MAX / 2` came out 0, so GNU tar's
 fired its `#error`. cpp no longer relies on the implicit conversion.
 Any other `signed_lvalue op= (unsigned)x` in the tree is still wrong.
 
+### #include nesting limit was 20
+
+`cpp/include.c` had the depth guard written as a bare `20`. That is a guard
+against a circular include, and it also stopped LibreSSL, which reaches 20 on
+an ordinary chain with nothing repeated in it:
+
+```
+pthread.h compat/pthread.h signal.h time.h compat/time.h sys/stat.h
+compat/sys/stat.h unistd.h compat/unistd.h stdio_impl.h stdio.h
+compat/stdio.h utf.h wchar.h string.h compat/string.h netinet/in.h
+compat/netinet/in.h sys/socket.h compat/sys/socket.h  ->  b_sock.c
+```
+
+LibreSSL ships a `compat/` header for most system headers, each ending in an
+`#include_next` of the real one, so every step of a normal chain counts twice.
+
+Now `NINCDEPTH` in `cpp.h`, set to 200, which is what gcc and clang use for
+`-fmax-include-depth`. A genuine cycle passes 200 as fast as it passed 20.
+`incdepth` is a depth and not a count — `cpp.c:52` decrements it at each
+end-of-file — so this does not make a file with many includes any dearer.
+
+`NIF`, the `#if` nesting limit, is still 32 and has not been a problem.
+
 ### char * against unsigned char * is a warning, not an error
 
 `char *` and `unsigned char *` are distinct types, so passing one where the

--- a/sys/src/cmd/cpp/cpp.h
+++ b/sys/src/cmd/cpp/cpp.h
@@ -4,6 +4,31 @@
 #define	NINCLUDE 64		/* Max number of include directories (-I) */
 #define	NONCE	256		/* Max number of #pragma once directives */
 #define	NIF	32		/* depth of nesting of #if */
+
+/*
+ * Depth of nesting of #include. The guard is against a circular
+ * include, which this still catches immediately -- a cycle passes 200
+ * as fast as it passes 20.
+ *
+ * It was 20, written into the test in include.c. LibreSSL reaches
+ * exactly that on its own: it ships a compat/ header for most system
+ * headers, each ending in an #include_next of the real one, so every
+ * step of an ordinary chain counts twice --
+ *
+ *   pthread.h compat/pthread.h signal.h time.h compat/time.h
+ *   sys/stat.h compat/sys/stat.h unistd.h compat/unistd.h
+ *   stdio_impl.h stdio.h compat/stdio.h utf.h wchar.h string.h
+ *   compat/string.h netinet/in.h compat/netinet/in.h sys/socket.h
+ *   compat/sys/socket.h  ->  crypto/bio/b_sock.c
+ *
+ * -- and that is a legitimate chain with no repetition in it.
+ * 200 is what gcc and clang use for -fmax-include-depth.
+ *
+ * incdepth is a depth, not a count: cpp.c decrements it at the end of
+ * each included file. Raising it does not make a long list of includes
+ * in one file any more expensive.
+ */
+#define	NINCDEPTH 200		/* depth of nesting of #include */
 #ifndef EOF
 #define	EOF	(-1)
 #endif

--- a/sys/src/cmd/cpp/include.c
+++ b/sys/src/cmd/cpp/include.c
@@ -127,7 +127,7 @@ doinclude(Tokenrow *trp, int next)
 		for (i=0; i<nblocked; i++)
 			if (oncecmp(incblocked+i, &n) == 0)
 				return;
-		if (++incdepth > 20)
+		if (++incdepth > NINCDEPTH)
 			error(FATAL, "#include too deeply nested");
 		s = setsource((char*)newstring((uchar*)iname, strlen(iname), 0), fd, NULL);
 		s->pos = pos;


### PR DESCRIPTION
	#include too deeply nested

The guard exists to catch a circular include. It was a bare 20 in include.c, and LibreSSL reaches 20 on a chain with nothing repeated in it, because it ships a compat/ header for most system headers and each ends in an #include_next of the real one -- so every step of an ordinary chain counts twice:

	pthread.h compat/pthread.h signal.h time.h compat/time.h
	sys/stat.h compat/sys/stat.h unistd.h compat/unistd.h
	stdio_impl.h stdio.h compat/stdio.h utf.h wchar.h string.h
	compat/string.h netinet/in.h compat/netinet/in.h sys/socket.h
	compat/sys/socket.h  ->  crypto/bio/b_sock.c

That is twenty, exactly the limit, and every one of them is a distinct file.

Now NINCDEPTH in cpp.h, 200, which is what gcc and clang use for -fmax-include-depth. A cycle passes 200 as quickly as it passed 20, so nothing is lost.

Checked before changing it that incdepth is a depth rather than a running count: cpp.c:52 decrements it at each end-of-file. Had it only incremented, the limit would have been "twenty includes in a file" and raising it would have papered over a different bug.

NIF, the #if nesting limit, stays at 32.

Rebuild cpp; cc and the arch compilers are unaffected by this one.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs