### PR TITLE
ape: drop the u8/u32/s8/s32 typedefs from <stdint.h>

### DIFF
--- a/sys/include/ape/stdint_generic.h
+++ b/sys/include/ape/stdint_generic.h
@@ -72,14 +72,21 @@ typedef unsigned int _uintptr_t;
 # error "stdint_generic.h: INTPTR_WIDTH is 64 but _BITS64 is not set"
 #endif
 
-typedef char s8;
-typedef short s16;
-typedef long s32;
-typedef long long s64;
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned long u32;
-typedef unsigned long long u64;
+/*
+ * There were u8/u16/u32/u64 and s8/s16/s32/s64 typedefs here. They are
+ * neither C nor POSIX names, <stdint.h> is included by nearly everything,
+ * and they are exactly the names a program picks for its own short
+ * aliases -- so any file that defined its own met a redeclaration:
+ *
+ *	camellia.c:93 external redeclaration of: u32
+ *	    TYPEDEF UINT   crypto/camellia/camellia.c:93
+ *	    TYPEDEF ULONG  /sys/include/ape/stdint_generic.h:81
+ *
+ * They were also wrong: u32/s32 were spelled "unsigned long"/"long",
+ * which is 32-bit only because kencc's long happens to be 32-bit on
+ * amd64. Nothing in this tree used them -- libsec's aes.c, aesCFB.c and
+ * aesOFB.c each declare their own -- so they are gone. Use uint32_t.
+ */
 
 typedef char int8_t;
 typedef short int16_t;


### PR DESCRIPTION
stdint_generic.h defined u8, u16, u32, u64, s8, s16, s32 and s64. None of those are C or POSIX names, <stdint.h> is included by nearly everything, and they are precisely the names a program picks for its own short aliases, so any file with its own definition met

    camellia.c:93 external redeclaration of: u32
        TYPEDEF UINT   crypto/camellia/camellia.c:93
        TYPEDEF ULONG  /sys/include/ape/stdint_generic.h:81

Same class as the "extern int cmp(void,void);" that <locale.h> used to carry.

They were also wrong: u32 and s32 were spelled "unsigned long" and "long", which is 32-bit only because kencc's long happens to be 32-bit on amd64 -- on any host where it is not, the names would have lied.

Nothing in the tree used them. libsec's aes.c, aesCFB.c and aesOFB.c are the only APE sources that mention u32 and each declares its own from ulong; as.c's matches are register-name strings. A comment in their place says why they are gone and points at uint32_t.

The other short typedefs under sys/include/ape are not this problem: u.h, f2c.h, p2c.h and curses.h are included deliberately rather than pulled in by everything, and sys/types.h's u_int is a reserved BSD name.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs