### PR TITLE
perl: and constant.pm, which completes miniperl's path

### DIFF
--- a/sys/src/ape/cmd/perl/mkfile
+++ b/sys/src/ape/cmd/perl/mkfile
@@ -58,6 +58,16 @@ $PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib: miniperl
 #                            call with defined &DynaLoader::boot_DynaLoader
 #                            and falls back to its pure-perl getcwd.
 #   dist/Carp/lib          — Carp.pm (used by warnings/strict chain)
+#   dist/constant/lib      — constant.pm, which File::Spec::Unix uses at
+#                            its line 115 ("use constant _fn_curdir").
+#
+# That is the whole closure. Following every use and require from
+# ExtUtils::Miniperl reaches four more names, and none of them loads
+# here: Scalar::Util is inside "if ($taint)" at File/Spec/Unix.pm:169,
+# XSLoader is behind the DynaLoader guard at Cwd.pm:80, and Errno and
+# ExtUtils::MakeMaker are in runtime error paths and POD examples. The
+# rest -- strict, warnings, vars, overload, re -- are built into the
+# interpreter and need no file.
 perlmain.c: miniperl $PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib
 	./miniperl \
 		-I$PERLSRC/ext/ExtUtils-Miniperl/lib \
@@ -66,5 +76,6 @@ perlmain.c: miniperl $PERLSRC/ext/ExtUtils-Miniperl/pm_to_blib
 		-I$PERLSRC/dist/PathTools/lib \
 		-I$PERLSRC/dist/PathTools \
 		-I$PERLSRC/dist/Carp/lib \
+		-I$PERLSRC/dist/constant/lib \
 		-MExtUtils::Miniperl \
 		-e 'writemain("perlmain.c")'


### PR DESCRIPTION
	Can't locate constant.pm in @INC ... at File/Spec/Unix.pm line 115.

Line 115 is "use constant _fn_curdir => ".";", so it loads. It lives in dist/constant/lib.

Rather than find the next one the same way, this is the closure: every use and require reachable from ExtUtils::Miniperl was followed and resolved against the tree. Four names are left over and none of them loads here -- Scalar::Util is inside "if ($taint)" at File/Spec/Unix.pm:169, XSLoader is behind the DynaLoader guard at Cwd.pm:80, and Errno and ExtUtils::MakeMaker appear only in runtime error paths and POD. strict, warnings, vars, overload and re are built into the interpreter and need no file at all.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs