### PR TITLE
perl: is the op list empty, or is op_moresib not sticking?

### DIFF
--- a/sys/lib/tests/bitfield-test.c
+++ b/sys/lib/tests/bitfield-test.c
@@ -80,6 +80,9 @@ struct opflags {
 	U16 op_spare:1;
 	U8 op_flags;
 	U8 op_private;
+	/* stands in for op_sibparent, which in perl precedes the flags;
+	   here it only has to be a pointer beside them */
+	int *op_sibparent_test;
 };
 
 /* The same widths in an int unit, which is the case kencc has always
@@ -112,8 +115,7 @@ main(void)
 	int n, bad;
 	char detail[128];
 
-	printf("sizeof(struct opflags) = %d (2 bit field bytes + 2 U8"
-	       " is 4)\n", (int)sizeof(struct opflags));
+	printf("sizeof(struct opflags) = %d\n", (int)sizeof(struct opflags));
 	printf("sizeof(struct intflags) = %d\n", (int)sizeof(struct intflags));
 	printf("sizeof(struct charflags) = %d\n", (int)sizeof(struct charflags));
 
@@ -253,6 +255,80 @@ main(void)
 		    (int)p->op_type, (int)p->op_moresib, (int)p->op_folded);
 		check("through a pointer", p->op_type == 33 &&
 		    p->op_moresib == 1 && p->op_folded == 1, detail);
+	}
+
+	/*
+	 * 8. The value of an assignment to a bit field.
+	 *
+	 * C99 6.5.16p3: the value of an assignment expression is the
+	 * value of the left operand after the assignment, converted to
+	 * its type. For a bit field that is the stored value, so
+	 * (o->op_moresib = 1) is 1.
+	 *
+	 * perl's op.h carries a note saying kencc gets this wrong --
+	 * "bitfield-assign expression value is unreliable (always 0)" --
+	 * and works around it in OpMAYBESIB_set. These cases say whether
+	 * that is still true and how far it goes, because the macro as
+	 * originally written is
+	 *
+	 *	((o)->op_sibparent = ((o)->op_moresib = cBOOL(sib))
+	 *	                     ? (sib) : (parent))
+	 *
+	 * which reads the assignment's value to choose a branch. A zero
+	 * there sets the sibling pointer to the parent while the flag
+	 * says there is a sibling, or leaves the flag clear -- either
+	 * way every op list in the program loses all but its first
+	 * element.
+	 */
+	{
+		int v;
+
+		memset(&o, 0, sizeof o);
+		v = (o.op_moresib = 1);
+		sprintf(detail, "(bf = 1) gave %d, field holds %d", v,
+		    (int)o.op_moresib);
+		check("value of a 1-bit assignment", v == 1, detail);
+
+		memset(&o, 0, sizeof o);
+		v = (o.op_type = 401);
+		sprintf(detail, "(bf = 401) gave %d, field holds %d", v,
+		    (int)o.op_type);
+		check("value of a 9-bit assignment", v == 401, detail);
+
+		/* The store must happen even when the value is used. */
+		sprintf(detail, "field holds %d after its value was read",
+		    (int)o.op_type);
+		check("a read value does not lose the store",
+		    o.op_type == 401, detail);
+	}
+
+	/*
+	 * 9. OpMAYBESIB_set as perl writes it upstream, which is where
+	 *    the whole op tree's sibling links come from.
+	 */
+	{
+		int sib = 7, parent = 9;
+		int *sibp = &sib, *parentp = &parent, *got;
+		struct opflags a;
+
+		memset(&a, 0, sizeof a);
+		a.op_sibparent_test = (a.op_moresib = (sibp != NULL))
+		    ? sibp : parentp;
+		got = (0 + a.op_moresib) ? a.op_sibparent_test : NULL;
+		sprintf(detail, "moresib=%d, sibparent %s", (int)a.op_moresib,
+		    a.op_sibparent_test == sibp ? "= sib" :
+		    a.op_sibparent_test == parentp ? "= parent (wrong)" :
+		    "= neither");
+		check("OpMAYBESIB_set with a sibling", got == sibp, detail);
+
+		memset(&a, 0, sizeof a);
+		a.op_sibparent_test = (a.op_moresib = (NULL != NULL))
+		    ? sibp : parentp;
+		got = (0 + a.op_moresib) ? a.op_sibparent_test : NULL;
+		sprintf(detail, "moresib=%d, sibparent %s", (int)a.op_moresib,
+		    a.op_sibparent_test == parentp ? "= parent" : "= other");
+		check("OpMAYBESIB_set without a sibling",
+		    got == NULL && a.op_sibparent_test == parentp, detail);
 	}
 
 	if (failures == 0)

--- a/sys/src/external/perl/op.c
+++ b/sys/src/external/perl/op.c
@@ -4705,6 +4705,36 @@ Perl_blockhook_register(pTHX_ BHK *hk)
     Perl_av_create_and_push(aTHX_ &PL_blockhooks, newSViv(PTR2IV(hk)));
 }
 
+#ifdef APEXP_PROBE_MAIN
+/* APExp: temporary, see Perl_newPROG below. The sibling walk is bounded
+ * because a mis-set op_sibparent can point back into the list. */
+static void
+apexp_dump_kids(pTHX_ const char *what, OP *o)
+{
+    OP *k;
+    int n;
+
+    PerlIO_printf(Perl_error_log, "APEXP %s: %p %s flags=%02x kids=%d\n",
+        what, (void *)o, o ? OP_NAME(o) : "(null)",
+        o ? (unsigned)o->op_flags : 0u,
+        (o && (o->op_flags & OPf_KIDS)) ? 1 : 0);
+
+    if (!o || !(o->op_flags & OPf_KIDS))
+        return;
+
+    k = cLISTOPx(o)->op_first;
+    for (n = 0; k && n < 20; n++) {
+        PerlIO_printf(Perl_error_log,
+            "APEXP   kid[%d] %p %-12s moresib=%d sibparent=%p\n",
+            n, (void *)k, OP_NAME(k), (int)k->op_moresib,
+            (void *)k->op_sibparent);
+        k = k->op_moresib ? k->op_sibparent : NULL;
+    }
+    PerlIO_printf(Perl_error_log, "APEXP %s: %d kid%s\n", what, n,
+        n == 1 ? "" : "s");
+}
+#endif
+
 void
 Perl_newPROG(pTHX_ OP *o)
 {
@@ -4713,14 +4743,17 @@ Perl_newPROG(pTHX_ OP *o)
     PERL_ARGS_ASSERT_NEWPROG;
 
 #ifdef APEXP_PROBE_MAIN
-    /* APExp: temporary. miniperl compiles and runs BEGIN and END blocks
-     * but never runs the main program, which means PL_main_start is NULL
-     * by the time S_run_body looks at it. This says which of the three
-     * ways that happens is the one here. Remove with the -D in
+    /* APExp: temporary. The main program's op_next chain is just
+     * "enter, leave" -- OpSIBLING(enter) is NULL where the statements
+     * should be -- so either the list never had children or op_moresib
+     * did not stick. This walks the children as the tree holds them,
+     * printing the raw op_moresib and op_sibparent of each, which tells
+     * those two apart. Remove with the -D in
      * sys/src/ape/cmd/perl/mkfile once known. */
     PerlIO_printf(Perl_error_log,
         "APEXP newPROG: in_eval=%d o=%p type=%s\n",
         (int)PL_in_eval, (void *)o, o ? OP_NAME(o) : "(null)");
+    apexp_dump_kids(aTHX_ "newPROG arg", o);
 #endif
 
     if (PL_in_eval) {
@@ -4786,6 +4819,9 @@ Perl_newPROG(pTHX_ OP *o)
             return;
         }
         PL_main_root = op_scope(sawparens(scalarvoid(o)));
+#ifdef APEXP_PROBE_MAIN
+        apexp_dump_kids(aTHX_ "after op_scope", PL_main_root);
+#endif
         PL_curcop = &PL_compiling;
         start = LINKLIST(PL_main_root);
         PL_main_root->op_next = 0;


### PR DESCRIPTION
The chain run_body follows is two ops:

	chain[0] enter  next=leave
	chain[1] leave  next=0

so Perl_op_linklist's sibling loop took its else branch on the very first child -- OpSIBLING(enter) was NULL where the statements should be. The flag word reads back correctly in the probe, so this is not a garbled read.

op.h here already carries

	/* Plan9 kencc: bitfield-assign expression value is unreliable
	 * (always 0); use comma operator ... */

on OpMAYBESIB_set, which is the only thing that ever sets op_moresib to 1 -- op_prepend_elem and op_append_elem both reach it through op_sibling_splice. So a kencc bug in exactly this area is already known in this tree and worked around locally.

bitfield-test gains the cases for that: the value of an assignment to a bit field (C99 6.5.16p3 makes it the value stored), that reading the value does not lose the store, and OpMAYBESIB_set as perl writes it upstream. All pass under gcc.

op.c gains a walk of a node's children as the tree holds them, printing each one's raw op_moresib and op_sibparent, at newPROG's entry and again after op_scope. That separates "the list never had children" from "op_moresib did not stick", which the op_next chain alone cannot.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs