### PR TITLE
perl: probe the op_next chain run_body is about to follow

### DIFF
--- a/sys/src/external/perl/perl.c
+++ b/sys/src/external/perl/perl.c
@@ -2874,6 +2874,24 @@ S_run_body(pTHX_ I32 oldscope)
         "APEXP run_body: restartop=%p main_start=%p main_root=%p in_eval=%d\n",
         (void *)PL_restartop, (void *)PL_main_start, (void *)PL_main_root,
         (int)PL_in_eval);
+    /* Walk the op_next chain the runops loop is about to follow. If it
+     * ends after an op or two, the chain is what is wrong; if it is the
+     * whole program, the ops run and something else swallows them. */
+    {
+        const OP *po = PL_main_start;
+        int pn = 0;
+
+        while (po && pn < 40) {
+            PerlIO_printf(Perl_error_log,
+                "APEXP chain[%d] %p %-12s next=%p ppaddr=%p\n",
+                pn, (const void *)po, OP_NAME(po),
+                (const void *)po->op_next, (const void *)po->op_ppaddr);
+            po = po->op_next;
+            pn++;
+        }
+        PerlIO_printf(Perl_error_log, "APEXP chain: %d ops, ended %s\n",
+            pn, po ? "at the probe's limit" : "with a null op_next");
+    }
 #endif
 
     if (PL_restartop) {


### PR DESCRIPTION
The first probes ruled out the thing they were written for. PL_main_start is set, the root is the OP_LEAVE that op_scope builds and the start is its OP_ENTER, and S_run_body sees both -- so CALLRUNOPS is called with a real optree and the main program still does nothing.

What is left is either an op_next chain that ends after an op or two, so runops_standard's

	while ((PL_op = op = op->op_ppaddr(aTHX)))

falls out and run_body reaches my_exit(0), or ops that execute against an empty argument stack -- which would explain both symptoms at once, since print with no arguments prints $_ and exit with no argument exits 0 rather than 42.

This walks the chain statically before running it, with each op's name, successor and ppaddr.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs