### PR TITLE
perl: remove the APEXP probes

### DIFF
--- a/sys/src/ape/cmd/perl/mkfile
+++ b/sys/src/ape/cmd/perl/mkfile
@@ -11,12 +11,7 @@ BIN=$APEXPROOT/$objtype/bin/ape
 <$APEXPROOT/sys/src/cmd/mkone
 
 PERLSRC=../../../external/perl
-# APEXP_PROBE_MAIN is temporary: it turns on the three PerlIO_printf
-# probes in op.c's Perl_newPROG and perl.c's S_run_body that say why
-# PL_main_start is NULL. Both files are compiled here rather than into
-# libperl.a, so this costs two objects and a relink. Remove it, and the
-# probes, once the answer is in.
-CFLAGS=-c -I$PERLSRC -D_POSIX_SOURCE -DHAVE_CONFIG_H -D_PLAN9_SOURCE -D_BSD_EXTENSION -DPERL_CORE -DAPEXP_PROBE_MAIN
+CFLAGS=-c -I$PERLSRC -D_POSIX_SOURCE -DHAVE_CONFIG_H -D_PLAN9_SOURCE -D_BSD_EXTENSION -DPERL_CORE
 
 CLEANFILES = *.c
 

--- a/sys/src/ape/lib/perl/mkfile
+++ b/sys/src/ape/lib/perl/mkfile
@@ -21,11 +21,7 @@ OFILES=\
 
 <$APEXPROOT/sys/src/cmd/mksyslib
 
-# APEXP_PROBE_MAIN is temporary; see the note in ../../cmd/perl/mkfile.
-# Here it turns on one probe in locale.c, printed just before perl
-# panics over a setlocale it thinks failed, which asks libc the same
-# question again and says what it answered.
-CFLAGS=-c -I$PERLSRC -D_POSIX_SOURCE -DHAVE_CONFIG_H -D_PLAN9_SOURCE -D_BSD_EXTENSION -DPERL_CORE -DAPEXP_PROBE_MAIN
+CFLAGS=-c -I$PERLSRC -D_POSIX_SOURCE -DHAVE_CONFIG_H -D_PLAN9_SOURCE -D_BSD_EXTENSION -DPERL_CORE
 
 %.$O: $PERLSRC/%.c
 	$CC $CFLAGS $prereq -o $target

--- a/sys/src/external/perl/locale.c
+++ b/sys/src/external/perl/locale.c
@@ -3386,25 +3386,6 @@ S_setlocale_failure_panic_via_i(pTHX_
 {
     PERL_ARGS_ASSERT_SETLOCALE_FAILURE_PANIC_VIA_I;
 
-#ifdef APEXP_PROBE_MAIN
-    /* APExp: temporary. Ask libc the same question again, raw, and say
-     * what it answers -- so this separates "libap's setlocale returned
-     * NULL" from "it answered and perl's layer above it turned that
-     * into a failure". Remove with the -D in sys/src/ape/lib/perl/mkfile
-     * and sys/src/ape/cmd/perl/mkfile. */
-    {
-        const int apexp_cat = categories[cat_index];
-        const char *apexp_raw = setlocale(apexp_cat, failed);
-        const char *apexp_qry = setlocale(apexp_cat, NULL);
-
-        PerlIO_printf(Perl_error_log,
-            "APEXP setlocale(%d, \"%s\") = %s; setlocale(%d, NULL) = %s\n",
-            apexp_cat, failed ? failed : "(null)",
-            apexp_raw ? apexp_raw : "(NULL)",
-            apexp_cat, apexp_qry ? apexp_qry : "(NULL)");
-    }
-#endif
-
     /* Called to panic when a setlocale form unexpectedly failed for the
      * category determined by 'cat_index', and the locale that was in effect
      * (and likely still is) is 'current'.  'current' may be NULL, which causes

--- a/sys/src/external/perl/op.c
+++ b/sys/src/external/perl/op.c
@@ -4705,56 +4705,12 @@ Perl_blockhook_register(pTHX_ BHK *hk)
     Perl_av_create_and_push(aTHX_ &PL_blockhooks, newSViv(PTR2IV(hk)));
 }
 
-#ifdef APEXP_PROBE_MAIN
-/* APExp: temporary, see Perl_newPROG below. The sibling walk is bounded
- * because a mis-set op_sibparent can point back into the list. */
-static void
-apexp_dump_kids(pTHX_ const char *what, OP *o)
-{
-    OP *k;
-    int n;
-
-    PerlIO_printf(Perl_error_log, "APEXP %s: %p %s flags=%02x kids=%d\n",
-        what, (void *)o, o ? OP_NAME(o) : "(null)",
-        o ? (unsigned)o->op_flags : 0u,
-        (o && (o->op_flags & OPf_KIDS)) ? 1 : 0);
-
-    if (!o || !(o->op_flags & OPf_KIDS))
-        return;
-
-    k = cLISTOPx(o)->op_first;
-    for (n = 0; k && n < 20; n++) {
-        PerlIO_printf(Perl_error_log,
-            "APEXP   kid[%d] %p %-12s moresib=%d sibparent=%p\n",
-            n, (void *)k, OP_NAME(k), (int)k->op_moresib,
-            (void *)k->op_sibparent);
-        k = k->op_moresib ? k->op_sibparent : NULL;
-    }
-    PerlIO_printf(Perl_error_log, "APEXP %s: %d kid%s\n", what, n,
-        n == 1 ? "" : "s");
-}
-#endif
-
 void
 Perl_newPROG(pTHX_ OP *o)
 {
     OP *start;
 
     PERL_ARGS_ASSERT_NEWPROG;
-
-#ifdef APEXP_PROBE_MAIN
-    /* APExp: temporary. The main program's op_next chain is just
-     * "enter, leave" -- OpSIBLING(enter) is NULL where the statements
-     * should be -- so either the list never had children or op_moresib
-     * did not stick. This walks the children as the tree holds them,
-     * printing the raw op_moresib and op_sibparent of each, which tells
-     * those two apart. Remove with the -D in
-     * sys/src/ape/cmd/perl/mkfile once known. */
-    PerlIO_printf(Perl_error_log,
-        "APEXP newPROG: in_eval=%d o=%p type=%s\n",
-        (int)PL_in_eval, (void *)o, o ? OP_NAME(o) : "(null)");
-    apexp_dump_kids(aTHX_ "newPROG arg", o);
-#endif
 
     if (PL_in_eval) {
         PERL_CONTEXT *cx;
@@ -4819,19 +4775,10 @@ Perl_newPROG(pTHX_ OP *o)
             return;
         }
         PL_main_root = op_scope(sawparens(scalarvoid(o)));
-#ifdef APEXP_PROBE_MAIN
-        apexp_dump_kids(aTHX_ "after op_scope", PL_main_root);
-#endif
         PL_curcop = &PL_compiling;
         start = LINKLIST(PL_main_root);
         PL_main_root->op_next = 0;
         S_process_optree(aTHX_ NULL, PL_main_root, start);
-#ifdef APEXP_PROBE_MAIN
-        PerlIO_printf(Perl_error_log,
-            "APEXP newPROG: start=%p main_start=%p main_root=%p type=%s\n",
-            (void *)start, (void *)PL_main_start, (void *)PL_main_root,
-            start ? OP_NAME(start) : "(null)");
-#endif
         if (!PL_parser->error_count)
             /* on error, leave CV slabbed so that ops left lying around
              * will eb cleaned up. Else unslab */

--- a/sys/src/external/perl/perl.c
+++ b/sys/src/external/perl/perl.c
@@ -2868,32 +2868,6 @@ S_run_body(pTHX_ I32 oldscope)
 
     PERL_SET_PHASE(PERL_PHASE_RUN);
 
-#ifdef APEXP_PROBE_MAIN
-    /* APExp: temporary, see the note in op.c's Perl_newPROG. */
-    PerlIO_printf(Perl_error_log,
-        "APEXP run_body: restartop=%p main_start=%p main_root=%p in_eval=%d\n",
-        (void *)PL_restartop, (void *)PL_main_start, (void *)PL_main_root,
-        (int)PL_in_eval);
-    /* Walk the op_next chain the runops loop is about to follow. If it
-     * ends after an op or two, the chain is what is wrong; if it is the
-     * whole program, the ops run and something else swallows them. */
-    {
-        const OP *po = PL_main_start;
-        int pn = 0;
-
-        while (po && pn < 40) {
-            PerlIO_printf(Perl_error_log,
-                "APEXP chain[%d] %p %-12s next=%p ppaddr=%p\n",
-                pn, (const void *)po, OP_NAME(po),
-                (const void *)po->op_next, (const void *)po->op_ppaddr);
-            po = po->op_next;
-            pn++;
-        }
-        PerlIO_printf(Perl_error_log, "APEXP chain: %d ops, ended %s\n",
-            pn, po ? "at the probe's limit" : "with a null op_next");
-    }
-#endif
-
     if (PL_restartop) {
 #ifdef DEBUGGING
         /* this complements the "EXECUTING..." debug we emit above.


### PR DESCRIPTION
perlmain.c generates and perl links, so they are done. All six go: the newPROG and child-walk probes in op.c, the run_body and op_next chain walk in perl.c, the setlocale retry in locale.c, and -DAPEXP_PROBE_MAIN from both mkfiles. The three perl sources are back to what they were before any of this, byte for byte.

What they were for, since none of the four bugs they found was perl's:

  cc: bool was a signed char, so every conversion to it truncated
      instead of comparing against zero (c5c5ee43e, 2bd70c3c7)
  ape: setlocale reported a locale it had not set (d64485f34)
  ape: <stdio.h> leaked errno, unistd, fcntl and pthread, and libap
      itself relied on the leak (9d77e31d9, 14bdf7123)
  perl: config.h described an 80-bit long double kencc does not have
      (d7baf5f72, c56bfa0d5)

The op_next chain walk is the one that earned its keep: "chain: 2 ops, ended with a null op_next" for a program with a print in it, and then the child walk beside it showing op_sibparent correct and op_moresib 0, is what turned "perl does not work" into a one-line compiler bug.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs