### PR TITLE
perl: miniperl needs dist/PathTools on its path for Cwd.pm

### DIFF
--- a/sys/src/ape/cmd/perl/mkfile
+++ b/sys/src/ape/cmd/perl/mkfile
@@ -50,6 +50,13 @@ $PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib: miniperl
 #   $PERLSRC/lib           — strict.pm, ExtUtils/Embed.pm, Config.pm stub, etc.
 #   dist/Exporter/lib      — Exporter.pm (used by ExtUtils::Miniperl)
 #   dist/PathTools/lib     — File::Spec (used by ExtUtils::Embed)
+#   dist/PathTools         — Cwd.pm, which File::Spec::Unix loads at its
+#                            line 4. It sits beside that dist's lib/
+#                            rather than in it, because a full build
+#                            copies it into lib/ instead. Safe under
+#                            miniperl: Cwd.pm:80 guards the XSLoader
+#                            call with defined &DynaLoader::boot_DynaLoader
+#                            and falls back to its pure-perl getcwd.
 #   dist/Carp/lib          — Carp.pm (used by warnings/strict chain)
 perlmain.c: miniperl $PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib
 	./miniperl \
@@ -57,6 +64,7 @@ perlmain.c: miniperl $PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib
 		-I$PERLSRC/lib \
 		-I$PERLSRC/dist/Exporter/lib \
 		-I$PERLSRC/dist/PathTools/lib \
+		-I$PERLSRC/dist/PathTools \
 		-I$PERLSRC/dist/Carp/lib \
 		-MExtUtils::Miniperl \
 		-e 'writemain("perlmain.c")'


### PR DESCRIPTION
	Can't locate Cwd.pm in @INC ... at File/Spec/Unix.pm line 4.

Everything before it now loads -- strict, Carp, Exporter, ExtUtils::Embed, File::Spec -- and File::Spec::Unix opens with "use Cwd ()".

Cwd.pm is at dist/PathTools/Cwd.pm, beside that dist's lib/ rather than in it; a full perl build copies it into lib/, which this one does not do. Adding the directory is enough, and is safe under miniperl: Cwd.pm's line 80 guards its XSLoader call with

	if(! defined &getcwd && defined &DynaLoader::boot_DynaLoader)

and falls back to the pure-perl getcwd below it, which is there to bootstrap the perl build in the first place.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs