### PR TITLE
perl: probe the setlocale return perl thinks failed

### DIFF
--- a/sys/src/ape/lib/perl/mkfile
+++ b/sys/src/ape/lib/perl/mkfile
@@ -21,7 +21,11 @@ OFILES=\
 
 <$APEXPROOT/sys/src/cmd/mksyslib
 
-CFLAGS=-c -I$PERLSRC -D_POSIX_SOURCE -DHAVE_CONFIG_H -D_PLAN9_SOURCE -D_BSD_EXTENSION -DPERL_CORE
+# APEXP_PROBE_MAIN is temporary; see the note in ../../cmd/perl/mkfile.
+# Here it turns on one probe in locale.c, printed just before perl
+# panics over a setlocale it thinks failed, which asks libc the same
+# question again and says what it answered.
+CFLAGS=-c -I$PERLSRC -D_POSIX_SOURCE -DHAVE_CONFIG_H -D_PLAN9_SOURCE -D_BSD_EXTENSION -DPERL_CORE -DAPEXP_PROBE_MAIN
 
 %.$O: $PERLSRC/%.c
 	$CC $CFLAGS $prereq -o $target

--- a/sys/src/external/perl/locale.c
+++ b/sys/src/external/perl/locale.c
@@ -3386,6 +3386,25 @@ S_setlocale_failure_panic_via_i(pTHX_
 {
     PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_VIA_I;
 
+#ifdef APEXP_PROBE_MAIN
+    /* APExp: temporary. Ask libc the same question again, raw, and say
+     * what it answers -- so this separates "libap's setlocale returned
+     * NULL" from "it answered and perl's layer above it turned that
+     * into a failure". Remove with the -D in sys/src/ape/lib/perl/mkfile
+     * and sys/src/ape/cmd/perl/mkfile. */
+    {
+        const int apexp_cat = categories[cat_index];
+        const char *apexp_raw = setlocale(apexp_cat, failed);
+        const char *apexp_qry = setlocale(apexp_cat, NULL);
+
+        PerlIO_printf(Perl_error_log,
+            "APEXP setlocale(%d, \"%s\") = %s; setlocale(%d, NULL) = %s\n",
+            apexp_cat, failed ? failed : "(null)",
+            apexp_raw ? apexp_raw : "(NULL)",
+            apexp_cat, apexp_qry ? apexp_qry : "(NULL)");
+    }
+#endif
+
     /* Called to panic when a setlocale form unexpectedly failed for the
      * category determined by 'cat_index', and the locale that was in effect
      * (and likely still is) is 'current'.  'current' may be NULL, which causes


### PR DESCRIPTION
Temporary, with the others.

The panic now reads "from 'C' to 'C'", so the name bookkeeping added in d64485f34 is in effect and correct -- and the failure was never about the name. This miniperl is non-threaded and HAS_SETLOCALE is defined, so USE_POSIX_2008_LOCALE is off and void_setlocale_c_with_caller reduces to

	if (! cBOOL(posix_setlocale(cat, locale))) panic

meaning setlocale(LC_NUMERIC, "C") came back NULL. libap's new one cannot do that for a category it knows with a one-character name, so one of the two is not doing what it appears to.

The probe asks libc the same question again, raw, immediately before the panic, and prints both the set and a following query. That separates "libap returned NULL" from "perl's layer above it turned an answer into a failure".

locale.c is in libperl.a rather than the command directory, so this one needs the -D there too; touching the source is what gets that single object rebuilt.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs