### PR TITLE
libressl: ssl needs crypto and crypto/bio on its include path

### DIFF
--- a/sys/src/ape/lib/libressl/mkfile
+++ b/sys/src/ape/lib/libressl/mkfile
@@ -681,7 +681,13 @@ CRYPTOFLAGS=$BASEFLAGS -DLIBRESSL_CRYPTO_INTERNAL\
 	-I$SSLSRC/crypto/x509\
 	-I$SSLSRC/crypto/arch/$objtype -I$SSLSRC/crypto/bn/arch/$objtype
 
-SSLFLAGS=$BASEFLAGS -I$SSLSRC/ssl/hidden -I$SSLSRC/crypto/arch/$objtype
+# ssl/Makefile.am adds crypto and crypto/bio to the base flags and
+# nothing else: bio_ssl.c reaches crypto/bio/bio_local.h for the BIO
+# method struct, and several files take crypto/*_local.h through the
+# plain crypto directory. It does NOT get crypto/hidden -- see above.
+SSLFLAGS=$BASEFLAGS -I$SSLSRC/ssl/hidden\
+	-I$SSLSRC/crypto -I$SSLSRC/crypto/bio\
+	-I$SSLSRC/crypto/arch/$objtype
 
 TLSFLAGS=$BASEFLAGS -DTLS_DEFAULT_CA_FILE="/sys/lib/ape/ssl/cert.pem"
 


### PR DESCRIPTION
    bio_ssl.c:69 Could not find include file "bio_local.h"

bio_local.h is crypto/bio/bio_local.h, and ssl/Makefile.am adds

    AM_CPPFLAGS += -I$(top_srcdir)/crypto
    AM_CPPFLAGS += -I$(top_srcdir)/crypto/bio

on top of the common flags. SSLFLAGS had neither. Still no crypto/hidden, which is deliberate and noted where the three flag sets are defined.

Checked the other two while here, by resolving every #include "..." in each tree against the -I list that compiles it: crypto and tls are both complete as they stand. crypto's one apparent miss, s2n-bignum.h, is inside a comment in bn/s2n_bignum.h.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs