### PR TITLE
cc: mark bool on the type, not by the identity of one Type

### DIFF
--- a/sys/lib/tests/bool-test.c
+++ b/sys/lib/tests/bool-test.c
@@ -55,7 +55,10 @@ check(const char *what, int ok, const char *detail)
 int zero = 0;
 int low_byte_zero = 256;
 int low_bit_zero = 2;
-long big = 0x100000000L;
+/* long long, not long: kencc's long is 32 bits even on amd64, so a
+   long here would be truncated to 0 before the cast ever saw it and the
+   case would test nothing. */
+long long big = 0x100000000LL;
 double half = 0.5;
 char buf[64];
 char *aligned = buf;
@@ -93,7 +96,8 @@ main(void)
 	check("cast of a value with a zero low bit",
 	    (bool)low_bit_zero == 1, detail);
 
-	sprintf(detail, "(bool)0x100000000 = %d", (int)(bool)big);
+	sprintf(detail, "(bool)0x100000000 = %d (big = %lld)",
+	    (int)(bool)big, big);
 	check("cast of a value with a zero low word", (bool)big == 1,
 	    detail);
 

--- a/sys/src/cmd/cc/cc.h
+++ b/sys/src/cmd/cc/cc.h
@@ -126,6 +126,7 @@ struct	Type
 	char	etype;
 	char	garb;
 	char	vla;		/* 1 = variable-length array */
+	char	isbool;		/* declared bool/_Bool; see typebool */
 	Node*	vlasizevar;	/* hidden auto holding runtime byte count (VLA only) */
 	short	alignas_req;	/* _Alignas() override; 0 = use type's natural alignment */
 };
@@ -481,9 +482,16 @@ EXTERN	Node*	thisfnnode;
 EXTERN	Type*	types[NCTYPE];		/* extended to hold TCFLOAT, TCDOUBLE */
 /*
  * bool/_Bool. Its representation is unsigned char -- there is no TBOOL
- * etype -- but it is its own Type object so that com.c can tell it from
- * a plain unsigned char and give conversions to it the semantics C99
- * 6.3.1.2 requires: a comparison against zero, not a truncation.
+ * etype -- but it carries the isbool mark so that com.c can tell it
+ * from a plain unsigned char and give conversions to it the semantics
+ * C99 6.3.1.2 requires: a comparison against zero, not a truncation.
+ *
+ * The mark is a field rather than the identity of this one Type,
+ * because a type is copied whenever it is used: copytyp() is a struct
+ * copy, and dcl.c copies a parameter's type to chain it into a
+ * prototype and copies again for const/volatile. Pointer identity
+ * therefore survives a cast and a return, but not a declaration or a
+ * parameter -- which is exactly the set of cases that used to fail.
  */
 EXTERN	Type*	typebool;
 EXTERN	Type*	fntypes[NTYPE];

--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -157,7 +157,7 @@ tcomo(Node *n, int f)
 		}
 		if(tcompat(n, l->type, n->type, tcast))
 			goto bad;
-		if(n->type == typebool && l->type != typebool)
+		if(n->type->isbool && (l->type == T || !l->type->isbool))
 			n->left = boolnorm(l);
 		break;
 
@@ -185,7 +185,7 @@ tcomo(Node *n, int f)
 			break;
 		constas(n, n->type, l->type);
 		/* returning is a conversion too; see the OAS case */
-		if(n->type == typebool && l->type != typebool) {
+		if(n->type->isbool && !l->type->isbool) {
 			l = boolnorm(l);
 			n->left = l;
 		}
@@ -205,6 +205,11 @@ tcomo(Node *n, int f)
 		typeext(l->type, r);
 		if(tcompat(n, l->type, r->type, tasign))
 			goto bad;
+		/* initialising converts; see the OAS case below */
+		if(l->type->isbool && !r->type->isbool) {
+			r = boolnorm(r);
+			n->right = r;
+		}
 		if(!sametype(l->type, r->type)) {
 			r = new1(OCAST, r, Z);
 			r->type = l->type;
@@ -243,7 +248,7 @@ tcomo(Node *n, int f)
 		 * below, which sees only etypes and so would let an
 		 * unsigned char through with no cast at all.
 		 */
-		if(l->type == typebool && r->type != typebool) {
+		if(l->type->isbool && !r->type->isbool) {
 			r = boolnorm(r);
 			n->right = r;
 		}
@@ -1096,7 +1101,7 @@ tcoma(Node *l, Node *n, Type *t, int f)
 		 * below turns a bool parameter into unsigned int, which
 		 * would otherwise pass the value through untouched.
 		 */
-		if(t == typebool && n->type != typebool) {
+		if(t->isbool && !n->type->isbool) {
 			n1 = new1(OXXX, Z, Z);
 			*n1 = *n;
 			n1 = boolnorm(n1);

--- a/sys/src/cmd/cc/lex.c
+++ b/sys/src/cmd/cc/lex.c
@@ -1686,6 +1686,7 @@ cinit(void)
 	 * but is a distinct Type object: see the note in cc.h.
 	 */
 	typebool = typ(TUCHAR, T);
+	typebool->isbool = 1;
 
 	for(i=0; i<NHASH; i++)
 		hash[i] = S;


### PR DESCRIPTION
bool-test found three of its cases still failing: an auto initialiser, an argument, and a long constant. The last is the test's own fault -- kencc's long is 32 bits, so "long big = 0x100000000L" was truncated to 0 before the cast ever saw it and the case tested nothing. It is long long now.

The other two are one cause. copytyp() is a struct copy, and a type gets copied whenever it is used for anything: dcl.c:996 copies a parameter's type to chain it into a prototype, and garbt() copies for const and volatile. So "t == typebool" holds for a cast and a return, where the type is the one the grammar produced, and fails for a declared variable or a parameter -- which is exactly the set that failed.

The mark is now a field, Type.isbool, which the struct copy carries along. That also closes the const-bool gap the previous commit documented.

The auto initialiser needed one more site regardless: tcomo has a separate OASI case for it, with its own copy of the conversion logic (no lvalue or const test, since init1 guarantees a CAUTO target), so the OAS case never sees it.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs