### PR TITLE
perl: probes for the main program that never runs

### DIFF
--- a/sys/src/ape/cmd/perl/mkfile
+++ b/sys/src/ape/cmd/perl/mkfile
@@ -11,7 +11,12 @@ BIN=$APEXPROOT/$objtype/bin/ape
 <$APEXPROOT/sys/src/cmd/mkone
 
 PERLSRC=../../../external/perl
-CFLAGS=-c -I$PERLSRC -D_POSIX_SOURCE -DHAVE_CONFIG_H -D_PLAN9_SOURCE -D_BSD_EXTENSION -DPERL_CORE
+# APEXP_PROBE_MAIN is temporary: it turns on the three PerlIO_printf
+# probes in op.c's Perl_newPROG and perl.c's S_run_body that say why
+# PL_main_start is NULL. Both files are compiled here rather than into
+# libperl.a, so this costs two objects and a relink. Remove it, and the
+# probes, once the answer is in.
+CFLAGS=-c -I$PERLSRC -D_POSIX_SOURCE -DHAVE_CONFIG_H -D_PLAN9_SOURCE -D_BSD_EXTENSION -DPERL_CORE -DAPEXP_PROBE_MAIN
 
 CLEANFILES = *.c
 

--- a/sys/src/external/perl/op.c
+++ b/sys/src/external/perl/op.c
@@ -4712,6 +4712,17 @@ Perl_newPROG(pTHX_ OP *o)
 
     PERL_ARGS_ASSERT_NEWPROG;
 
+#ifdef APEXP_PROBE_MAIN
+    /* APExp: temporary. miniperl compiles and runs BEGIN and END blocks
+     * but never runs the main program, which means PL_main_start is NULL
+     * by the time S_run_body looks at it. This says which of the three
+     * ways that happens is the one here. Remove with the -D in
+     * sys/src/ape/cmd/perl/mkfile once known. */
+    PerlIO_printf(Perl_error_log,
+        "APEXP newPROG: in_eval=%d o=%p type=%s\n",
+        (int)PL_in_eval, (void *)o, o ? OP_NAME(o) : "(null)");
+#endif
+
     if (PL_in_eval) {
         PERL_CONTEXT *cx;
         I32 i;
@@ -4779,6 +4790,12 @@ Perl_newPROG(pTHX_ OP *o)
         start = LINKLIST(PL_main_root);
         PL_main_root->op_next = 0;
         S_process_optree(aTHX_ NULL, PL_main_root, start);
+#ifdef APEXP_PROBE_MAIN
+        PerlIO_printf(Perl_error_log,
+            "APEXP newPROG: start=%p main_start=%p main_root=%p type=%s\n",
+            (void *)start, (void *)PL_main_start, (void *)PL_main_root,
+            start ? OP_NAME(start) : "(null)");
+#endif
         if (!PL_parser->error_count)
             /* on error, leave CV slabbed so that ops left lying around
              * will eb cleaned up. Else unslab */

--- a/sys/src/external/perl/perl.c
+++ b/sys/src/external/perl/perl.c
@@ -2868,6 +2868,14 @@ S_run_body(pTHX_ I32 oldscope)
 
     PERL_SET_PHASE(PERL_PHASE_RUN);
 
+#ifdef APEXP_PROBE_MAIN
+    /* APExp: temporary, see the note in op.c's Perl_newPROG. */
+    PerlIO_printf(Perl_error_log,
+        "APEXP run_body: restartop=%p main_start=%p main_root=%p in_eval=%d\n",
+        (void *)PL_restartop, (void *)PL_main_start, (void *)PL_main_root,
+        (int)PL_in_eval);
+#endif
+
     if (PL_restartop) {
 #ifdef DEBUGGING
         /* this complements the "EXECUTING..." debug we emit above.


### PR DESCRIPTION
Temporary, to be reverted once it has answered.

miniperl links, runs, reports syntax errors and executes BEGIN and END blocks, but the main program does nothing -- "-e 'exit 42'" exits 0. END blocks run from perl_run's case 2, after my_exit(0), so perl_parse returned 0 and S_run_body was entered and fell through its final my_exit(0). That happens exactly when PL_main_start is NULL:

	else if (PL_main_start) {
	    CvDEPTH(PL_main_cv) = 1;
	    PL_op = PL_main_start;
	    CALLRUNOPS(aTHX);
	}
	my_exit(0);

Perl_newPROG leaves it NULL three ways: PL_in_eval nonzero, so the eval branch runs and PL_main_root is never assigned; an OP_STUB optree, so it returns early; or op_prune_chain_head walking a degenerate op_next chain to NULL. The probes print enough to say which.

op.c and perl.c are compiled in sys/src/ape/cmd/perl, not into libperl.a, so this is two objects and a relink rather than a DEBUGGING rebuild of the whole library.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs