### PR TITLE
cc: a comma expression's type must not decay when sizeof asks

### DIFF
--- a/sys/lib/tests/compound-literal-test.c
+++ b/sys/lib/tests/compound-literal-test.c
@@ -225,6 +225,29 @@ main(void)
 	}
 
 	/*
+	 * Storage, which is a separate question from sizeof.
+	 * compoundlit() in cc/dcl.c calls adecl() -- which reserves the
+	 * frame slot from t->width -- before doinit(), and it is doinit
+	 * that sets the width of an array declared with an empty [].
+	 * So the slot may be reserved as zero bytes and overlap the next
+	 * auto. bison never sees this: it uses these literals only
+	 * inside sizeof, whose operand is not evaluated.
+	 */
+	{
+		int *p = (int[]){11, 22, 33, 44, 55};
+		int guard[8];
+		char detail[96];
+		int i;
+
+		for (i = 0; i < 8; i++)
+			guard[i] = -1;
+		sprintf(detail, "p[0]=%d p[4]=%d, wanted 11 and 55",
+		    p[0], p[4]);
+		checkd("array literal keeps its storage", p[0] == 11
+		    && p[4] == 55 && guard[0] == -1, detail);
+	}
+
+	/*
 	 * The whole idiom: count the arguments with the literal, then
 	 * pass them variadically. This is bison's UNIQSTR_CONCAT, and
 	 * the string below is the muscle key it failed to build.

--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -705,8 +705,36 @@ tcomo(Node *n, int f)
 
 	case OLIST:		/* compound literal initialiser list */
 	case OCOMMA:
+		/*
+		 * The right operand carries the comma's type, so it has to be
+		 * typed with the flags this node was typed with -- not with
+		 * tcom(), which is tcomo(..., ADDROF) and so decays an array
+		 * to a pointer at the bottom of this function.
+		 *
+		 * sizeof is the case that cares. It types its operand with
+		 * tcomo(l, 0) precisely to keep an array an array, and an
+		 * array compound literal reaches it as OCOMMA(init, ONAME)
+		 * from compoundlit(). Decaying the ONAME made every such
+		 * sizeof the size of a pointer:
+		 *
+		 *	sizeof((int[]){1,2,3,4,5,6,7})		8, not 28
+		 *	sizeof((char const *[]){"a",...,"e"})	8, not 40
+		 *
+		 * which silently breaks the standard way of counting variadic
+		 * arguments,
+		 *
+		 *	#define ARRAY_CARDINALITY(a) (sizeof (a) / sizeof (*(a)))
+		 *	ARRAY_CARDINALITY (((char const *[]) {__VA_ARGS__}))
+		 *
+		 * used by gnulib and by bison, where it made every muscle key
+		 * come out as its first fragment alone. Note it reads as 1
+		 * rather than 0, since sizeof the element is a pointer too.
+		 *
+		 * The left operand is evaluated only for its side effects, so
+		 * tcom() stays right for it.
+		 */
 		o = tcom(l);
-		if(o | tcom(r))
+		if(o | tcomo(r, f))
 			goto bad;
 		n->type = r->type;
 		/*


### PR DESCRIPTION
	sizeof((int[]){1,2,3,4,5,6,7})		gave 8, not 28
	sizeof((char const *[]){"a",..,"e"})	gave 8, not 40

Eight both times, which is the giveaway: that is the width of a pointer, not of one element -- the type had decayed, it was not merely sized wrong.

tcomo decays an array to a pointer at its end, but only when called with ADDROF. sizeof knows that and types its operand with tcomo(l, 0) precisely to keep an array an array. compoundlit() lowers an array compound literal to OCOMMA(init, ONAME), and the OCOMMA case typed both children with tcom() -- which is tcomo(..., ADDROF) -- so the ONAME decayed and the comma took a pointer type before sizeof ever saw it.

The right operand carries the comma's type, so it must be typed with the flags the comma itself was given; the left is evaluated only for its side effects and tcom() stays right for it. That also makes &(int[]){1,2,3} come out as int(*)[3] rather than failing the l-value test, since the ONAME stays addable for the hoist in the OADDR case.

What it cost: this is how C counts variadic arguments,

	#define ARRAY_CARDINALITY(a) (sizeof (a) / sizeof (*(a)))
	ARRAY_CARDINALITY (((char const *[]) {__VA_ARGS__}))

and the answer was always 1 -- not 0, because sizeof the element is a pointer too. gnulib and bison both use it. bison builds every muscle key that way, so muscle_name("lr.type", "kind") returned "percent_define_", every muscle collided into one entry, and muscle_kind_new aborted on the empty string it found. No diagnostic, and bison could not generate a parser at all -- which is where objc's stage 2 has been stuck.

The test gains a storage case as well. compoundlit() calls adecl(), which reserves the frame slot from t->width, before doinit(), and it is doinit that sets the width of an array declared with an empty []. So the slot may be reserved as zero bytes. bison never sees that -- it uses these literals only inside sizeof, whose operand is not evaluated -- but if the case fails it is real and separate from this fix.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs