### PR TITLE
bison: probe the muscle kind that makes muscle_kind_new abort

### DIFF
--- a/sys/src/external/bison/src/muscle-tab.c
+++ b/sys/src/external/bison/src/muscle-tab.c
@@ -38,6 +38,12 @@ muscle_kind_new (char const *k)
     return muscle_keyword;
   else if (STREQ (k, "string"))
     return muscle_string;
+  /* APExp: temporary. This abort is silent, and the stack alone does
+     not say what k holds. Remove with the probe in
+     muscle_percent_define_get_raw below. */
+  fprintf (stderr, "APEXP muscle_kind_new: k=%p len=%d [%s]\n",
+           (void *) k, k ? (int) strlen (k) : -1, k ? k : "<NULL>");
+  fflush (stderr);
   abort ();
 }
 
@@ -585,6 +591,11 @@ muscle_percent_define_get_raw (char const *variable, char const *field)
 {
   uniqstr name = muscle_name (variable, field);
   char const *res = muscle_find_const (name);
+  /* APExp: temporary, with the one in muscle_kind_new above. */
+  fprintf (stderr, "APEXP get_raw: var=[%s] field=[%s] name=[%s] res=%p [%s]\n",
+           variable ? variable : "<NULL>", field ? field : "<NULL>",
+           name ? name : "<NULL>", (void *) res, res ? res : "<NULL>");
+  fflush (stderr);
   if (!res)
     complain (NULL, fatal, _("%s: undefined %%define variable %s"),
               "muscle_percent_define_get_raw", quote (variable));


### PR DESCRIPTION
Temporary, to be reverted.

The stack is clear -- muscle_kind_new gets a kind string that is none of "code", "keyword" or "string", for the %define variable lr.type, whose default is set two lines earlier by

	muscle_percent_define_default ("lr.type", "lalr");
	  MUSCLE_INSERT_STRING (muscle_name (variable, "kind"), "keyword");

-- but not what the string actually is. It is not missing: an absent muscle takes the "undefined %%define variable" path just above, which prints. So the muscle exists and holds the wrong text, and reading it out of the debugger has cost two rounds to acid's expression syntax.

These print it, along with the key it was found under, so the next step can be chosen from what is there rather than from what it might be.

Ruled out on the way: obstack_escape is a character-copy macro with no printf in it, uniqstr_concat allocates with xmalloc rather than sharing muscle_obstack (so the two arguments of MUSCLE_INSERT_STRING cannot interleave, whatever order kencc evaluates them in), and neither bison nor libap contains a "(null)" literal.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs