### PR TITLE
ape: netdb.h defines socklen_t itself rather than including sys/socket.h

### DIFF
--- a/sys/include/ape/netdb.h
+++ b/sys/include/ape/netdb.h
@@ -25,13 +25,26 @@
  */
 
 /*
- * size_t for the _r functions below, socklen_t for gethostbyaddr_r, and
- * struct sockaddr for getnameinfo. This header declared all three
- * without defining any of them, so it only compiled where the caller
- * happened to have included <sys/socket.h> first.
+ * size_t for the _r functions below, and socklen_t for
+ * gethostbyaddr_r.
+ *
+ * NOT by including <sys/socket.h>: that header includes this one at its
+ * top, before it defines socklen_t, so the include is a cycle and the
+ * typedef arrives too late --
+ *
+ *   netdb.h:122 mixed ansi/old function declaration: gethostbyaddr_r
+ *
+ * which is what an unknown type name in a prototype looks like, since
+ * "socklen_t" then parses as a parameter name. So socklen_t is defined
+ * here under the same guard <sys/socket.h> uses, and whichever is read
+ * first wins.
  */
 #include <stddef.h>
-#include <sys/socket.h>
+
+#ifndef __socklen_t_defined
+#define __socklen_t_defined
+typedef int socklen_t;
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/ape/sys/socket.h
+++ b/sys/include/ape/sys/socket.h
@@ -22,7 +22,15 @@ extern "C" {
 /*
  * Definitions related to sockets: types, address families, options.
  */
+/*
+ * <netdb.h> above needs socklen_t for gethostbyaddr_r and is included
+ * before this point, so it defines the typedef too, under this guard.
+ * Whichever header a translation unit reaches first supplies it.
+ */
+#ifndef __socklen_t_defined
+#define __socklen_t_defined
 typedef int socklen_t;
+#endif
 typedef unsigned short sa_family_t;
 typedef unsigned short in_port_t;
 


### PR DESCRIPTION
    netdb.h:122 mixed ansi/old function declaration: gethostbyaddr_r

<sys/socket.h> includes <netdb.h> at its top, before it defines socklen_t, so the #include I added in 6e722b97f was a cycle: when a translation unit reaches sys/socket.h first, netdb.h's include of it is a no-op against the already-set guard, and socklen_t is still unknown when gethostbyaddr_r is declared. An unknown type name in a prototype parses as a parameter name, which is why the complaint is about K&R syntax rather than about the type.

socklen_t is now defined in both headers under a shared __socklen_t_defined guard, so whichever is read first supplies it. alltypes.h is not an option for this -- it includes sys/socket.h too.

struct sockaddr in the getnameinfo prototype is left as it was: netdb.h has always been read before that struct exists, and a pointer to an incomplete struct in a prototype is fine.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs