### PR TITLE
libzip: include <fcntl.h> from config.h so compat.h sees O_CLOEXEC

### DIFF
--- a/sys/src/ape/lib/zip/config.h
+++ b/sys/src/ape/lib/zip/config.h
@@ -20,6 +20,35 @@
 #include "zipconf.h"
 #endif
 
+/*
+ * Not in config.h.in, and not decoration.
+ *
+ * compat.h reads this file at its line 39 and then, at line 82, does
+ *
+ *	#ifndef O_CLOEXEC
+ *	#define O_CLOEXEC 0
+ *	#endif
+ *
+ * for the sake of Windows. Nothing above that point includes <fcntl.h>,
+ * so on a system that does have O_CLOEXEC the guard still fires unless
+ * some earlier header dragged fcntl.h in. Here one eventually does --
+ * APE's <stdio.h> includes <stdio_impl.h>, which includes <fcntl.h> --
+ * but not until zip.h asks for stdio, by which time compat.h has
+ * already decided O_CLOEXEC is 0:
+ *
+ *	fcntl.h:21 ... zip.h:80 ... zipint.h:51 zip_add.c:36
+ *	  Macro redefinition of O_CLOEXEC
+ *
+ * Including it here is the fix rather than a workaround: it gives
+ * compat.h the information it is testing for, before it tests. Every
+ * file in libzip reaches compat.h, so one include covers all of them.
+ *
+ * The same reasoning would apply to compat.h's EOPNOTSUPP and EOVERFLOW
+ * fallbacks, but those are safe: it includes <errno.h> itself, at line
+ * 65, before testing them.
+ */
+#include <fcntl.h>
+
 /* zip_fdopen(). Needs fdopen and dup, both of which APE has. */
 #define ENABLE_FDOPEN
 


### PR DESCRIPTION
    fcntl.h:21 ... zip.h:80 ... zipint.h:51 zip_add.c:36
      Macro redefinition of O_CLOEXEC

compat.h reads config.h at its line 39 and then, at line 82, does

    #ifndef O_CLOEXEC
    #define O_CLOEXEC 0
    #endif

for Windows' sake. Nothing above that point includes <fcntl.h>, so the guard fires even where O_CLOEXEC exists, unless some earlier header happened to drag fcntl.h in. Here one eventually does, but too late: APE's <stdio.h> includes <stdio_impl.h>, which includes <fcntl.h>, and zip.h does not ask for stdio until after compat.h has already decided O_CLOEXEC is 0. fcntl.h then says 02000000 and the two disagree.

Including <fcntl.h> from config.h is the fix rather than a workaround: it gives compat.h the information it is testing for, before it tests. Every source in libzip reaches compat.h, so one include covers all 120.

compat.h's EOPNOTSUPP and EOVERFLOW fallbacks have the same shape but are safe, because it includes <errno.h> itself at line 65 before testing them. Those are the only three.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs