### PR TITLE
tests: record that the 6c spill bug is fixed; keep them as regressions

### DIFF
--- a/sys/lib/tests/rol64-test.c
+++ b/sys/lib/tests/rol64-test.c
@@ -13,37 +13,37 @@
  *
  *	st[j] = crypto_rol_u64(t0, sha3_keccakf_rotc[i]);
  *
- * is correct, so it is not the function: it is something about this
- * call site. Modelling the permutation with only the theta call's
- * result masked to 32 bits reproduces all 25 lanes of the observed
- * wrong state after 24 rounds -- a 1600-bit match, so the diagnosis is
- * not in doubt. What is not yet known is which property of the call
- * site triggers it.
+ * is correct, so it was never the function: it was the call site.
  *
- * That is what this file is for. Each case changes one thing, and the
- * first run through it already ruled most of them out:
+ * FIXED in 6c/cgen.c. cgen spills AX, CX or DX where the instruction it
+ * is about to emit can only use that register -- a divide or modulo
+ * needs AX and DX, a variable shift needs CX -- and the save was
  *
- *	how the result is used	assigned, or an operand of ^	 both pass
- *	the shift		a literal, or a variable	 both pass
- *	the function		static inline, static, extern	 all pass
- *	a 64-bit return with no shifting in it			 passes
- *	the rotation written out, no call			 passes
- *	the arguments		scalars				 pass
- *				array elements, computed index	 FAIL
+ *	regsalloc(&nod2, n);	-- slot sized from n, the divide
+ *	gmove(&nod, &nod2);	-- so a 32-bit save
  *
- * So it is not the call, the XOR, the shift or the inline keyword. It
- * is the array operands -- and the one thing that distinguishes them on
- * amd64 is that the index expressions contain %, which needs AX and DX,
- * the same registers a call returns its result in. The block of cases
- * that follows separates the possibilities: division in the argument,
- * in the other operand of the ^, in both, / instead of %, * instead of
- * %, the division hoisted into a variable, and the whole shape with no
- * call at all.
+ * regsalloc takes its size from the node it is given, and n is the
+ * divide. A 32-bit operation therefore spilled four bytes of a register
+ * that might hold eight. What is live in AX at that point belongs to an
+ * earlier part of the expression and has nothing to do with the type of
+ * the operation being generated. OFUNC has complex == FNX, so cgen's
+ * OXOR case evaluates the call first and it lands in AX; the 32-bit
+ * "% 5" beside it then saved AX four bytes wide.
  *
- * The pattern of PASS and FAIL across them names the trigger. Every
- * case computes the same rotation of the same value -- the one theta
- * actually got wrong, 0x0000300000200200 rotated left by 1 -- so any
- * FAIL is the compiler and nothing else.
+ * Now a regression test. The cases below found the trigger by changing
+ * one thing at a time, and the pattern was:
+ *
+ *	% in the call's argument		passed
+ *	% in the other operand of the ^		FAILED
+ *	% in the other operand, but no call	passed
+ *	% hoisted into a variable first		passed
+ *	/ or * instead of %			passed
+ *
+ * so the trigger is <expression containing / or %> op <64-bit function
+ * call>, with the division in the *other* operand: an argument is
+ * evaluated before the call, so nothing 64-bit is live across it yet.
+ * All of that is kept because it is what makes a future regression
+ * legible rather than just red.
  *
  * Nothing here is Keccak-specific and nothing here is unusual C. A
  * 64-bit function result feeding an XOR is ordinary enough that this is

--- a/sys/src/ape/lib/libressl/test/keccakf_probe.c
+++ b/sys/src/ape/lib/libressl/test/keccakf_probe.c
@@ -1,7 +1,17 @@
 /*
  * keccakf_probe.c -- find the miscompiled step of Keccak-f[1600].
  *
- * Where this stands. sha3_kat.c showed every 64-bit primitive Keccak is
+ * FIXED. The answer was a 6c code-generation bug: cgen spills AX for
+ * the 32-bit "% 5" in theta's bc[(i + 4) % 5], and sized the spill slot
+ * from the divide rather than from the register, so the 64-bit
+ * crypto_rol_u64 result live in AX lost its top half. Round 3 was the
+ * first round wrong because rounds 1 and 2 act on a state too sparse
+ * for the lost bits to matter. See sys/lib/tests/rol64-test.c.
+ *
+ * Kept as a regression test, and as the shape of a working method: to
+ * find a miscompiled step in a diffusing function, stop it early.
+ *
+ * How it went. sha3_kat.c showed every 64-bit primitive Keccak is
  * built from to be correct -- crypto_rol_u64 at the amounts it uses,
  * both shifts by a size_t, the byte/word union -- and every SHA-3 and
  * SHAKE vector to be wrong. The first version of this file then showed

--- a/sys/src/ape/lib/libressl/test/sha3_kat.c
+++ b/sys/src/ape/lib/libressl/test/sha3_kat.c
@@ -32,7 +32,13 @@
  * hashes with SHA-256 and SHA-384 -- which is why TLS 1.2 and
  * -groups X25519 both work.
  *
- * The source is not at fault. This file's logic was checked by
+ * FIXED: the cause was a 6c code-generation bug, not anything in
+ * sha3.c -- cgen spilled AX four bytes wide for the 32-bit "% 5" in
+ * theta while a 64-bit call result was live in it. See
+ * sys/lib/tests/rol64-test.c and the note in CLAUDE.md. This file is
+ * now a regression test.
+ *
+ * The source was never at fault. This file's logic was checked by
  * transcribing sha3.c's permutation and sponge and running the vectors
  * below against it under gcc, where every case passes. So the fault is
  * in what pcc makes of that source, and this test exists to say which


### PR DESCRIPTION
rol64-test passes in full with the rebuilt 6c, including the two cases that failed before, so regwide/regspill is the right fix.

The three test files still described the bug as an open hunt in the present tense. They now say what it was, and stay: rol64-test.c is the regression test for the compiler, and the Keccak files are the regression test for the consequence.

rol64-test.c keeps the whole narrowing matrix rather than being cut down to the one failing case. The pattern -- % in the argument passes, % in the other operand fails, % with no call passes, % hoisted out passes, / and * pass -- is what would make a future regression legible instead of merely red.

keccakf_probe.c keeps its round and step bisect for the same reason, and because the method generalises: to find a miscompiled step inside a function that diffuses, stop it early rather than reasoning backwards from the output. Twenty-four rounds of Keccak turn any fault into noise; two rounds of it turn the same fault into four sparse numbers.

Also fixed a real bug in my own edit: the FIXED note quoted two lines of cgen.c that carry /* */ comments, inside a block comment, which would have closed it early.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs