### PR TITLE
ape: make eight headers self-contained; sys/uio.h returns ssize_t

### DIFF
--- a/sys/include/ape/arpa/nameser.h
+++ b/sys/include/ape/arpa/nameser.h
@@ -1,6 +1,9 @@
 #ifndef _ARPA_NAMESER_H
 #define _ARPA_NAMESER_H
 
+/* used in the buffer sizes, so that this header stands on its own. */
+#include <stddef.h>
+
 #include <stdint.h>
 #include <sys/types.h>
 

--- a/sys/include/ape/bio.h
+++ b/sys/include/ape/bio.h
@@ -4,6 +4,9 @@
 
 #ifndef __BIO_H_
 #define __BIO_H_
+
+/* Bprint takes a va_list, so that this header stands on its own. */
+#include <stdarg.h>
 #pragma	src	"/sys/src/libbio"
 #pragma	lib	"/$M/lib/ape/libbio.a"
 

--- a/sys/include/ape/fts.h
+++ b/sys/include/ape/fts.h
@@ -35,6 +35,9 @@
 #ifndef	_FTS_H_
 #define	_FTS_H_
 
+/* fts uses size_t for the name lengths, so that this header stands on its own. */
+#include <stddef.h>
+
 #pragma lib "/$M/lib/ape/libap.a"
 
 

--- a/sys/include/ape/grp.h
+++ b/sys/include/ape/grp.h
@@ -1,6 +1,9 @@
 #ifndef __GRP
 #define __GRP
 
+/* POSIX: <grp.h> defines size_t and gid_t, so that this header stands on its own. */
+#include <stddef.h>
+
 #pragma lib "/$M/lib/ape/libap.a"
 #include <sys/types.h>
 

--- a/sys/include/ape/langinfo.h
+++ b/sys/include/ape/langinfo.h
@@ -1,5 +1,8 @@
 #ifndef _LANGINFO_H
 #define _LANGINFO_H
+
+/* POSIX: <langinfo.h> defines locale_t; size_t is used here, so that this header stands on its own. */
+#include <stddef.h>
 #pragma lib "/$M/lib/ape/libap.a"
 
 #ifdef __cplusplus

--- a/sys/include/ape/pwd.h
+++ b/sys/include/ape/pwd.h
@@ -1,6 +1,9 @@
 #ifndef __PWD
 #define __PWD
 
+/* POSIX: <pwd.h> defines size_t, uid_t and gid_t, so that this header stands on its own. */
+#include <stddef.h>
+
 #pragma lib "/$M/lib/ape/libap.a"
 #include <sys/types.h>
 

--- a/sys/include/ape/sys/random.h
+++ b/sys/include/ape/sys/random.h
@@ -1,5 +1,8 @@
 #ifndef _SYS_RANDOM_H
 #define _SYS_RANDOM_H
+
+/* getentropy and getrandom both take a size_t, so that this header stands on its own. */
+#include <stddef.h>
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/include/ape/sys/uio.h
+++ b/sys/include/ape/sys/uio.h
@@ -8,6 +8,17 @@ extern "C" {
 #pragma lib "/$M/lib/ape/libap.a"
 
 /*
+ * size_t for iov_len and ssize_t for the two return values. This header
+ * used both and included nothing, so it compiled only when something
+ * else had defined them first. LibreSSL's include/compat/sys/uio.h
+ * reaches this one through #include_next before anything else has:
+ *
+ *   /sys/include/ape/sys/uio.h:20 syntax error, last name: size_t
+ */
+#include <stddef.h>
+#include <sys/types.h>
+
+/*
  * Copyright (c) 1982, 1986 Regents of the University of California.
  * All rights reserved.  The Berkeley software License Agreement
  * specifies the terms and conditions for redistribution.
@@ -20,8 +31,20 @@ struct iovec {
       size_t iov_len;    /* was int */
   };
 
-extern int writev(int, struct iovec*, int);
-extern int readv(int, struct iovec*, int);
+/*
+ * POSIX gives both an ssize_t return, and they said int. On amd64 that
+ * is the readlinkat bug again (see ap/unistd/at_functions.c): the
+ * callee writes four bytes where an ssize_t caller reads eight, so the
+ * top half is whatever was in the register. ap/unistd/writev.c and
+ * readv.c return ssize_t to match.
+ *
+ * Not const-qualified, unlike POSIX's "const struct iovec *", because
+ * the definitions are not either and a declaration that disagrees with
+ * its definition is worse than one that is merely lax. A caller passing
+ * a non-const array is unaffected.
+ */
+extern ssize_t writev(int, struct iovec*, int);
+extern ssize_t readv(int, struct iovec*, int);
 
 #ifdef __cplusplus
 }

--- a/sys/include/ape/utime.h
+++ b/sys/include/ape/utime.h
@@ -1,6 +1,9 @@
 #ifndef __UTIME_H
 #define __UTIME_H
 
+/* POSIX: <utime.h> defines time_t, so that this header stands on its own. */
+#include <sys/types.h>
+
 #pragma lib "/$M/lib/ape/libap.a"
 
 struct utimbuf

--- a/sys/src/ape/lib/ap/unistd/readv.c
+++ b/sys/src/ape/lib/ap/unistd/readv.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <sys/uio.h>
 
-int
+ssize_t
 readv(int fd, struct iovec *v, int ent)
 {
 	int x, i, n, len;

--- a/sys/src/ape/lib/ap/unistd/writev.c
+++ b/sys/src/ape/lib/ap/unistd/writev.c
@@ -8,7 +8,7 @@
 
 #include "priv.h"
 
-int
+ssize_t
 writev(int fd, struct iovec *v, int ent)
 {
 	int i, n, written;


### PR DESCRIPTION
	/sys/include/ape/sys/uio.h:20 syntax error, last name: size_t

<sys/uio.h> used size_t for iov_len and included nothing that defines it, so it compiled only where something else had got there first. LibreSSL's include/compat/sys/uio.h reaches it through #include_next before anything has. Fixed with <stddef.h> and <sys/types.h>.

While there: writev and readv were declared and defined returning int, and POSIX gives both ssize_t. That is the readlinkat bug again -- the note in ap/unistd/at_functions.c spells it out -- where on amd64 the callee writes four bytes and an ssize_t caller reads eight, leaving whatever was in the top half of the register. Header and both definitions now say ssize_t. Not const-qualified, unlike POSIX's "const struct iovec *": the definitions are not, and a declaration that disagrees with its definition is worse than one that is merely lax.

Swept the rest of sys/include/ape for the same shape -- a header naming size_t, ssize_t, time_t, va_list or FILE with nothing in its include closure that defines them. 34 hits, of which eight are APE's own and are fixed here: grp.h, pwd.h, langinfo.h, utime.h, sys/random.h, fts.h, arpa/nameser.h and bio.h.

The other 26 are upstream copies -- curl/, lzma/, openssl/, png.h, readline/, and the C++ and Objective-C runtime headers -- and are left alone deliberately. None of them is self-contained upstream either; curl/easy.h is meant to arrive through curl/curl.h and lzma/base.h through lzma.h. Patching them would buy nothing and drift from the originals, which for openssl/ and curl/ are copies this tree has to keep in step by hand.

This class only surfaces now because LibreSSL's compat/ headers pull APE's in earlier than anything has before.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs