### PR TITLE
gettext: msgfmt and msgmerge were built but never installed

### DIFF
--- a/sys/src/ape/cmd/gettext/mkfile
+++ b/sys/src/ape/cmd/gettext/mkfile
@@ -28,10 +28,31 @@ $O.msgfmt: msgfmt.$O $PARSEROBJS
 $O.msgmerge: msgmerge.$O
 	$CC -o $O.msgmerge msgmerge.$O $PARSEROBJS
 
-install:V:
+# The two shell scripts that go beside the binaries. This adds a
+# prerequisite to install and puts the work in a private target, rather
+# than giving install a second recipe.
+#
+# It used to be a second recipe, and mkmany's install has one too:
+#
+#	install:V:
+#		for (i in $TARG)
+#			mk $MKFLAGS $i.install
+#
+# Two recipes for one target with the same prerequisites -- both empty
+# here -- and one of them silently wins. This one did, so "mk install"
+# wrote the two scripts and never installed msgfmt or msgmerge. mkone's
+# install is prerequisite-only, which is why cmd/awk gets away with the
+# same shape; mkmany's is not.
+#
+# (When the prerequisites differ instead, mk refuses outright with
+# "ambiguous recipes for install" rather than choosing. Either way, a
+# prerequisite and a private target is the arrangement that works.)
+install:V:	gettextscripts
+
+gettextscripts:V:
 	cat $GETTEXTSRC/src/autopoint.in | sed 's,@datadir@,"/sys/lib/ape",' > $APEXPROOT/rc/bin/ape/autopoint
 	cp $GETTEXTSRC/src/xgettext.sh $APEXPROOT/rc/bin/ape/xgettext
-	chmod +x $APEXPROOT/rc/bin/ape/*
+	chmod +x $APEXPROOT/rc/bin/ape/autopoint $APEXPROOT/rc/bin/ape/xgettext
 
 
 


### PR DESCRIPTION
The mkfile ends in

    install:V:
            cat .../autopoint.in | sed ... > .../autopoint
            cp .../xgettext.sh .../xgettext
            chmod +x .../rc/bin/ape/*

and mkmany, which it includes, has an install rule with a recipe too. Two recipes for one target with the same prerequisites -- both empty here -- and one silently wins. This one did, so "mk install" wrote the two shell scripts and never copied msgfmt or msgmerge into $objtype/bin/ape.

Fixed the way cmd/pax, cmd/zip and cmd/openssl now are: install gains a prerequisite and no recipe, and the work moves into a private target. mkmany's own recipe then runs and installs the binaries. mkone's install is prerequisite-only, which is why cmd/awk gets away with the same shape and this did not.

The other two mkmany users with an install recipe, cmd/base and cmd/core, are correct and left alone: both install the binaries themselves before adding their man pages -- base with an explicit cp of $O.$i, core by reproducing mkmany's "mk $i.install" loop verbatim. They duplicate the include's work rather than displacing it.

Also narrowed the chmod. It was "+x rc/bin/ape/*", which marks every file in a shared directory executable, not just the two scripts this had written; it now names them. Nothing depended on the wider form -- cmd/awk chmods its own igawk, and cmd/cfront's only use of that directory is commented out.

Not built here; gettext wants a rebuild to confirm the two binaries now land in bin/ape.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs