### PR TITLE
libressl: probe the Keccak permutation directly

### DIFF
--- a/sys/src/ape/lib/libressl/test/keccakf_probe.c
+++ b/sys/src/ape/lib/libressl/test/keccakf_probe.c
@@ -1,0 +1,147 @@
+/*
+ * keccakf_probe.c -- the Keccak-f[1600] permutation on its own.
+ *
+ * sha3_kat.c narrowed the TLS 1.3 failure to SHA-3: every 64-bit
+ * primitive Keccak is built from passes -- rotation at the amounts it
+ * uses, both shifts, the byte/word union -- and every SHA-3 and SHAKE
+ * vector fails. So the fault is in the permutation or the sponge around
+ * it, and neither can be seen from a digest.
+ *
+ * A digest shows 256 bits of a wrong 1600-bit state, after padding and
+ * truncation have mixed everything together. This calls the permutation
+ * directly and prints all 25 lanes, which is the whole state and six
+ * times the signal. sha3_keccakf is static, so this file #includes
+ * sha3.c rather than linking against it -- which is also why it does
+ * not link libressl.a: the archive has the same symbols.
+ *
+ * The vectors are the standard Keccak-f[1600] ones: the permutation
+ * applied once and twice to an all-zero state. Nothing else is
+ * involved -- no padding, no rate, no absorb loop -- so a failure here
+ * is the permutation itself, and a pass means the permutation is right
+ * and sha3_update/sha3_final/shake_out are where to look.
+ *
+ * The two extra inputs are not decoration. A zero state makes theta's
+ * column parities zero for the first round, so the first round exercises
+ * little; starting from a single set bit, and from a state with one bit
+ * in every lane, drives different paths through rho's 24 distinct
+ * rotate amounts and chi's non-linearity. If one input matches and
+ * another does not, that difference says a great deal.
+ *
+ * Print the got lines even when they fail: the full wrong state is what
+ * makes it possible to work out which step is wrong without another
+ * round trip.
+ *
+ * Build and run:  mk test  (from this directory)
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "sha3.c"
+
+static int failures;
+
+static void
+show(const char *label, const uint64_t *st, int nlanes)
+{
+	int i;
+
+	for (i = 0; i + 5 <= nlanes; i += 5)
+		printf("  %s%s 0x%016llx 0x%016llx 0x%016llx 0x%016llx 0x%016llx\n",
+		    label, i == 0 ? "" : "    ",
+		    (unsigned long long)st[i], (unsigned long long)st[i + 1],
+		    (unsigned long long)st[i + 2], (unsigned long long)st[i + 3],
+		    (unsigned long long)st[i + 4]);
+}
+
+static void
+check(const char *what, const uint64_t *got, const uint64_t *want, int nlanes)
+{
+	int i, bad = -1;
+
+	for (i = 0; i < nlanes; i++)
+		if (got[i] != want[i]) {
+			bad = i;
+			break;
+		}
+	if (bad < 0) {
+		printf("PASS  %s\n", what);
+		return;
+	}
+	printf("FAIL  %s (first difference at lane %d)\n", what, bad);
+	show("got ", got, nlanes);
+	show("want", want, nlanes);
+	failures++;
+}
+
+int
+main(void)
+{
+	/* Keccak-f[1600] applied once to an all-zero state. */
+	static const uint64_t once[25] = {
+		0xf1258f7940e1dde7ULL, 0x84d5ccf933c0478aULL,
+		0xd598261ea65aa9eeULL, 0xbd1547306f80494dULL,
+		0x8b284e056253d057ULL,
+		0xff97a42d7f8e6fd4ULL, 0x90fee5a0a44647c4ULL,
+		0x8c5bda0cd6192e76ULL, 0xad30a6f71b19059cULL,
+		0x30935ab7d08ffc64ULL,
+		0xeb5aa93f2317d635ULL, 0xa9a6e6260d712103ULL,
+		0x81a57c16dbcf555fULL, 0x43b831cd0347c826ULL,
+		0x01f22f1a11a5569fULL,
+		0x05e5635a21d9ae61ULL, 0x64befef28cc970f2ULL,
+		0x613670957bc46611ULL, 0xb87c5a554fd00ecbULL,
+		0x8c3ee88a1ccf32c8ULL,
+		0x940c7922ae3a2614ULL, 0x1841f924a2c509e4ULL,
+		0x16f53526e70465c2ULL, 0x75f644e97f30a13bULL,
+		0xeaf1ff7b5ceca249ULL,
+	};
+	/* And twice: the first five lanes are enough to tell. */
+	static const uint64_t twice[5] = {
+		0x2d5c954df96ecb3cULL, 0x6a332cd07057b56dULL,
+		0x093d8d1270d76b6cULL, 0x8a20d9b25569d094ULL,
+		0x4f9c4f99e5e7f156ULL,
+	};
+	uint64_t st[25];
+	int i;
+
+	printf("--- Keccak-f[1600] on its own, no padding or sponge\n");
+
+	memset(st, 0, sizeof(st));
+	sha3_keccakf(st);
+	check("permutation of the all-zero state", st, once, 25);
+
+	sha3_keccakf(st);
+	check("permutation applied twice", st, twice, 5);
+
+	/*
+	 * No reference value for these, so they cannot pass or fail --
+	 * they are printed because the full wrong state from an input
+	 * that exercises different rotate amounts is what identifies the
+	 * faulty step without another round trip.
+	 */
+	if (failures) {
+		printf("\n--- two more states, for diagnosis only; there is no\n"
+		       "--- expected value here, the numbers themselves are the\n"
+		       "--- point\n");
+
+		memset(st, 0, sizeof(st));
+		st[0] = 1;
+		sha3_keccakf(st);
+		show("lane0=1 ", st, 25);
+
+		for (i = 0; i < 25; i++)
+			st[i] = 0x0000000100000001ULL;
+		sha3_keccakf(st);
+		show("all lanes 0x100000001 ", st, 25);
+	}
+
+	if (failures)
+		printf("\n%d failure(s) -- the permutation is wrong, so the\n"
+		       "sponge above it is not the place to look.\n", failures);
+	else
+		printf("\nall ok -- the permutation is correct, so the fault is\n"
+		       "in the sponge: sha3_update, sha3_final, shake_xof or\n"
+		       "shake_out.\n");
+	return failures;
+}

--- a/sys/src/ape/lib/libressl/test/mkfile
+++ b/sys/src/ape/lib/libressl/test/mkfile
@@ -70,7 +70,7 @@ APE=$APEXPROOT/sys/src/ape
 # installed; BIN points at this directory so that an accidental
 # "mk install" stays local.
 
-TARG=sha3_kat mlkem_tests mlkem_unittest
+TARG=keccakf_probe sha3_kat mlkem_tests mlkem_unittest
 BIN=.
 
 SSLSRC=$APEXPROOT/sys/src/external/libressl
@@ -107,6 +107,12 @@ CFLAGS=-c -I$SSLSRC/include -I$SSLSRC/include/compat\
 	-DOPENSSL_NO_ASM -DOPENSSL_NO_HW_PADLOCK\
 	$HAVEFLAGS
 
+# No $LIB here on purpose: keccakf_probe.c #includes sha3.c to reach the
+# static sha3_keccakf, so linking the archive would supply sha3_init and
+# friends a second time.
+$O.keccakf_probe: keccakf_probe.$O
+	$LD -o $target $prereq
+
 $O.sha3_kat: sha3_kat.$O
 	$LD -o $target $prereq $LIB
 
@@ -119,6 +125,9 @@ $O.mlkem_unittest: mlkem_unittest.$O mlkem_tests_util.$O
 sha3_kat.$O: sha3_kat.c
 	$CC $CFLAGS sha3_kat.c
 
+keccakf_probe.$O: keccakf_probe.c
+	$CC $CFLAGS -I$SSLSRC/crypto/sha keccakf_probe.c
+
 %.$O: $SSLSRC/tests/%.c
 	$CC $CFLAGS $SSLSRC/tests/$stem.c
 
@@ -130,7 +139,9 @@ V=$SSLSRC/tests
 # tree redefines a target after the include (cmd/awk and cmd/gettext do
 # the same with install).
 test:V: $PROGS
-	echo '---- Keccak, which everything in ML-KEM is built on'
+	echo '---- the Keccak permutation alone'
+	$O.keccakf_probe
+	echo '---- SHA-3 and SHAKE around it'
 	$O.sha3_kat
 	echo '---- keygen (first: encap and decap both build on it)'
 	$O.mlkem_tests mlkem768_keygen_tests $V/mlkem768_keygen_tests.txt


### PR DESCRIPTION
sha3_kat splits it cleanly: all eleven 64-bit primitives pass -- crypto_rol_u64 at the amounts Keccak uses, both shifts by a size_t, the byte/word union -- and all eight SHA-3 and SHAKE vectors fail. So the rotation the whole permutation is built on is fine, and the fault is in the permutation's structure or in the sponge around it.

Neither is visible from a digest. A digest is 256 bits of a wrong 1600-bit state after padding and truncation have mixed it, which is why none of the obvious guesses could be confirmed from the numbers already in hand: byte-swapped state, round constants truncated to 32 bits or sign-extended from them, a dropped or extra round, theta without its rotate, chi with the wrong operator -- all computed and compared against the reported SHA3-256 of the empty string, and none of them matches.

So this calls sha3_keccakf directly and prints all 25 lanes: the whole state, six times the signal, with no padding, rate or absorb loop involved. A failure is the permutation itself; a pass means the permutation is right and sha3_update, sha3_final, shake_xof or shake_out is where to look. Vectors are the standard Keccak-f[1600] values for the all-zero state permuted once and twice.

sha3_keccakf is static, so the probe #includes sha3.c rather than linking against it, and for the same reason does not link the archive.

When it fails it also prints the permuted state for two further inputs that have no published value. That is deliberate: a zero state leaves theta's column parities zero for the first round, so it exercises little, and a state built from single set bits drives rho's 24 distinct rotate amounts and chi's non-linearity differently. Those numbers are what make it possible to identify the faulty step offline rather than with another round trip.

Verified against a faithful transcription of sha3.c under gcc, which caught a real bug in the probe itself: the two-lane-count check passed a 5-element array to a printer that read 25.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs