### PR TITLE
mkfiles: add prerequisites, not second recipes, to the include's targets

### DIFF
--- a/sys/src/ape/cmd/openssl/mkfile
+++ b/sys/src/ape/cmd/openssl/mkfile
@@ -145,7 +145,25 @@ CFLAGS=-c -I$SSLSRC/include -I$SSLSRC/include/compat\
 # certs/ is the -CApath hash directory. It stays empty: filling it is
 # certhash(1)'s job, and certhash needs symlinks, which Plan 9 does not
 # have -- see the note on certhash_win.c above.
-install:V:
+# Adding to a target the include already gives a recipe to needs care.
+# mk merges two rules for one target only when it can: if both carry a
+# recipe and their prerequisites differ, it refuses --
+#
+#	mk: ambiguous recipes for install:
+#	    install <-(.../mkmany:40)-
+#	    install <-(mkfile:85)- 6.zipcmp <-...
+#
+# and if both carry a recipe with the same prerequisites, one silently
+# wins. mkone's install is prerequisite-only so a second recipe is safe
+# there (cmd/awk relies on it), but mkmany's install and every nuke and
+# clean do carry one.
+#
+# So the rule below adds a prerequisite and no recipe, and the work goes
+# in a private target. That is correct whichever way mk would have gone,
+# and it leaves the include's own recipe running.
+install:V:	ssldata
+
+ssldata:V:
 	mkdir -p $APEXPROOT/sys/lib/ape/ssl/certs
 	cp $SSLSRC/cert.pem $APEXPROOT/sys/lib/ape/ssl/cert.pem
 	cp $SSLSRC/openssl.cnf $APEXPROOT/sys/lib/ape/ssl/openssl.cnf
@@ -154,7 +172,9 @@ install:V:
 
 # Only the three files this installs. certs/ is left alone: it is where
 # a user would put their own, and nothing here put anything in it.
-nuke:V:
+nuke:V:	sslundata
+
+sslundata:V:
 	rm -f $APEXPROOT/sys/lib/ape/ssl/cert.pem
 	rm -f $APEXPROOT/sys/lib/ape/ssl/openssl.cnf
 	rm -f $APEXPROOT/sys/lib/ape/ssl/x509v3.cnf

--- a/sys/src/ape/cmd/pax/mkfile
+++ b/sys/src/ape/cmd/pax/mkfile
@@ -194,18 +194,33 @@ CFLAGS=-c -I$PAXSRC\
 %.$O: $PAXSRC/%.c
 	$CC $CFLAGS $PAXSRC/$stem.c
 
-# Installs pax itself as well as the second name, rather than leaving
-# the first half to mkone's install rule -- see the note in ../zip/mkfile.
-# cp of the same file twice is harmless.
-#
 # tar is not installed; see the note at the top.
-install:V:	$O.out
-	cp $O.out $BIN/pax
+# Adding to a target the include already gives a recipe to needs care.
+# mk merges two rules for one target only when it can: if both carry a
+# recipe and their prerequisites differ, it refuses --
+#
+#	mk: ambiguous recipes for install:
+#	    install <-(.../mkmany:40)-
+#	    install <-(mkfile:85)- 6.zipcmp <-...
+#
+# and if both carry a recipe with the same prerequisites, one silently
+# wins. mkone's install is prerequisite-only so a second recipe is safe
+# there (cmd/awk relies on it), but mkmany's install and every nuke and
+# clean do carry one.
+#
+# So the rule below adds a prerequisite and no recipe, and the work goes
+# in a private target. That is correct whichever way mk would have gone,
+# and it leaves the include's own recipe running.
+install:V:	paxextra
+
+paxextra:V:	$O.out
 	cp $O.out $BIN/cpio
 	cp $PAXSRC/pax.1 $APEXPROOT/sys/man/1/pax
 	cp $PAXSRC/cpio.1 $APEXPROOT/sys/man/1/cpio
 
-nuke:V:
+nuke:V:	paxunman
+
+paxunman:V:
 	rm -f $BIN/cpio
 	rm -f $APEXPROOT/sys/man/1/pax
 	rm -f $APEXPROOT/sys/man/1/cpio

--- a/sys/src/ape/cmd/zip/mkfile
+++ b/sys/src/ape/cmd/zip/mkfile
@@ -71,25 +71,35 @@ $O.zipcmp: zipcmp.$O diff_output.$O
 %.$O: $ZIPSRC/src/%.c
 	$CC $CFLAGS $ZIPSRC/src/$stem.c
 
-# Written to do the whole job -- build the three programs, copy them,
-# then the manual pages -- rather than relying on mkmany's install rule
-# also running. Two rules for one target is established practice in this
-# tree (cmd/awk, cmd/gettext, cmd/openssl all do it and all work), but
-# depending on it here buys nothing: the copies are idempotent and this
-# way the rule is readable on its own.
-#
 # man/ carries each page three times: .mdoc is the source, .man is the
 # same page converted to the older man macros, and .html is for the web.
 # Plan 9's man(1) wants the man macros, so .man is the one to install.
-install:V:	$PROGS
-	cp $O.zipcmp $BIN/zipcmp
-	cp $O.zipmerge $BIN/zipmerge
-	cp $O.ziptool $BIN/ziptool
+# Adding to a target the include already gives a recipe to needs care.
+# mk merges two rules for one target only when it can: if both carry a
+# recipe and their prerequisites differ, it refuses --
+#
+#	mk: ambiguous recipes for install:
+#	    install <-(.../mkmany:40)-
+#	    install <-(mkfile:85)- 6.zipcmp <-...
+#
+# and if both carry a recipe with the same prerequisites, one silently
+# wins. mkone's install is prerequisite-only so a second recipe is safe
+# there (cmd/awk relies on it), but mkmany's install and every nuke and
+# clean do carry one.
+#
+# So the rule below adds a prerequisite and no recipe, and the work goes
+# in a private target. That is correct whichever way mk would have gone,
+# and it leaves the include's own recipe running.
+install:V:	zipman
+
+zipman:V:	$PROGS
 	cp $ZIPSRC/man/zipcmp.man $APEXPROOT/sys/man/1/zipcmp
 	cp $ZIPSRC/man/zipmerge.man $APEXPROOT/sys/man/1/zipmerge
 	cp $ZIPSRC/man/ziptool.man $APEXPROOT/sys/man/1/ziptool
 
-nuke:V:
+nuke:V:	zipunman
+
+zipunman:V:
 	rm -f $APEXPROOT/sys/man/1/zipcmp
 	rm -f $APEXPROOT/sys/man/1/zipmerge
 	rm -f $APEXPROOT/sys/man/1/ziptool

--- a/sys/src/ape/lib/libressl/test/mkfile
+++ b/sys/src/ape/lib/libressl/test/mkfile
@@ -133,12 +133,26 @@ keccakf_probe.$O: keccakf_probe.c
 
 V=$SSLSRC/tests
 
-# Named "test" because that is the target mksyslib invokes here. mkmany
-# defines one too -- it looks for a ./test below this directory, finds
-# none and does nothing -- so both recipes run, as they do wherever this
-# tree redefines a target after the include (cmd/awk and cmd/gettext do
-# the same with install).
-test:V: $PROGS
+# Named "test" because that is the target mksyslib invokes in here.
+# Adding to a target the include already gives a recipe to needs care.
+# mk merges two rules for one target only when it can: if both carry a
+# recipe and their prerequisites differ, it refuses --
+#
+#	mk: ambiguous recipes for install:
+#	    install <-(.../mkmany:40)-
+#	    install <-(mkfile:85)- 6.zipcmp <-...
+#
+# and if both carry a recipe with the same prerequisites, one silently
+# wins. mkone's install is prerequisite-only so a second recipe is safe
+# there (cmd/awk relies on it), but mkmany's install and every nuke and
+# clean do carry one.
+#
+# So the rule below adds a prerequisite and no recipe, and the work goes
+# in a private target. That is correct whichever way mk would have gone,
+# and it leaves the include's own recipe running.
+test:V:	runtests
+
+runtests:V:	$PROGS
 	echo '---- the Keccak permutation alone'
 	$O.keccakf_probe
 	echo '---- SHA-3 and SHAKE around it'


### PR DESCRIPTION
    mk: ambiguous recipes for install:
        install <-(.../mkmany:40)-
        install <-(mkfile:85)- 6.zipcmp <-...

mk merges two rules for one target only when it can. If both carry a recipe and the prerequisites differ it refuses outright; if both carry a recipe and the prerequisites match, one silently wins. That accounts for everything seen here, including the two different failures cmd/zip gave: the first version's install had no prerequisites, matched mkmany's, and quietly replaced it -- so "mk install" copied three manual pages for programs it had never built, which is what "the zip utilities do not build" was. Adding $PROGS to it then made the prerequisites differ, and mk refused.

It also corrects what I said last time. Two rules for one target is not simply established practice: mkone's install is prerequisite-only, so a second recipe is safe there and cmd/awk relies on it, but mkmany's install carries a recipe and so do nuke and clean in mkone, mkmany and mksyslib alike. cmd/openssl's install was safe for that reason; its nuke was not, and neither was cmd/pax's.

All of them now add a prerequisite and no recipe, with the work in a private target -- zipman, paxextra, ssldata, runtests and the three nuke equivalents. That is correct whichever way mk would have gone, and the include's own recipe still runs, which is what installs the binaries. The private targets carry the prerequisites the install rules used to have, so nothing runs before it is built.

Dropped from the recipes as a result: cmd/zip no longer copies the three binaries and cmd/pax no longer copies pax, because mkmany's install and mkone's $BIN/$TARG respectively already do exactly that. cmd/pax still copies the second name, cpio, which nothing else would.

cmd/gettext has the same latent fault -- mkmany plus an install rule with a recipe and no prerequisites -- so its two scripts are installed and its binaries silently are not. Left alone here; it is not part of this change and wants testing on its own.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs