### PR TITLE
6c: spilling a fixed register saved only the operation's width

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -723,6 +723,66 @@ divide unsigned. `UINTMAX_MAX / 2` came out 0, so GNU tar's
 fired its `#error`. cpp no longer relies on the implicit conversion.
 Any other `signed_lvalue op= (unsigned)x` in the tree is still wrong.
 
+### Spilling a fixed register saved only the operation's width (FIXED)
+
+`6c/cgen.c` spills AX, CX or DX where the instruction it is about to emit
+can only use that register — a divide or modulo needs AX and DX, a
+variable shift needs CX. The save was
+
+```c
+if(nodreg(&nod, nn, D_AX)) {
+        regsalloc(&nod2, n);      /* slot sized from n, the divide */
+        gmove(&nod, &nod2);       /* ... so a 32-bit save */
+```
+
+`regsalloc` takes its size from the node handed to it, and `n` is the
+divide or the shift. So a **32-bit** operation spilled **four** bytes of a
+register that might be holding eight, and the top half was lost. What is
+live in AX at that moment belongs to some earlier part of the
+expression and has nothing to do with the type of the operation being
+generated.
+
+Found in LibreSSL's Keccak:
+
+```c
+t0 = bc[(i + 4) % 5] ^ crypto_rol_u64(bc[(i + 1) % 5], 1);
+```
+
+`cgen`'s `OXOR` case evaluates the call first, because `OFUNC` has
+`complex == FNX`, and it lands in AX. Then `bc[(i + 4) % 5]` needs AX for
+the 32-bit `% 5`, spills it four bytes wide, and `crypto_rol_u64`'s
+`uint64_t` result comes back with bits 32..63 cleared. The *identical*
+call two lines below, `st[j] = crypto_rol_u64(t0, rotc[i])`, is correct —
+no division beside it.
+
+The trigger is exactly `<expression containing / or %> op <64-bit
+function call>`, and `%` has to be in the **other operand**, not in the
+call's arguments: an argument is evaluated before the call, so nothing
+64-bit is live yet.
+
+Fixed with `regwide()`/`regspill()` at the head of `cgen.c`: the save
+uses a full-width alias of the register and an 8-byte slot, and the
+narrow node is left alone because callers still need it at the
+operation's own type for the result. Six sites — AX and DX in
+`ODIV`/`OMOD` and in the `OAS*` forms, CX in both shift cases.
+
+Only `6c` has this. `8c` is 32-bit, so a one-register save cannot
+truncate; the RISC back-ends need no fixed register for division, and
+their one `regsalloc(&nod, n)` is `OFUNC` with a discarded result, where
+`n` *is* the call and its type is right.
+
+What it cost: every SHA-3 digest was wrong, so ML-KEM was wrong, so
+every TLS 1.3 handshake offering X25519MLKEM768 failed at the first
+encrypted record with `bad decrypt` — while TLS 1.2 and
+`-groups X25519` worked, because nothing else in a handshake uses
+Keccak. **Nothing about this is Keccak-specific.** A 64-bit value live
+across a 32-bit `%` is ordinary C, so anything built before this fix is
+suspect and wants rebuilding.
+
+Covered by `sys/lib/tests/rol64-test.c`, which isolates the trigger
+one variable at a time, and by the Keccak vectors in
+`sys/src/ape/lib/libressl/test/`.
+
 ### #include nesting limit was 20
 
 `cpp/include.c` had the depth guard written as a bare `20`. That is a guard

--- a/sys/src/cmd/6c/cgen.c
+++ b/sys/src/cmd/6c/cgen.c
@@ -3,12 +3,63 @@
 /* ,x/^(print|prtree)\(/i/\/\/ */
 int castup(Type*, Type*);
 
+/*
+ * Save and restore a fixed register across code that must have it.
+ *
+ * The paths below spill AX, CX or DX because the instruction about to
+ * be generated can only use that register: a divide or modulo needs AX
+ * and DX, a variable shift needs CX. What is live in the register at
+ * that point belongs to some earlier, already-evaluated part of the
+ * expression, and its type has nothing to do with the type of the
+ * operation being generated -- so the save has to be the width of the
+ * register, not the width of the operation.
+ *
+ * They used to save it with regsalloc(&nod, n), which takes its size
+ * from n, the divide or shift. A 32-bit operation therefore spilled
+ * four bytes of a register that might hold eight, and the top half was
+ * lost. LibreSSL's Keccak is where this surfaced:
+ *
+ *	t0 = bc[(i + 4) % 5] ^ crypto_rol_u64(bc[(i + 1) % 5], 1);
+ *
+ * cgen evaluates the call first, into AX, then needs AX for the 32-bit
+ * "% 5" -- and saved it four bytes wide, so crypto_rol_u64's uint64_t
+ * result came back with bits 32..63 cleared. Every SHA-3 digest was
+ * wrong, which broke ML-KEM, which broke every TLS 1.3 handshake
+ * offering X25519MLKEM768.
+ *
+ * regwide makes a full-width alias of the register node; regspill
+ * allocates a full-width slot and saves it there. Restoring is a plain
+ * gmove back through the wide alias. The narrow node is left alone,
+ * because the callers still need it at the operation's own type for
+ * the result.
+ *
+ * Covered by sys/lib/tests/rol64-test.c.
+ */
+static void
+regwide(Node *w, Node *r)
+{
+	*w = *r;
+	w->type = types[TVLONG];
+	w->etype = TVLONG;
+}
+
+static void
+regspill(Node *slot, Node *w, Node *n)
+{
+	Node t;
+
+	t = *n;
+	t.type = types[TVLONG];
+	regsalloc(slot, &t);
+	gmove(w, slot);
+}
+
 void
 cgen(Node *n, Node *nn)
 {
 	Node *l, *r, *t;
 	Prog *p1;
-	Node nod, nod1, nod2, nod3, nod4;
+	Node nod, nod1, nod2, nod3, nod4, nodw;
 	int o, hardleft;
 	long v, curs;
 	vlong c;
@@ -218,11 +269,11 @@ cgen(Node *n, Node *nn)
 		 * get nod to be D_CX
 		 */
 		if(nodreg(&nod, nn, D_CX)) {
-			regsalloc(&nod1, n);
-			gmove(&nod, &nod1);
+			regwide(&nodw, &nod);
+			regspill(&nod1, &nodw, n);
 			cgen(n, &nod);		/* probably a bug */
 			gmove(&nod, nn);
-			gmove(&nod1, &nod);
+			gmove(&nod1, &nodw);
 			break;
 		}
 		reg[D_CX]++;
@@ -401,8 +452,8 @@ cgen(Node *n, Node *nn)
 		 * get nod1 to be D_DX
 		 */
 		if(nodreg(&nod, nn, D_AX)) {
-			regsalloc(&nod2, n);
-			gmove(&nod, &nod2);
+			regwide(&nodw, &nod);
+			regspill(&nod2, &nodw, n);
 			v = reg[D_AX];
 			reg[D_AX] = 0;
 
@@ -418,13 +469,13 @@ cgen(Node *n, Node *nn)
 			} else
 				cgen(n, nn);
 
-			gmove(&nod2, &nod);
+			gmove(&nod2, &nodw);
 			reg[D_AX] = v;
 			break;
 		}
 		if(nodreg(&nod1, nn, D_DX)) {
-			regsalloc(&nod2, n);
-			gmove(&nod1, &nod2);
+			regwide(&nodw, &nod1);
+			regspill(&nod2, &nodw, n);
 			v = reg[D_DX];
 			reg[D_DX] = 0;
 
@@ -440,7 +491,7 @@ cgen(Node *n, Node *nn)
 			} else
 				cgen(n, nn);
 
-			gmove(&nod2, &nod1);
+			gmove(&nod2, &nodw);
 			reg[D_DX] = v;
 			break;
 		}
@@ -511,12 +562,12 @@ cgen(Node *n, Node *nn)
 		 * get nod to be D_CX
 		 */
 		if(nodreg(&nod, nn, D_CX)) {
-			regsalloc(&nod1, n);
-			gmove(&nod, &nod1);
+			regwide(&nodw, &nod);
+			regspill(&nod1, &nodw, n);
 			cgen(n, &nod);
 			if(nn != Z)
 				gmove(&nod, nn);
-			gmove(&nod1, &nod);
+			gmove(&nod1, &nodw);
 			break;
 		}
 		reg[D_CX]++;
@@ -733,8 +784,8 @@ cgen(Node *n, Node *nn)
 		 * get nod1 to be D_DX
 		 */
 		if(nodreg(&nod, nn, D_AX)) {
-			regsalloc(&nod2, n);
-			gmove(&nod, &nod2);
+			regwide(&nodw, &nod);
+			regspill(&nod2, &nodw, n);
 			v = reg[D_AX];
 			reg[D_AX] = 0;
 
@@ -750,13 +801,13 @@ cgen(Node *n, Node *nn)
 			} else
 				cgen(n, nn);
 
-			gmove(&nod2, &nod);
+			gmove(&nod2, &nodw);
 			reg[D_AX] = v;
 			break;
 		}
 		if(nodreg(&nod1, nn, D_DX)) {
-			regsalloc(&nod2, n);
-			gmove(&nod1, &nod2);
+			regwide(&nodw, &nod1);
+			regspill(&nod2, &nodw, n);
 			v = reg[D_DX];
 			reg[D_DX] = 0;
 
@@ -772,7 +823,7 @@ cgen(Node *n, Node *nn)
 			} else
 				cgen(n, nn);
 
-			gmove(&nod2, &nod1);
+			gmove(&nod2, &nodw);
 			reg[D_DX] = v;
 			break;
 		}


### PR DESCRIPTION
    PASS  other ^ rol(bc[(i+1)%5], 1)        -- % in the argument
    FAIL  bc[(i+4)%5] ^ rol(bc[k], 1)        -- % in the left operand
    PASS  bc[(i+4)%5] ^ (shift written out)  -- % but no call
    PASS  bc[m] ^ rol(bc[idx], 1)            -- % hoisted out

The trigger is <expression containing / or %> op <64-bit function call>, with the division in the *other* operand rather than in the call's arguments -- an argument is evaluated before the call, so nothing 64-bit is live across it yet.

cgen.c spills AX, CX or DX where the instruction it is about to emit can only use that register: divide and modulo need AX and DX, a variable shift needs CX. The save was

    if(nodreg(&nod, nn, D_AX)) {
            regsalloc(&nod2, n);
            gmove(&nod, &nod2);

and regsalloc takes its size from the node handed to it -- here n, the divide. So a 32-bit operation spilled four bytes of a register that might hold eight. Whatever is live in AX at that moment belongs to an earlier part of the expression and has nothing to do with the type of the operation being generated.

In LibreSSL's Keccak,

    t0 = bc[(i + 4) % 5] ^ crypto_rol_u64(bc[(i + 1) % 5], 1);

OFUNC has complex == FNX, so cgen's OXOR case evaluates the call first and it lands in AX; then the 32-bit "% 5" needs AX, saves it four bytes wide, and crypto_rol_u64's uint64_t comes back with bits 32..63 cleared. The identical call two lines below is correct -- no division beside it.

regwide() makes a full-width alias of the register node and regspill() saves it through an 8-byte slot; restoring goes back through the alias. The narrow node is untouched because the callers still need it at the operation's own type for the result. Six sites: AX and DX in ODIV/OMOD and in the OAS* forms, CX in both shift cases. nodreg forces an integer register at all six and the float paths leave earlier via "goto fop", so widening to TVLONG cannot catch an X register.

6c is the only compiler with this. 8c is 32-bit, so a one-register save cannot truncate; the RISC back-ends need no fixed register for division, and their single regsalloc(&nod, n) is OFUNC with a discarded result, where n is the call itself and its type is right.

Untested: I cannot build 6c here. It needs

    cd sys/src/cmd/6c && mk nuke && mk install

then rol64-test, then the Keccak probe, and then everything, because a 64-bit value live across a 32-bit % is ordinary C and nothing about this was Keccak-specific.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs