### PR TITLE
cc: the pointer-signedness relaxation reaches static initializers too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -771,8 +771,19 @@ e_sm4.c:241 argument prototype mismatch "IND INT" for "IND UINT":
 
 from `&ctx->num`, an `int *`, against `unsigned int *num`.
 
-`cc/sub.c` `stcompat()` now calls `ptrsignonly()` in the `BIND`/`TIND` branch
-and warns instead. **One level only, and only when the two pointees are the
+There are **two** sites, because static initializers do not go through
+`stcompat()`. `cc/dcl.c` `init1()` has its own `sametype()` test and gave
+
+```
+s_client.c:540 initialization of incompatible pointers: s_client_options
+  IND INT and IND UINT
+```
+
+for `.opt.value = &cfg.off` with `unsigned int off` against the union's
+`int *value`. Both sites now call `ptrsignonly()` (declared in `cc.h`) and
+warn instead.
+
+`cc/sub.c` `stcompat()` calls it in the `BIND`/`TIND` branch. **One level only, and only when the two pointees are the
 signed and unsigned spellings of the same type** — the five pairs are listed
 in `pairs[]` there. Still errors: `int *` for `char *`; `int *` for
 `unsigned long *`, which are the same width on amd64 but are not a

--- a/sys/lib/tests/charptr-test.c
+++ b/sys/lib/tests/charptr-test.c
@@ -53,6 +53,38 @@
 
 static int failures;
 
+/* Static initializers go through a different path in the compiler --
+   dcl.c's init1, not stcompat -- and needed the same relaxation. This is
+   apps/openssl/s_client.c's shape: an "unsigned int" whose address is
+   stored in an "int *" member of a file-scope aggregate.
+
+	s_client.c:540 initialization of incompatible pointers:
+	  s_client_options / IND INT and IND UINT
+
+   These have to be at file scope, and const-qualified members like the
+   real thing, for the static path to be the one taken. */
+static unsigned int cfg_off = 7;
+static int cfg_af = 9;
+
+struct sopt {
+	const char *name;
+	union {
+		int *value;
+		unsigned int *uvalue;
+	} opt;
+	const int flags;
+};
+
+static const struct sopt sopts[] = {
+	{ .name = "off",  .opt.value = &cfg_off, .flags = 1 },
+	{ .name = "af",   .opt.uvalue = &cfg_af, .flags = 2 },
+	{ NULL },
+};
+
+/* And the plain, non-aggregate static case. */
+static int *const p_to_unsigned = &cfg_off;
+static unsigned int *const p_to_signed = &cfg_af;
+
 static void
 check(const char *what, int ok, const char *detail)
 {
@@ -211,6 +243,24 @@ main(void)
 			      (void *)cu == (void *)&num, NULL);
 		}
 	}
+
+	/* Static initializers -- dcl.c's path rather than stcompat's. The
+	   real test is that the file compiled at all; these confirm the
+	   addresses landed where they should. */
+	sprintf(detail, "opt.value=%p want %p, flags=%d want 1",
+	        (void *)sopts[0].opt.value, (void *)&cfg_off, sopts[0].flags);
+	check("int * member initialised from an unsigned int *",
+	      (void *)sopts[0].opt.value == (void *)&cfg_off
+	      && sopts[0].flags == 1, detail);
+	sprintf(detail, "opt.uvalue=%p want %p, flags=%d want 2",
+	        (void *)sopts[1].opt.uvalue, (void *)&cfg_af, sopts[1].flags);
+	check("unsigned int * member initialised from an int *",
+	      (void *)sopts[1].opt.uvalue == (void *)&cfg_af
+	      && sopts[1].flags == 2, detail);
+	check("static int * = &unsigned int",
+	      (void *)p_to_unsigned == (void *)&cfg_off, NULL);
+	check("static unsigned int * = &int",
+	      (void *)p_to_signed == (void *)&cfg_af, NULL);
 
 	if (failures)
 		printf("\n%d failure(s)\n", failures);

--- a/sys/src/cmd/cc/cc.h
+++ b/sys/src/cmd/cc/cc.h
@@ -621,6 +621,7 @@ Decl*	push(void);
 Decl*	push1(Sym*);
 Node*	revertdcl(void);
 long	round(long, int);
+int	ptrsignonly(Type*, Type*);
 int	rsametype(Type*, Type*, int, int);
 int	sametype(Type*, Type*);
 ulong	sign(Sym*);

--- a/sys/src/cmd/cc/dcl.c
+++ b/sys/src/cmd/cc/dcl.c
@@ -624,9 +624,28 @@ init1(Sym *s, Type *t, long o, int exflag)
 		if(t->etype == TIND) {
 			if(a->op == OCAST)
 				warn(a, "CAST in initialization ignored");
-			if(!sametype(t, a->type))
-				diag(a, "initialization of incompatible pointers: %s\n%T and %T",
-					s->name, t, a->type);
+			if(!sametype(t, a->type)) {
+				/*
+				 * Same relaxation as stcompat's: a pointer
+				 * differing only in the signedness of what
+				 * it points at is -Wpointer-sign, a warning
+				 * everywhere else, and it reaches static
+				 * initializers too. LibreSSL's
+				 * apps/openssl/s_client.c has
+				 *
+				 *   unsigned int off;
+				 *   ...
+				 *   .opt.value = &cfg.off,
+				 *
+				 * against the union's "int *value".
+				 */
+				if(!ptrsignonly(t, a->type))
+					diag(a, "initialization of incompatible pointers: %s\n%T and %T",
+						s->name, t, a->type);
+				else
+					warn(a, "pointer signedness: %s\n%T and %T",
+						s->name, t, a->type);
+			}
 		}
 
 		while(a->op == OCAST)

--- a/sys/src/cmd/cc/sub.c
+++ b/sys/src/cmd/cc/sub.c
@@ -311,7 +311,7 @@ simplet(long b)
  * difference can actually be observed. Signedness of the pointee
  * changes no representation, so nothing generated differs either way.
  */
-static int
+int
 ptrsignonly(Type *t1, Type *t2)
 {
 	static int pairs[][2] = {


### PR DESCRIPTION
    s_client.c:540 initialization of incompatible pointers:
      s_client_options / IND INT and IND UINT

from LibreSSL's apps/openssl/s_client.c:

    unsigned int off;
    ...
    .opt.value = &cfg.off,

against the union's "int *value" -- the same -Wpointer-sign case as the argument and assignment ones, in a file-scope aggregate.

Static initializers do not go through stcompat(): dcl.c's init1() has its own sametype() test and its own diagnostic, so relaxing stcompat alone left this half untouched. ptrsignonly() loses its static and is declared in cc.h; both sites call it and warn instead of refusing.

Those are the only two. The "argument prototype mismatch" in com.c goes through stcompat, and nothing else in cc/ rejects a pointer pair.

charptr-test.c gains the static cases -- an int * member initialised from an unsigned int * and the reverse, in an aggregate with a const member so the static path is really the one taken, plus the plain file-scope pointer form. Passes under gcc -std=c99.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs