### PR TITLE
ape: move the POSIX types out of <alltypes.h> into <sys/types.h>

### DIFF
--- a/sys/include/ape/alltypes.h
+++ b/sys/include/ape/alltypes.h
@@ -17,17 +17,26 @@
 #include <langinfo.h>
 
 typedef long register_t;
-typedef long long suseconds_t;
 typedef uint64_t u_int64_t;
 
-typedef long blksize_t;
-typedef int64_t blkcnt_t;
-typedef uint64_t fsblkcnt_t;
-typedef uint64_t fsfilcnt_t;
-
-typedef unsigned id_t;
-typedef int key_t;
-typedef unsigned useconds_t;
+/*
+ * suseconds_t, blksize_t, blkcnt_t, fsblkcnt_t, fsfilcnt_t, id_t, key_t
+ * and useconds_t were all defined here. They are POSIX <sys/types.h>
+ * types and are now defined there, and reach this file through the
+ * include above.
+ *
+ * This file is not a header anyone includes by name, so a type that
+ * lives only here cannot be found by portable code that spells it:
+ *
+ *   timediff.c:52 syntax error, last name: tv_usec
+ *
+ * from curl's "tv->tv_usec = (suseconds_t)tv_usec;". An unknown type
+ * name turns the cast into a syntax error, which is why the complaint
+ * names the operand rather than the type.
+ *
+ * blksize_t and blkcnt_t were defined in both places; the two spellings
+ * agreed (int64_t is long long here), so it went unnoticed.
+ */
 
 typedef va_list __isoc_va_list;
 

--- a/sys/include/ape/sys/select.h
+++ b/sys/include/ape/sys/select.h
@@ -3,6 +3,12 @@
 
 #pragma lib "/$M/lib/ape/libap.a"
 
+/* POSIX lists suseconds_t here too; same guard as <sys/time.h>. */
+#ifndef __suseconds_t_defined
+#define __suseconds_t_defined
+typedef long suseconds_t;
+#endif
+
 #ifndef _FD_SET_T
 #define _FD_SET_T
 /* BSD select, and adjunct types and macros */

--- a/sys/include/ape/sys/statvfs.h
+++ b/sys/include/ape/sys/statvfs.h
@@ -28,8 +28,7 @@
  * no way to say "unknown" is worse than one that can. It is always 0.
  */
 
-#include <sys/types.h>
-#include <alltypes.h>	/* fsblkcnt_t, fsfilcnt_t */
+#include <sys/types.h>	/* fsblkcnt_t, fsfilcnt_t */
 
 struct statvfs {
 	unsigned long	f_bsize;	/* file system block size */

--- a/sys/include/ape/sys/time.h
+++ b/sys/include/ape/sys/time.h
@@ -5,9 +5,30 @@
 #ifndef __TIMEVAL__
 #define __TIMEVAL__
 
+/*
+ * POSIX puts suseconds_t in <sys/types.h>, <sys/time.h> and
+ * <sys/select.h>, and says tv_usec below has that type. It used to be
+ * in <alltypes.h> alone -- which is not a header anyone includes by
+ * name -- so portable code that spelled the type could not find it:
+ *
+ *   timediff.c:52 syntax error, last name: tv_usec
+ *
+ * from curl's "tv->tv_usec = (suseconds_t)tv_usec;", where an unknown
+ * type name turns the cast into a syntax error.
+ *
+ * It is "long", not the "long long" alltypes.h had, because tv_usec is
+ * long and POSIX requires the two to agree. The alltypes.h spelling was
+ * musl's, where long is 64-bit; here it is 32, which is ample for
+ * [0, 999999] and is what every caller taking &tv->tv_usec expects.
+ */
+#ifndef __suseconds_t_defined
+#define __suseconds_t_defined
+typedef long suseconds_t;
+#endif
+
 struct timeval {
 	long long	tv_sec;		/* seconds since epoch — 64-bit to survive 2038 */
-	long		tv_usec;	/* microseconds [0, 999999] — 32-bit is fine */
+	suseconds_t	tv_usec;	/* microseconds [0, 999999] — 32-bit is fine */
 };
 
 struct itimerval {

--- a/sys/include/ape/sys/types.h
+++ b/sys/include/ape/sys/types.h
@@ -6,6 +6,13 @@
 
 #pragma lib "/$M/lib/ape/libap.a"
 
+/* Also in <sys/time.h> and <sys/select.h>, under the same guard; see
+   the note beside struct timeval for why it is long. */
+#ifndef __suseconds_t_defined
+#define __suseconds_t_defined
+typedef long		suseconds_t;
+#endif
+
 typedef	unsigned short	ino_t;
 typedef	unsigned short	dev_t;
 typedef	long long		off_t;
@@ -22,6 +29,18 @@ typedef unsigned long	u_long;
 typedef unsigned int	in_addr_t;
 typedef long      blksize_t;   /* preferred I/O block size */
 typedef long long blkcnt_t;    /* count of file system blocks */
+
+/*
+ * The rest of the POSIX <sys/types.h> set. These used to be in
+ * <alltypes.h> alone, which is not a header anyone includes by name, so
+ * portable code that spelled one of them could not find it. blksize_t
+ * and blkcnt_t were in both -- the spellings happened to agree.
+ */
+typedef unsigned long long fsblkcnt_t;	/* file system block count */
+typedef unsigned long long fsfilcnt_t;	/* file system inode count */
+typedef unsigned	id_t;		/* uid_t or gid_t or pid_t */
+typedef int		key_t;		/* System V IPC key */
+typedef unsigned	useconds_t;	/* microseconds, for usleep */
 
 #ifndef _SIZE_T
 #define _SIZE_T


### PR DESCRIPTION
    timediff.c:52 syntax error, last name: tv_usec

from curl's

    tv->tv_usec = (suseconds_t)tv_usec;

suseconds_t was defined in <alltypes.h> and nowhere else. That file is not a header anyone includes by name -- it is pulled in sideways by regex.h, locale.h, glob.h and a few others -- so code that spells the type cannot find it, and an unknown type name in a cast is a syntax error naming the operand rather than the type. Enabling HAVE_SUSECONDS_T in curl_config.h is what reached it.

POSIX puts suseconds_t in <sys/types.h>, <sys/time.h> and <sys/select.h>; it is now in all three under a shared __suseconds_t_defined guard. It is "long", not the "long long" alltypes.h had: struct timeval's tv_usec is long, and POSIX requires the two to agree. The old spelling was musl's, where long is 64-bit. tv_usec is now declared as suseconds_t so the two cannot drift again.

The same treatment for the rest of the POSIX set stranded there -- fsblkcnt_t, fsfilcnt_t, id_t, key_t and useconds_t. blksize_t and blkcnt_t were defined in both files; the spellings agreed (int64_t is long long here), so nothing complained. <sys/statvfs.h> included <alltypes.h> purely for fsblkcnt_t and no longer needs to.

register_t and u_int64_t stay: they are BSD names, not POSIX ones.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs