### PR TITLE
bison: install the skeletons it cannot run without

### DIFF
--- a/sys/src/ape/cmd/bison/mkfile
+++ b/sys/src/ape/cmd/bison/mkfile
@@ -117,9 +117,36 @@ liby_a-%.$O: $BISONSRC/lib/%.c
 libbison.a$O: $LIB_OBJS
 		ar vu libbison.a$O $LIB_OBJS
 
+# bison cannot generate a parser from the program alone. It shells out
+# to m4 -- config.h says /bin/m4, which mount-include now puts on the
+# path -- and feeds it a skeleton and the m4sugar library, both read
+# from PKGDATADIR at run time. src/configmake.h sets that to
+# /sys/lib/ape/bison; this is what puts the files there.
+#
+# Until now nothing in the tree had ever run bison, so it had never
+# mattered that only the man pages were installed. objc's stage 2 is
+# the first, and got no diagnostic at all -- bison read yacc.ym and
+# then aborted.
+#
+# xslt and the css are for bison --html and are small; installing the
+# whole data directory keeps this from having to track which skeletons
+# upstream adds.
+BISONDATA=$APEXPROOT/sys/lib/ape/bison
+
 install:V:
 		cp $BISONSRC/doc/bison.1 $APEXPROOT/sys/man/1/bison
 		cp $BISONSRC/doc/yacc.1 $APEXPROOT/sys/man/1/yacc
+		mkdir -p $BISONDATA
+		dircp $BISONSRC/data $BISONDATA
+
+# A prerequisite with no recipe, not a second nuke recipe: mkone's nuke
+# carries one and takes no prerequisites, so two recipes would leave mk
+# to pick one silently. mkone's install is prerequisite-only, which is
+# why adding to it above is safe.
+nuke:V:	bisondatanuke
+
+bisondatanuke:V:
+		rm -rf $BISONDATA
 
 
 

--- a/sys/src/external/bison/src/configmake.h
+++ b/sys/src/external/bison/src/configmake.h
@@ -1,4 +1,22 @@
-
-#define PKGDATADIR "/sys/lib/ape"
-
-
+/*
+ * APExp: hand-written, where a normal build has configure generate it.
+ * Only bison/src reads this file; the gnulib tree has its own
+ * configmake.h with no PKGDATADIR at all, which is why the include
+ * order in sys/src/ape/cmd/bison/mkfile puts -I$BISONSRC/src ahead of
+ * -I$GNUSRC.
+ *
+ * PKGDATADIR is where bison looks for the files it cannot run without:
+ * output.c:885 wants pkgdatadir()/skeletons -- yacc.c and the twenty
+ * m4 files beside it -- and output.c:725 wants pkgdatadir()/m4sugar.
+ * Without them bison reads its grammar and then dies with no message
+ * at all:
+ *
+ *	bison -y -d yacc.ym
+ *	mk: ... : exit status=rc 23058: bison 23059: abort
+ *
+ * It was "/sys/lib/ape", which would have scattered skeletons/,
+ * m4sugar/ and xslt/ directly into the directory that also holds awk,
+ * locale, m4 and termcap. Upstream installs to $(datadir)/bison, so
+ * this does too; sys/src/ape/cmd/bison/mkfile's install populates it.
+ */
+#define PKGDATADIR "/sys/lib/ape/bison"


### PR DESCRIPTION
	bison -y -d yacc.ym
	mk: ... : exit status=rc 23058: bison 23059: abort

No diagnostic, because bison had nothing to say: it reads the grammar, then shells out to m4 with a skeleton and the m4sugar library, both read from PKGDATADIR at run time (output.c:725 and :885). Only the man pages were ever installed, so neither was there.

Nothing in the tree had run bison before -- YACC=bison in sys/src/ape/config was never exercised -- so this had never mattered. objc's stage 2 is the first caller.

PKGDATADIR was the bare "/sys/lib/ape", which would have scattered skeletons/, m4sugar/ and xslt/ into the directory that also holds awk, locale, m4 and termcap. Upstream installs to $(datadir)/bison, so configmake.h now says /sys/lib/ape/bison and install populates it with the whole data directory -- 21 skeletons, m4sugar, and the xslt and css that bison --html wants. Copying all of it saves tracking which skeletons upstream adds.

M4 is already "/bin/m4" in config.h, and mount-include's new bind puts this tree's m4 there.

The nuke is a prerequisite with no recipe: mkone's nuke carries one and takes no prerequisites, so two recipes would leave mk to pick one silently. Its install is prerequisite-only, which is why the existing recipe there is safe.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs