### PR TITLE
ape: musl.h declared an "int errno" APE does not have

### DIFF
--- a/sys/src/ape/lib/ap/include/musl.h
+++ b/sys/src/ape/lib/ap/include/musl.h
@@ -12,19 +12,53 @@
 #include <stddef.h>
 #include <stdint.h>
 
-/* musl expects ssize_t */
+/*
+ * musl expects ssize_t. <sys/types.h> is reached through <libc.h>
+ * above and uses this same guard, so this fallback normally does not
+ * fire; it must still agree with it, because "long" is 32 bits on
+ * amd64 and a 32-bit ssize_t against a 64-bit caller reads four bytes
+ * of stack garbage in the top half.
+ */
 #ifndef _SSIZE_T
 #define _SSIZE_T
+#ifdef _BITS64
+typedef long long ssize_t;
+#else
 typedef long ssize_t;
+#endif
 #endif
 
 /* -------------------------------------------------------------
- * errno handling – APExp already provides global 'errno'
+ * errno handling
+ *
+ * APE has no "int errno" to declare: <errno.h> defines
+ *
+ *	extern int *_errnoloc;
+ *	#define errno (*_errnoloc)
+ *
+ * so &errno below is _errnoloc, which is what __errno_location has to
+ * return.  This used to be
+ *
+ *	#ifndef errno
+ *	extern int errno;
+ *	#endif
+ *
+ * which is a reference to a symbol that does not exist anywhere in
+ * libap.  It never fired only because <libc.h> above includes <utf.h>,
+ * which includes <stdio.h>, which used to include stdio_impl.h, which
+ * includes <errno.h> -- so the macro happened to be defined by the
+ * time this file was read.  When <stdio.h> stopped dragging errno in,
+ * every object that reaches this header without naming <errno.h> first
+ * -- locale_stubs.o among them, so anything that calls setlocale --
+ * came out referencing it, and the link failed:
+ *
+ *	errno: not defined
+ *
+ * seen first from dash, whose main() calls setlocale(LC_ALL, "").
+ * Including <errno.h> here is unconditional and order-independent.
  * ------------------------------------------------------------- */
 
-#ifndef errno
-extern int errno;
-#endif
+#include <errno.h>
 
 /* musl stdio expects a macro to retrieve errno */
 static inline int *__errno_location(void) {


### PR DESCRIPTION
Fallout from 825dc5295, and the first of it. musl.h had

	#ifndef errno
	extern int errno;
	#endif
	static inline int *__errno_location(void) { return &errno; }

APE has no such object: <errno.h> is "extern int *_errnoloc;" plus "#define errno (*_errnoloc)".  So whenever the guard did not fire, the declaration produced a reference to a symbol that exists nowhere in libap.

It did not fire before only by accident.  musl.h includes <libc.h>, which includes <utf.h>, which includes <stdio.h>, which used to include stdio_impl.h and so <errno.h>.  With <stdio.h> no longer dragging errno in, every object reaching this header without <errno.h> of its own now references the missing symbol -- locale_stubs.o among them, hence anything that calls setlocale:

	errno: not defined

seen linking dash, whose main() opens with setlocale(LC_ALL, "").

Including <errno.h> here instead is unconditional and order-independent, and &errno is then _errnoloc, which is what __errno_location must return.

The ssize_t fallback beside it gets the _BITS64 test the rest of the tree uses.  It is guarded with _SSIZE_T and <sys/types.h> is reached through <libc.h> first, so it does not fire either -- but "long" is 32 bits on amd64, and a fallback that disagrees with the header it is standing in for is the exact shape of the size_t/ssize_t bug already on record.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs