### PR TITLE
pax, zip: make the install rules do the whole job themselves

### DIFF
--- a/sys/src/ape/cmd/pax/mkfile
+++ b/sys/src/ape/cmd/pax/mkfile
@@ -194,9 +194,13 @@ CFLAGS=-c -I$PAXSRC\
 %.$O: $PAXSRC/%.c
 	$CC $CFLAGS $PAXSRC/$stem.c
 
-# mkone's install puts $O.out at $BIN/pax; this adds the second name and
-# the two manual pages. tar.1 is not installed -- see the note above.
+# Installs pax itself as well as the second name, rather than leaving
+# the first half to mkone's install rule -- see the note in ../zip/mkfile.
+# cp of the same file twice is harmless.
+#
+# tar is not installed; see the note at the top.
 install:V:	$O.out
+	cp $O.out $BIN/pax
 	cp $O.out $BIN/cpio
 	cp $PAXSRC/pax.1 $APEXPROOT/sys/man/1/pax
 	cp $PAXSRC/cpio.1 $APEXPROOT/sys/man/1/cpio

--- a/sys/src/ape/cmd/zip/mkfile
+++ b/sys/src/ape/cmd/zip/mkfile
@@ -71,10 +71,20 @@ $O.zipcmp: zipcmp.$O diff_output.$O
 %.$O: $ZIPSRC/src/%.c
 	$CC $CFLAGS $ZIPSRC/src/$stem.c
 
+# Written to do the whole job -- build the three programs, copy them,
+# then the manual pages -- rather than relying on mkmany's install rule
+# also running. Two rules for one target is established practice in this
+# tree (cmd/awk, cmd/gettext, cmd/openssl all do it and all work), but
+# depending on it here buys nothing: the copies are idempotent and this
+# way the rule is readable on its own.
+#
 # man/ carries each page three times: .mdoc is the source, .man is the
 # same page converted to the older man macros, and .html is for the web.
 # Plan 9's man(1) wants the man macros, so .man is the one to install.
-install:V:
+install:V:	$PROGS
+	cp $O.zipcmp $BIN/zipcmp
+	cp $O.zipmerge $BIN/zipmerge
+	cp $O.ziptool $BIN/ziptool
 	cp $ZIPSRC/man/zipcmp.man $APEXPROOT/sys/man/1/zipcmp
 	cp $ZIPSRC/man/zipmerge.man $APEXPROOT/sys/man/1/zipmerge
 	cp $ZIPSRC/man/ziptool.man $APEXPROOT/sys/man/1/ziptool


### PR DESCRIPTION
cmd/zip's install copied three manual pages and nothing else, so it documented programs it had never built or installed. It now builds $PROGS and copies all three binaries first. cmd/pax's had the same shape: it installed cpio and the man pages but left pax itself to mkone's rule.

Both now stand alone rather than assuming the include's install rule also runs. That assumption is probably fine -- cmd/awk, cmd/gettext and cmd/openssl all add a second install rule after the include, and openssl's rebuilt binary was demonstrably installed after the 6c fix, so mk does run both -- but nothing is gained by relying on it, and a rule that reads correctly on its own is worth more. The extra cp is idempotent.

This may not be what stopped the zip tools building; I have not seen the error. It is wrong regardless.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs