### PR TITLE
cc: pointer signedness relaxation covers every integer type, not just…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -744,7 +744,7 @@ end-of-file — so this does not make a file with many includes any dearer.
 
 `NIF`, the `#if` nesting limit, is still 32 and has not been a problem.
 
-### char * against unsigned char * is a warning, not an error
+### Pointer signedness is a warning, not an error
 
 `char *` and `unsigned char *` are distinct types, so passing one where the
 other is declared is a constraint violation and C requires a diagnostic. gcc
@@ -760,15 +760,27 @@ a_object.c:185 argument prototype mismatch "IND CHAR" for "IND CONST UCHAR":
 from LibreSSL's `CBB_add_bytes(cbb, s, n)` with `char s[22]` against
 `int CBB_add_bytes(CBB *, const uint8_t *, size_t)`.
 
-`cc/sub.c` `stcompat()` now calls `charptrsign()` in the `BIND`/`TIND` branch
-and warns instead. **One level only, and only between the two one-byte integer
-types** — `int *` for `char *` is still an error, and so is `char **` for
-`unsigned char **`, which is the case where the difference can actually be
-observed.
+`-Wpointer-sign` is not about `char`, and LibreSSL hit the `int` case next:
 
-This cannot change code generation: `char` and `unsigned char` have the same
-representation, so the only thing that differs is whether a diagnostic is
-fatal. `warn()` is gated on `debug['w']`, so it is quiet unless `-w` is passed.
+```
+e_sm4.c:241 argument prototype mismatch "IND INT" for "IND UINT":
+  CRYPTO_ctr128_encrypt
+```
+
+from `&ctx->num`, an `int *`, against `unsigned int *num`.
+
+`cc/sub.c` `stcompat()` now calls `ptrsignonly()` in the `BIND`/`TIND` branch
+and warns instead. **One level only, and only when the two pointees are the
+signed and unsigned spellings of the same type** — the five pairs are listed
+in `pairs[]` there. Still errors: `int *` for `char *`; `int *` for
+`unsigned long *`, which are the same width on amd64 but are not a
+signed/unsigned pair, and which gcc calls incompatible pointer types rather
+than a signedness difference; and `char **` for `unsigned char **`, which is
+the case where the difference can actually be observed.
+
+This cannot change code generation: a type and its opposite signedness have
+the same representation, so the only thing that differs is whether a
+diagnostic is fatal. `warn()` is gated on `debug['w']`, so it is quiet unless `-w` is passed.
 
 Note `rsametype()` in `dcl.c` compares `etype` and the `GNORET` bit and
 nothing else — it already ignores `const` and `volatile`, which is why

--- a/sys/lib/tests/charptr-test.c
+++ b/sys/lib/tests/charptr-test.c
@@ -26,9 +26,22 @@
  * value checks confirm the obvious -- that a relaxation which changes
  * no representation changes no behaviour.
  *
+ * -Wpointer-sign is not about char, though the name of this file is:
+ * it is any integer type against its own opposite signedness. LibreSSL
+ * hit the int case next --
+ *
+ *   e_sm4.c:241 argument prototype mismatch "IND INT" for "IND UINT":
+ *     CRYPTO_ctr128_encrypt
+ *
+ * from passing "&ctx->num", an int *, to a "unsigned int *num"
+ * parameter -- so short, int, long and long long are covered below too.
+ *
  * Deliberately NOT here, because they must stay errors: "char **" for
  * "unsigned char **", which is the case where the difference can be
- * observed, and any pointer of a different width.
+ * observed; any pointer of a different width; and "int *" for
+ * "unsigned long *", which are the same width here but are not each
+ * other's signed/unsigned spelling, so gcc calls them incompatible
+ * pointer types rather than a signedness difference.
  *
  * Build and run:  pcc -o charptr-test charptr-test.c
  * Prints "PASS" per case; exit status is the number of failures.
@@ -90,6 +103,17 @@ takes_char(char *p)
 	return p[0];
 }
 
+/* The wider types, in the shape CRYPTO_ctr128_encrypt uses: a pointer
+   the callee increments. One of each signedness for every width. */
+static int		bump_i(int *p)			{ return ++*p; }
+static unsigned int	bump_u(unsigned int *p)		{ return ++*p; }
+static int		bump_sh(short *p)		{ return ++*p; }
+static int		bump_ush(unsigned short *p)	{ return ++*p; }
+static long		bump_l(long *p)			{ return ++*p; }
+static unsigned long	bump_ul(unsigned long *p)	{ return ++*p; }
+static long long	bump_ll(long long *p)		{ return ++*p; }
+static unsigned long long bump_ull(unsigned long long *p)	{ return ++*p; }
+
 int
 main(void)
 {
@@ -145,6 +169,48 @@ main(void)
 	/* Returning one for the other. */
 	check("sizeof(char) == sizeof(unsigned char)",
 	      sizeof(char) == 1 && sizeof(unsigned char) == 1, NULL);
+
+	/* The wider integer types, which are the same rule. e_sm4.c's
+	   case is the int one: an int * for an "unsigned int *num"
+	   parameter, written to by the callee. */
+	{
+		int num = 3;
+		unsigned int unum = 3;
+		short sh = 7;
+		unsigned short ush = 7;
+		long lo = 11;
+		unsigned long ulo = 11;
+		long long ll = 13;
+		unsigned long long ull = 13;
+
+		check("int * passed as unsigned int *",
+		      bump_u(&num) == 4 && num == 4, "store went astray");
+		check("unsigned int * passed as int *",
+		      bump_i(&unum) == 4 && unum == 4, "store went astray");
+		check("short * passed as unsigned short *",
+		      bump_ush(&sh) == 8 && sh == 8, "store went astray");
+		check("unsigned short * passed as short *",
+		      bump_sh(&ush) == 8 && ush == 8, "store went astray");
+		check("long * passed as unsigned long *",
+		      bump_ul(&lo) == 12 && lo == 12, "store went astray");
+		check("unsigned long * passed as long *",
+		      bump_l(&ulo) == 12 && ulo == 12, "store went astray");
+		check("long long * passed as unsigned long long *",
+		      bump_ull(&ll) == 14 && ll == 14, "store went astray");
+		check("unsigned long long * passed as long long *",
+		      bump_ll(&ull) == 14 && ull == 14, "store went astray");
+
+		/* Assignment, and const on the target. */
+		{
+			const unsigned int *cu = &num;
+			unsigned int *u = &num;
+
+			check("unsigned int * = int *", (void *)u == (void *)&num,
+			      NULL);
+			check("const unsigned int * = int *",
+			      (void *)cu == (void *)&num, NULL);
+		}
+	}
 
 	if (failures)
 		printf("\n%d failure(s)\n", failures);

--- a/sys/src/cmd/cc/sub.c
+++ b/sys/src/cmd/cc/sub.c
@@ -297,16 +297,32 @@ simplet(long b)
  * nothing wrong with it, and there is no portable spelling that avoids
  * a cast at every such call.
  *
- * Only one level, and only between the two one-byte integer types: an
- * "int *" for a "char *" is still an error, and so is "char **" for
- * "unsigned char **", which is the case where the difference can
- * actually be observed. Signedness of the pointee changes no
- * representation, so nothing generated differs either way.
+ * -Wpointer-sign is not about char: it is any integer type against its
+ * own opposite signedness, and the wider ones turn up just as often.
+ * LibreSSL's evp/e_sm4.c passes "&ctx->num", an int *, to
+ * CRYPTO_ctr128_encrypt's "unsigned int *num".
+ *
+ * So: one level of indirection, and the two pointees must be the signed
+ * and unsigned spellings of the same type. "int *" for "char *" is
+ * still an error; so is "int *" for "unsigned long *", which merely
+ * happen to be the same width here and are what gcc calls incompatible
+ * pointer types rather than a signedness difference; and so is
+ * "char **" for "unsigned char **", which is the case where the
+ * difference can actually be observed. Signedness of the pointee
+ * changes no representation, so nothing generated differs either way.
  */
 static int
-charptrsign(Type *t1, Type *t2)
+ptrsignonly(Type *t1, Type *t2)
 {
+	static int pairs[][2] = {
+		{TCHAR, TUCHAR},
+		{TSHORT, TUSHORT},
+		{TINT, TUINT},
+		{TLONG, TULONG},
+		{TVLONG, TUVLONG},
+	};
 	Type *p1, *p2;
+	int i, e1, e2;
 
 	if(t1 == T || t2 == T)
 		return 0;
@@ -316,11 +332,13 @@ charptrsign(Type *t1, Type *t2)
 	p2 = t2->link;
 	if(p1 == T || p2 == T)
 		return 0;
-	if(p1->etype != TCHAR && p1->etype != TUCHAR)
-		return 0;
-	if(p2->etype != TCHAR && p2->etype != TUCHAR)
-		return 0;
-	return p1->etype != p2->etype;
+	e1 = p1->etype;
+	e2 = p2->etype;
+	for(i = 0; i < nelem(pairs); i++)
+		if((e1 == pairs[i][0] && e2 == pairs[i][1])
+		|| (e1 == pairs[i][1] && e2 == pairs[i][0]))
+			return 1;
+	return 0;
 }
 
 int
@@ -357,7 +375,7 @@ stcompat(Node *n, Type *t1, Type *t2, long ttab[])
 		if(n->op != OCAST)
 		 	if(b == BIND && i == TIND)
 				if(!sametype(t1, t2)) {
-					if(!charptrsign(t1, t2))
+					if(!ptrsignonly(t1, t2))
 						return 1;
 					warn(n, "pointer signedness: \"%T\" and \"%T\"",
 						t1, t2);


### PR DESCRIPTION
… char

The relaxation added in 5bdcad202 was narrowed to the two one-byte types, which is not what -Wpointer-sign means: it is any integer type against its own opposite signedness, and the wider ones turn up just as often. LibreSSL hit the int case immediately after the char one --

    e_sm4.c:241 argument prototype mismatch "IND INT" for "IND UINT":
      CRYPTO_ctr128_encrypt

from sm4_ctr_cipher passing "&ctx->num", an int *, to CRYPTO_ctr128_encrypt's "unsigned int *num".

charptrsign() becomes ptrsignonly() and matches against an explicit table of the five signed/unsigned pairs rather than testing widths. Pairing rather than "same width, different signedness" keeps "int *" for "unsigned long *" an error: those are the same width on amd64 but are not each other's spelling, and gcc calls them incompatible pointer types rather than a signedness difference. One level of indirection still, so "char **" for "unsigned char **" -- the case where the difference can actually be observed -- stays an error too.

No code generation changes: a type and its opposite signedness share a representation, so only whether the diagnostic is fatal differs.

charptr-test.c gains the eight wider cases, each written in the shape e_sm4.c uses -- a pointer the callee writes through -- plus assignment and a const target.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs