### PR TITLE
ape: <stdio.h> no longer drags errno, unistd, fcntl and pthread in

### DIFF
--- a/sys/include/ape/_iofile.h
+++ b/sys/include/ape/_iofile.h
@@ -1,0 +1,85 @@
+#ifndef _IOFILE_H
+#define _IOFILE_H
+
+/*
+ * struct _IO_FILE -- the definition <stdio.h> needs and nothing more.
+ *
+ * <stdio.h> has to see this, because FILE is a typedef of it and
+ * callers put FILE * in structures and pass it about. It used to get it
+ * by including <stdio_impl.h>, which is musl's *internal* header, and
+ * which in this tree opens with
+ *
+ *	#include <stdint.h>
+ *	#include <stddef.h>
+ *	#include <errno.h>
+ *	#include <unistd.h>
+ *	#include <fcntl.h>
+ *	#include <sys/types.h>
+ *	#include <pthread.h>
+ *
+ * because the implementation genuinely wants all of that. The effect
+ * was that every translation unit including <stdio.h> -- which is
+ * nearly all of them -- also got every O_ and F_ macro, all of unistd
+ * and all of pthread.
+ *
+ * That is not merely untidy. Portable code guards its fallbacks on
+ * whether a name exists, and a name that appears earlier or later than
+ * the author expected changes the answer. libzip is the case that
+ * prompted this: its compat.h does
+ *
+ *	#ifndef O_CLOEXEC
+ *	#define O_CLOEXEC 0
+ *	#endif
+ *
+ * for Windows' sake, having included neither <fcntl.h> nor anything
+ * that leads to it -- but <zip.h> asks for stdio a little later, fcntl
+ * arrives through the back door, and the two definitions disagree:
+ *
+ *	fcntl.h:21 ... zip.h:80 ... zipint.h:51 zip_add.c:36
+ *	  Macro redefinition of O_CLOEXEC
+ *
+ * musl's own arrangement is the one restored here: the struct lives in
+ * a header with only the types it needs, and both <stdio.h> and
+ * stdio_impl.h include that. stdio_impl.h keeps its heavy includes, so
+ * the 64 files in ap/stdio that use it are unaffected.
+ *
+ * Three includes, and each is used: size_t for the buffer sizes and the
+ * read and write hooks, off_t for seek and the offsets, intptr_t for
+ * the lock. struct __locale_struct is only ever a pointer here, so it
+ * stays incomplete and needs no header.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+struct _IO_FILE {
+	unsigned flags;
+	unsigned char *rpos, *rend;
+	int (*close)(struct _IO_FILE *);
+	unsigned char *wend, *wpos;
+	unsigned char *mustbezero_1;
+	unsigned char *wbase;
+	size_t (*read)(struct _IO_FILE *, unsigned char *, size_t);
+	size_t (*write)(struct _IO_FILE *, const unsigned char *, size_t);
+	off_t (*seek)(struct _IO_FILE *, off_t, int);
+	unsigned char *buf;
+	size_t buf_size;
+	struct _IO_FILE *prev, *next;
+	int fd;
+	int pipe_pid;
+	long lockcount;
+	int mode;
+	volatile intptr_t lock;
+	int lbf;
+	void *cookie;
+	off_t off;
+	char *getln_buf;
+	void *mustbezero_2;
+	unsigned char *shend;
+	off_t shlim, shcnt;
+	struct _IO_FILE *prev_locked, *next_locked;
+	struct __locale_struct *locale;
+};
+
+#endif /* _IOFILE_H */

--- a/sys/include/ape/stdio.h
+++ b/sys/include/ape/stdio.h
@@ -9,8 +9,13 @@
 #include <stddef.h>
 #include <sys/types.h>
 
-/* Include musl-compatible stdio internal definitions */
-#include <stdio_impl.h>
+/*
+ * struct _IO_FILE only. This used to be <stdio_impl.h>, musl's internal
+ * header, which also pulls errno, unistd, fcntl and pthread in -- so
+ * every file including <stdio.h> got every O_ and F_ macro with it.
+ * See the note in <_iofile.h>.
+ */
+#include <_iofile.h>
 
 /* FILE is now the musl struct _IO_FILE */
 typedef struct _IO_FILE FILE;

--- a/sys/include/ape/stdio_impl.h
+++ b/sys/include/ape/stdio_impl.h
@@ -2,7 +2,11 @@
 #define _STDIO_IMPL_H
 
 #include <stdio.h>
-/* APExp: replaced #include "syscall.h" with the POSIX headers we actually need */
+#include <_iofile.h>	/* struct _IO_FILE; <stdio.h> gets it from here too */
+/* APExp: replaced #include "syscall.h" with the POSIX headers we actually need.
+ * These stay: the implementation wants them. They no longer reach every
+ * file that includes <stdio.h>, because that now includes <_iofile.h>
+ * rather than this header -- see the note there. */
 #include <stdint.h>
 #include <stddef.h>
 #include <errno.h>
@@ -30,34 +34,6 @@
 #define F_SVB 64
 #define F_APP 128
 
-struct _IO_FILE {
-	unsigned flags;
-	unsigned char *rpos, *rend;
-	int (*close)(struct _IO_FILE *);
-	unsigned char *wend, *wpos;
-	unsigned char *mustbezero_1;
-	unsigned char *wbase;
-	size_t (*read)(struct _IO_FILE *, unsigned char *, size_t);
-	size_t (*write)(struct _IO_FILE *, const unsigned char *, size_t);
-	off_t (*seek)(struct _IO_FILE *, off_t, int);
-	unsigned char *buf;
-	size_t buf_size;
-	struct _IO_FILE *prev, *next;
-	int fd;
-	int pipe_pid;
-	long lockcount;
-	int mode;
-	volatile intptr_t lock;
-	int lbf;
-	void *cookie;
-	off_t off;
-	char *getln_buf;
-	void *mustbezero_2;
-	unsigned char *shend;
-	off_t shlim, shcnt;
-	struct _IO_FILE *prev_locked, *next_locked;
-	struct __locale_struct *locale;
-};
 
 extern struct _IO_FILE *volatile __stdin_used;
 extern struct _IO_FILE *volatile __stdout_used;


### PR DESCRIPTION
<stdio.h> has to see struct _IO_FILE, because FILE is a typedef of it. It was getting that by including <stdio_impl.h>, musl's *internal* header, which in this tree opens with

    #include <stdint.h>   #include <stddef.h>  #include <errno.h>
    #include <unistd.h>   #include <fcntl.h>   #include <sys/types.h>
    #include <pthread.h>

because the implementation genuinely wants all of it. So every translation unit that included <stdio.h> -- nearly all of them -- also got every O_ and F_ macro, all of unistd and all of pthread.

That is not only untidy. Portable code guards its fallbacks on whether a name exists, and a name arriving earlier or later than the author expected changes the answer. libzip's compat.h is the case that prompted this: it defines O_CLOEXEC as 0 for Windows' sake, having included nothing that leads to <fcntl.h> -- but <zip.h> asks for stdio a little later, fcntl arrives through the back door, and the two disagree.

musl's own arrangement restored: struct _IO_FILE moves to a new <_iofile.h> with only the three headers it needs -- stddef for size_t, sys/types for off_t, stdint for the lock's intptr_t; struct __locale_struct stays an incomplete type behind a pointer. <stdio.h> includes that instead. stdio_impl.h includes it too and keeps its heavy includes, so the 64 files in ap/stdio that use it are unaffected.

Checked before, not after: every .c in libap that includes <stdio.h>
without <stdio_impl.h> was scanned for uses of the four leaked headers, counting what lib.h supplies transitively. Nothing in libap depended on the leak -- the first pass flagged eight files and all eight were the regex's fault, EOF and ERR matching an errno-constant pattern, Plan 9's own open() from sys9.h matching POSIX open(), and read.c's O_NONBLOCK coming from lib.h's <fcntl.h> rather than from stdio.

That is libap. Ported packages are another matter: any that used open(), errno or pthread while including only <stdio.h> compiled by accident until now and will want the right #include adding. Those are real bugs and each is a one-line fix, but a full rebuild is the way to find them.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs