### PR TITLE
libressl: resolve the either/or source pairs; add the missing explici…

### DIFF
--- a/sys/src/ape/cmd/libressl-apps/mkfile
+++ b/sys/src/ape/cmd/libressl-apps/mkfile
@@ -10,6 +10,28 @@ APE=$APEXPROOT/sys/src/ape
 #
 # mkone rather than mkmany: this is a single multi-call binary with a
 # subcommand table (openssl.c), not a directory of programs.
+#
+# Makefile.am has two either/or pairs, and this list originally had both
+# halves of each:
+#
+#	if HOST_WIN  apps_win.c  else apps_posix.c
+#	if BUILD_CERTHASH  certhash.c  else certhash_win.c
+#
+# apps_win.c opens with #include <windows.h>, so it stopped the build at
+# once. apps_posix.c is the one to keep.
+#
+# certhash is the less obvious of the two. Its condition upstream is
+#
+#	AM_CONDITIONAL([BUILD_CERTHASH], [test "x$ac_cv_func_symlink" = xyes])
+#
+# and configure would answer yes here, because libap does define
+# symlink() -- but only as a stub that sets ENOSYS and returns -1, since
+# Plan 9 has no symbolic links. certhash(1) exists to fill a directory
+# with hash-named symlinks to certificates, so the real implementation
+# would fail on every entry. certhash_win.c is misnamed: it is the
+# "platforms without symlinks" dummy, it includes nothing but apps.h,
+# and it prints one clear line saying certhash is not available. That is
+# the honest answer on Plan 9, so it is the half we keep.
 
 TARG=openssl
 BIN=$APEXPROOT/$objtype/bin/ape
@@ -17,10 +39,8 @@ BIN=$APEXPROOT/$objtype/bin/ape
 OFILES=\
 	apps.$O\
 	apps_posix.$O\
-	apps_win.$O\
 	asn1pars.$O\
 	ca.$O\
-	certhash.$O\
 	certhash_win.$O\
 	ciphers.$O\
 	cms.$O\

--- a/sys/src/ape/lib/libressl/mkfile
+++ b/sys/src/ape/lib/libressl/mkfile
@@ -16,6 +16,17 @@ APE=$APEXPROOT/sys/src/ape
 #   ARC4RANDOM_BUF GETENTROPY        yes, libap has them
 #   HAVE_STRTONUM FREEZERO RECALLOCARRAY SYSLOG_R TIMINGSAFE_MEMCMP
 #   TIMINGSAFE_BCMP EXPLICIT_BZERO   no, so compat/ supplies them
+#
+# explicit_bzero.$O was named in that list but missing from the objects
+# below, which the archive build cannot notice -- it would have surfaced
+# as an undefined symbol the first time something linked. 57 files in
+# crypto call it, and include/compat/string.h renames it to
+# libressl_explicit_bzero, so libap could not have supplied it even if
+# it had one. Upstream builds this single file at -O0, in its own
+# libcompatnoopt.la, so the memset cannot be optimised away; that is
+# belt and braces over the opaque call to __explicit_bzero_hook() that
+# follows the memset, which is what actually defeats dead-store
+# elimination. It is built with the ordinary flags here.
 #   HOST_X86_64                      yes; every other HOST_* no
 #   HOST_ASM_*                       no, hence -DOPENSSL_NO_ASM
 #
@@ -232,6 +243,7 @@ CRYPTOBJ=\
 	err.$O\
 	err_all.$O\
 	err_prn.$O\
+	explicit_bzero.$O\
 	evp_aead.$O\
 	evp_cipher.$O\
 	evp_digest.$O\


### PR DESCRIPTION
…t_bzero

    apps_win.c:8 Could not find include file <windows.h>

apps/openssl/Makefile.am has two either/or pairs and the object list had both halves of each.

  apps_win.c / apps_posix.c is the one that broke: keep apps_posix.c.

  certhash.c / certhash_win.c is the less obvious one. Its condition is
  "test x$ac_cv_func_symlink = xyes", and configure would answer yes
  here -- libap defines symlink(), but only as a stub that sets ENOSYS,
  since Plan 9 has no symbolic links. certhash(1) exists to fill a
  directory with hash-named symlinks to certificates, so the real
  implementation would fail on every entry. certhash_win.c is misnamed:
  its own comment calls it the dummy "for platforms without symlinks",
  it includes nothing but apps.h, and it prints one line saying
  certhash is not available. That is the honest answer here, so it is
  the half we keep.

Auditing the library's compat conditionals the same way turned up a missing object rather than a surplus one: explicit_bzero.$O was named in the mkfile's summary of what compat/ has to supply and was absent from the objects. Building an archive cannot notice that -- it would have surfaced as an undefined symbol the first time something linked, which is the openssl(1) build now starting. 57 files in crypto call it, and include/compat/string.h renames it to libressl_explicit_bzero, so libap could not have supplied it in any case. Upstream compiles that one file at -O0 so the memset cannot be elided; the note beside it records that, and that the opaque __explicit_bzero_hook() call after the memset is what actually defeats dead-store elimination.

The rest of the summary checked out: libap really does have strlcat, strlcpy, strndup, strnlen, strsep, asprintf, ftruncate, getdelim, getline, getpagesize, getprogname, reallocarray, arc4random_buf and getentropy, and really does lack strtonum, freezero, recallocarray, syslog_r, timingsafe_memcmp and timingsafe_bcmp.

Also checked, since these lists were derived by hand: all 779 objects named across the four libressl and curl mkfiles resolve to a source file, and curl's two lists match lib/Makefile.inc and src/Makefile.inc exactly.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs