### PR TITLE
cc: converting to bool is a comparison, not a truncation

### DIFF
--- a/sys/lib/tests/bool-test.c
+++ b/sys/lib/tests/bool-test.c
@@ -1,0 +1,171 @@
+/*
+ * bool-test.c -- converting to bool is a comparison, not a truncation.
+ *
+ * C99 6.3.1.2: "When any scalar value is converted to _Bool, the result
+ * is 0 if the value compares equal to 0; otherwise, the result is 1."
+ * Every conversion to bool means that -- casts, assignments,
+ * initialisers, arguments, returns -- and it is what makes bool usable
+ * as a flag at all.
+ *
+ * kencc had no separate bool type: lex.c mapped _Bool and bool onto
+ * LCHAR, which the grammar turns into BCHAR, so bool was a plain signed
+ * char and converting to it kept the low byte. So (bool)256 was 0, and
+ * (bool)p for an 8-byte-aligned pointer was whatever its low byte held
+ * -- always even, so storing it in a one-bit bit field, which keeps
+ * bit 0, always gave 0.
+ *
+ * Found through perl. handy.h has
+ *
+ *	#define cBOOL(cbool) ((bool) (cbool))
+ *
+ * and op.h uses it to record whether an op has a next sibling:
+ *
+ *	#define OpMAYBESIB_set(o, sib, parent) \
+ *	    ((o)->op_moresib = cBOOL(sib), ...)
+ *
+ * Every op in every compiled program came out with op_moresib = 0
+ * beside a correct op_sibparent, so Perl_op_linklist found no siblings,
+ * every statement list collapsed to its first element, and miniperl
+ * compiled programs it then declined to execute -- no output, no
+ * diagnostic, exit status 0. Case 6 below is that macro.
+ *
+ * Build and run:  pcc -o bool-test bool-test.c
+ * Prints "PASS" per case; exit status is the number of failures.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures;
+
+static void
+check(const char *what, int ok, const char *detail)
+{
+	if (ok)
+		printf("PASS  %s\n", what);
+	else {
+		printf("FAIL  %s%s%s\n", what, detail ? ": " : "",
+		       detail ? detail : "");
+		failures++;
+	}
+}
+
+/* not static: nothing may fold these away */
+int zero = 0;
+int low_byte_zero = 256;
+int low_bit_zero = 2;
+long big = 0x100000000L;
+double half = 0.5;
+char buf[64];
+char *aligned = buf;
+char *nullp = 0;
+
+static bool
+returns_bool(int v)
+{
+	return v;		/* a return is a conversion too */
+}
+
+static int
+takes_bool(bool b)
+{
+	return b;		/* as is an argument */
+}
+
+int
+main(void)
+{
+	bool b;
+	char detail[128];
+
+	printf("sizeof(bool) = %d\n", (int)sizeof(bool));
+
+	/*
+	 * 1. The cast, on values whose low byte or low bit is zero --
+	 *    the ones a truncating conversion gets wrong.
+	 */
+	sprintf(detail, "(bool)256 = %d", (int)(bool)low_byte_zero);
+	check("cast of a value with a zero low byte",
+	    (bool)low_byte_zero == 1, detail);
+
+	sprintf(detail, "(bool)2 = %d", (int)(bool)low_bit_zero);
+	check("cast of a value with a zero low bit",
+	    (bool)low_bit_zero == 1, detail);
+
+	sprintf(detail, "(bool)0x100000000 = %d", (int)(bool)big);
+	check("cast of a value with a zero low word", (bool)big == 1,
+	    detail);
+
+	sprintf(detail, "(bool)0 = %d", (int)(bool)zero);
+	check("cast of zero", (bool)zero == 0, detail);
+
+	/*
+	 * 2. Pointers. An object pointer is aligned, so its low bits are
+	 *    zero; this is the case perl hit.
+	 */
+	sprintf(detail, "(bool)%p = %d", (void *)aligned, (int)(bool)aligned);
+	check("cast of a non-null pointer", (bool)aligned == 1, detail);
+	check("cast of a null pointer", (bool)nullp == 0, NULL);
+
+	/* 3. Floating point: a value below 1 must not round to false. */
+	sprintf(detail, "(bool)0.5 = %d", (int)(bool)half);
+	check("cast of a fraction", (bool)half == 1, detail);
+
+	/* 4. Assignment and initialisation convert as well. */
+	b = low_byte_zero;
+	sprintf(detail, "b = 256 gave %d", (int)b);
+	check("assignment of a value with a zero low byte", b == 1, detail);
+
+	{
+		bool init = low_bit_zero;
+
+		sprintf(detail, "bool b = 2 gave %d", (int)init);
+		check("initialisation", init == 1, detail);
+	}
+
+	/* 5. Arguments and returns. */
+	sprintf(detail, "takes_bool(256) = %d", takes_bool(low_byte_zero));
+	check("argument conversion", takes_bool(low_byte_zero) == 1, detail);
+	sprintf(detail, "returns_bool(256) = %d",
+	    (int)returns_bool(low_byte_zero));
+	check("return conversion", returns_bool(low_byte_zero) == 1, detail);
+
+	/*
+	 * 6. perl's OpMAYBESIB_set: a cast to bool stored in a one-bit
+	 *    bit field, which keeps bit 0 of whatever it is given. This
+	 *    is correct C for the field -- the conversion in front of it
+	 *    is what has to produce 1.
+	 */
+	{
+		struct {
+			unsigned moresib:1;
+			unsigned spare:15;
+		} op;
+		char *sib = aligned;
+
+		memset(&op, 0, sizeof op);
+		op.moresib = (bool)(sib);
+		sprintf(detail, "moresib = (bool)%p gave %d", (void *)sib,
+		    (int)op.moresib);
+		check("cast to bool stored in a one-bit field",
+		    op.moresib == 1, detail);
+
+		op.moresib = (bool)(nullp);
+		check("and a null pointer still gives 0", op.moresib == 0,
+		    NULL);
+	}
+
+	/* 7. bool keeps unsigned char's representation. */
+	check("sizeof(bool) is 1", sizeof(bool) == 1, NULL);
+
+	/* 8. true and false. */
+	check("true and false", (int)true == 1 && (int)false == 0, NULL);
+
+	if (failures == 0)
+		printf("\nall bool cases passed\n");
+	else
+		printf("\n%d bool case%s failed\n", failures,
+		    failures == 1 ? "" : "s");
+	return failures;
+}

--- a/sys/src/cmd/cc/cc.h
+++ b/sys/src/cmd/cc/cc.h
@@ -479,6 +479,13 @@ EXTERN	char*	thestring;
 EXTERN	Type*	thisfn;
 EXTERN	Node*	thisfnnode;
 EXTERN	Type*	types[NCTYPE];		/* extended to hold TCFLOAT, TCDOUBLE */
+/*
+ * bool/_Bool. Its representation is unsigned char -- there is no TBOOL
+ * etype -- but it is its own Type object so that com.c can tell it from
+ * a plain unsigned char and give conversions to it the semantics C99
+ * 6.3.1.2 requires: a comparison against zero, not a truncation.
+ */
+EXTERN	Type*	typebool;
 EXTERN	Type*	fntypes[NTYPE];
 EXTERN	Node*	initlist;
 EXTERN	Term	term[NTERM];

--- a/sys/src/cmd/cc/cc.y
+++ b/sys/src/cmd/cc/cc.y
@@ -70,6 +70,7 @@ static Type *auto_deduct_type(Node*, Node*);
 %token	LWHILE LVOID LENUM LSIGNED LCONSTNT LVOLATILE LSET LSIGNOF
 %token	LRESTRICT LINLINE LNORET LDOTDOTDOT LCOMPLEX LIMAGINARY LCOMPLEXF LCOMPLEXD
 %token	LTYPEOF LTYPEOF_UNQUAL
+%token	LBOOL
 %token	LNULLPTR LSTATICASSERT
 %token	LALIGNOF
 %token	LALIGNAS
@@ -1235,7 +1236,19 @@ ctlist:
 	}
 
 complex:
-	LSTRUCT ltag
+	/*
+	 * bool/_Bool. In "complex" rather than "tname" because that rule
+	 * yields a bit in a type mask, and the mask has no spare bit --
+	 * BNORET is already 1<<31 in a 32-bit long. "complex" hands back
+	 * a Type* directly, which is what typebool needs to be: unsigned
+	 * char's representation under a distinct identity, so com.c can
+	 * give conversions to it C99 6.3.1.2's meaning.
+	 */
+	LBOOL
+	{
+		$$ = typebool;
+	}
+|	LSTRUCT ltag
 	{
 		dotag($2, TSTRUCT, 0);
 		$$ = $2->suetag;

--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -54,6 +54,40 @@ enum
 	ADDROP	= 1<<2,
 };
 
+/*
+ * C99 6.3.1.2: when any scalar value is converted to _Bool, the result
+ * is 0 if the value compares equal to 0, and 1 otherwise. It is a
+ * comparison, not a truncation.
+ *
+ * kencc has no TBOOL etype -- bool is unsigned char (lex.c, and see
+ * typebool in cc.h) -- so without this, converting to bool keeps the
+ * low byte. Every 8-byte-aligned pointer then converts to something
+ * whose bit 0 is 0, and (bool)256 is 0 as well. Perl's
+ *
+ *	#define OpMAYBESIB_set(o, sib, parent) \
+ *	    ((o)->op_moresib = cBOOL(sib), ...)
+ *
+ * with cBOOL(x) being ((bool)(x)), is the case that found this: every
+ * op in a compiled program got op_moresib = 0 beside a perfectly good
+ * op_sibparent, so Perl_op_linklist saw no siblings, every statement
+ * list collapsed to its first element, and a program compiled and then
+ * executed almost nothing -- silently, exit status 0.
+ *
+ * n is already type-checked; !! needs nothing but int, which is what
+ * tcomo's ONOT case gives it.
+ */
+static Node*
+boolnorm(Node *n)
+{
+	Node *q;
+
+	q = new1(ONOT, n, Z);
+	q->type = types[TINT];
+	q = new1(ONOT, q, Z);
+	q->type = types[TINT];
+	return q;
+}
+
 int
 tcom(Node *n)
 {
@@ -123,6 +157,8 @@ tcomo(Node *n, int f)
 		}
 		if(tcompat(n, l->type, n->type, tcast))
 			goto bad;
+		if(n->type == typebool && l->type != typebool)
+			n->left = boolnorm(l);
 		break;
 
 	case ORETURN:
@@ -148,6 +184,11 @@ tcomo(Node *n, int f)
 		if(tcompat(n, n->type, l->type, tasign))
 			break;
 		constas(n, n->type, l->type);
+		/* returning is a conversion too; see the OAS case */
+		if(n->type == typebool && l->type != typebool) {
+			l = boolnorm(l);
+			n->left = l;
+		}
 		if(!sametype(n->type, l->type)) {
 			l = new1(OCAST, l, Z);
 			l->type = n->type;
@@ -196,6 +237,16 @@ tcomo(Node *n, int f)
 		if(tcompat(n, l->type, r->type, tasign))
 			goto bad;
 		constas(n, l->type, r->type);
+		/*
+		 * Assigning to a bool converts, so the same comparison
+		 * applies. It has to happen before the sametype test
+		 * below, which sees only etypes and so would let an
+		 * unsigned char through with no cast at all.
+		 */
+		if(l->type == typebool && r->type != typebool) {
+			r = boolnorm(r);
+			n->right = r;
+		}
 		if(!sametype(l->type, r->type)) {
 			r = new1(OCAST, r, Z);
 			r->type = l->type;
@@ -1038,6 +1089,18 @@ tcoma(Node *l, Node *n, Type *t, int f)
 			diag(l, "argument prototype mismatch \"%T\" for \"%T\": %F",
 				n->type, t, l);
 			return 1;
+		}
+		/*
+		 * Passing an argument converts, so the same comparison
+		 * applies -- and it has to happen before the promotion
+		 * below turns a bool parameter into unsigned int, which
+		 * would otherwise pass the value through untouched.
+		 */
+		if(t == typebool && n->type != typebool) {
+			n1 = new1(OXXX, Z, Z);
+			*n1 = *n;
+			n1 = boolnorm(n1);
+			*n = *n1;
 		}
 		switch(t->etype) {
 		case TCHAR:

--- a/sys/src/cmd/cc/lex.c
+++ b/sys/src/cmd/cc/lex.c
@@ -1549,17 +1549,18 @@ struct
 	"__signed__",		LSIGNED,	0,
 
 	/*
-	 * _Bool: C99 boolean.  Map to LCHAR (unsigned char width).
-	 * Values are 0 or 1; the width and integer promotion match.
+	 * _Bool (C99) and bool (C23). Its own token rather than LCHAR:
+	 * the grammar's "tname: LCHAR" yields BCHAR, so these used to
+	 * declare a plain signed char, and a conversion to one truncates
+	 * where C99 6.3.1.2 requires a comparison against zero. LBOOL
+	 * reduces to typebool, and com.c normalises conversions to it.
 	 */
-	"_Bool",		LCHAR,		TUCHAR,
+	"_Bool",		LBOOL,		0,
+	"bool",			LBOOL,		0,
 
 	/*
-	 * C23 bool, true, and false.
-	 * bool is mapped to LCHAR (unsigned char width) like _Bool.
-	 * true and false are mapped to LCONST 1 and 0.
+	 * C23 true and false, mapped to LCONST 1 and 0.
 	 */
-	"bool",			LCHAR,		TUCHAR,
 	"true",			LCONST,		1,
 	"false",		LCONST,		0,
 
@@ -1679,6 +1680,12 @@ cinit(void)
 	types[TENUM] = typ(TENUM, T);
 	types[TFUNC] = typ(TFUNC, types[TINT]);
 	types[TIND] = typ(TIND, types[TVOID]);
+
+	/*
+	 * bool has unsigned char's representation, width and alignment,
+	 * but is a distinct Type object: see the note in cc.h.
+	 */
+	typebool = typ(TUCHAR, T);
 
 	for(i=0; i<NHASH; i++)
 		hash[i] = S;


### PR DESCRIPTION
C99 6.3.1.2: "When any scalar value is converted to _Bool, the result is 0 if the value compares equal to 0; otherwise, the result is 1."

kencc had no bool. lex.c's itab mapped both _Bool and bool to LCHAR, and the grammar's "tname: LCHAR" yields BCHAR -- so bool was a plain signed char and every conversion to it kept the low byte. (bool)256 was 0. (bool)p for any object pointer was its low byte, always even because the pointer is aligned, so storing that in a one-bit bit field, which keeps bit 0, always gave 0.

Found through perl, and it is worth spelling out what it cost, because nothing about it is perl-specific. handy.h has

	#define cBOOL(cbool) ((bool) (cbool))

and op.h records whether an op has a next sibling with

	#define OpMAYBESIB_set(o, sib, parent) \
	    ((o)->op_moresib = cBOOL(sib), ...)

so every op in every program miniperl compiled came out with op_moresib = 0 beside a correct op_sibparent. Perl_op_linklist walks a node's children with OpSIBLING, which reads that flag, so every statement list collapsed to its first element: the op_next chain for "print" was enter, leave. miniperl parsed its input, reported syntax errors correctly, ran BEGIN and END blocks, and executed none of the program in between -- no output, no diagnostic, exit status 0. op.h already carried a workaround blaming the value of a bit field assignment, which was a misdiagnosis of this.

bool now has its own token, LBOOL, and its own Type, typebool: unsigned char's representation, width and alignment under a distinct identity, so com.c can tell it from a plain unsigned char. It is created in the "complex" production rather than "tname" because tname yields a bit in a type mask and the mask has no spare bit -- BNORET is already 1<<31 in a 32-bit long. sametype() compares etypes, so nothing about type compatibility changes; bison reports the same 26 shift/reduce and 6 reduce/reduce conflicts as before, so the grammar is unchanged in substance.

com.c's boolnorm() wraps the value in !!, which tcomo's ONOT case already gives type int, and the narrowing cast that follows then sees a value that is 0 or 1. It is applied at the four places a conversion to bool happens: the explicit cast, assignment, return, and argument passing -- the last before the promotion that turns a bool parameter into unsigned int, which would otherwise pass the value straight through.

Known gaps, both narrow: a static or file-scope initialiser is folded in dcl.c rather than going through com.c, so "static bool b = 256;" still truncates; and "const bool" is a garbt() copy of typebool, which loses the identity the check needs. Ordinary "bool b = expr;" on an auto is an OAS and is covered.

sys/lib/tests/bool-test.c covers all of it, including the OpMAYBESIB_set shape. Every case is required by C99, so it passes on gcc, which is how it was checked.

Build order: cc first (y.tab.h gains LBOOL), then every arch compiler.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs