### PR TITLE
ape: give S_IFSOCK its own value instead of aliasing it to S_IFIFO

### DIFF
--- a/sys/include/ape/dirent.h
+++ b/sys/include/ape/dirent.h
@@ -72,10 +72,11 @@ struct	dirent {
  * unknown mode reports DT_UNKNOWN and DT_WHT maps back through the same
  * shift gnulib uses -- which is what gnulib's own DTTOIF does too.
  *
- * S_ISFIFO and S_ISSOCK are the same test in <sys/stat.h>, both mode
- * 0010000, so the FIFO arm is reached first and a socket cannot be
- * distinguished -- the same limitation readdir() has when it fills
- * d_type. DTTOIF has it in the other direction: S_IFSOCK is S_IFIFO.
+ * The DT_SOCK arms below are correct but unreachable in practice:
+ * S_IFSOCK has its own value in <sys/stat.h>, distinct from S_IFIFO,
+ * and Plan 9 has no Unix-domain sockets in the file system for anything
+ * to carry it. They used to be the same value, which made S_ISSOCK()
+ * true for every FIFO and IFTODT report DT_FIFO for both.
  */
 #ifndef IFTODT
 #define IFTODT(mode) \

--- a/sys/include/ape/sys/stat.h
+++ b/sys/include/ape/sys/stat.h
@@ -32,7 +32,7 @@ struct	stat {
 
 #define	S__MASK		     0170000
 #define S_ISLNK(m)	(((m)&S__MASK) == 0120000)
-#define S_ISSOCK(m)	(((m)&S__MASK) == 0010000)
+#define S_ISSOCK(m)	(((m)&S__MASK) == 0140000)
 #define S_ISREG(m)	(((m)&S__MASK) == 0100000)
 #define S_ISDIR(m)	(((m)&S__MASK) == 0040000)
 #define S_ISCHR(m)	(((m)&S__MASK) == 0020000)
@@ -152,7 +152,28 @@ struct	stat {
 #define S_IFREG 0100000
 #define S_IFIFO 0010000
 #define S_IFLNK 0120000
-#define S_IFSOCK S_IFIFO
+/*
+ * 0140000 is the conventional S_IFSOCK, and it is free under S__MASK
+ * (0170000). It used to be defined as S_IFIFO, on the reasoning that
+ * Plan 9 has no Unix-domain sockets in the file system so nothing can
+ * ever be one. Both halves of that were wrong in practice:
+ *
+ *   - S_ISSOCK() was then true for every FIFO, which is a wrong answer
+ *     rather than a missing one. Code that asks "is this a socket?"
+ *     about a pipe got yes.
+ *   - The two names being the same value makes any switch over file
+ *     types ill-formed, and archivers all have one:
+ *
+ *       ftree.c:458 duplicate cases in switch 4096
+ *
+ *     from pax's switch (S_IFMT & sb.st_mode) having both a case
+ *     S_IFIFO and a case S_IFSOCK. GNU tar, cpio and find have the
+ *     same shape.
+ *
+ * With a distinct value S_ISSOCK() is simply never true here, which is
+ * the accurate statement, and the switches compile.
+ */
+#define S_IFSOCK 0140000
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/src/ape/lib/ap/dirent/readdir.c
+++ b/sys/src/ape/lib/ap/dirent/readdir.c
@@ -15,10 +15,10 @@
  * DT_* constants, which are small integers unrelated to the S_IF* bits,
  * so the two have to be mapped rather than aliased.
  *
- * S_ISFIFO and S_ISSOCK are the same test in APE's <sys/stat.h> -- both
- * are mode 0010000 -- so a FIFO and a socket cannot be told apart here.
- * FIFO wins, since mkfifo() can create one and Plan 9 has no Unix-domain
- * sockets in the filesystem.
+ * There is no DT_SOCK arm. S_IFSOCK has its own value in APE's
+ * <sys/stat.h> now, but Plan 9 has no Unix-domain sockets in the file
+ * system, so nothing here ever has that mode and the arm would be dead.
+ * A FIFO, which mkfifo() can create, does reach DT_FIFO.
  */
 static unsigned char
 _dtype(mode_t m)


### PR DESCRIPTION
    ftree.c:458 duplicate cases in switch 4096

from pax's switch (S_IFMT & sb.st_mode), which has both a case S_IFIFO and a case S_IFSOCK. <sys/stat.h> defined

    #define S_IFSOCK S_IFIFO

so the two labels were the same value, 0010000, and the switch is ill-formed. GNU tar, cpio and find all have a switch of that shape, so this was waiting for any of them.

The aliasing was deliberate -- Plan 9 has no Unix-domain sockets in the file system, so nothing can ever be one -- but it was wrong in both directions. Besides breaking switches, it made S_ISSOCK() true for every FIFO: code asking "is this a socket?" about a pipe got yes, which is a wrong answer rather than a missing one.

0140000 is the conventional S_IFSOCK and is free under S__MASK (0170000), so S_IFSOCK now has it and S_ISSOCK tests for it. Nothing in this tree ever sets that mode -- ap/plan9/dirtostat.c gives a pipe S_IFIFO and there is no other producer -- so S_ISSOCK() is simply never true, which is the accurate statement.

The two comments that described the old arrangement, in dirent.h's IFTODT/DTTOIF and in readdir.c's _dtype, are updated: the DT_SOCK arms are correct but unreachable rather than shadowed by the FIFO arm, and readdir's missing DT_SOCK case is now dead code rather than a limitation.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs