### PR TITLE
objc: -nolinetags, and clean the files the yacc and lex rules rename

### DIFF
--- a/rc/bin/ape/objc
+++ b/rc/bin/ape/objc
@@ -29,7 +29,21 @@ ld=${LD-"pcc"}
 cpp=${CPP-"pcc -E"}
 cppwantsdotc=1
 cpargs="-D__PORTABLE_OBJC__ "
-ocargs="-gnu -noTags"
+# APExp: -nolinetags, not -noTags. objc1 has never had a -noTags option
+# -- neither the bootstrap one nor src/objc/objc1.m, both of which take
+# -nolinetags and -shortTags -- and this script's own option table says
+# as much a couple of hundred lines below:
+#
+#	-nolinetags|-noTags) ocargs="$ocargs -nolinetags";;
+#
+# so -noTags is a spelling this driver accepts and translates. It is
+# only the default, which goes to objc1 untranslated, that had it:
+#
+#	objc1: unknown option -noTags
+#
+# configure.in:409 is where it comes from, added when the C compiler is
+# found not to handle long #line tags.
+ocargs="-gnu -nolinetags"
 ccargs=""
 ldargs=""
 dlargs="-bogus"

--- a/sys/src/ape/cmd/objc/mkfile.rebuild
+++ b/sys/src/ape/cmd/objc/mkfile.rebuild
@@ -269,6 +269,13 @@ PLINKOBJS=postlink.$O
 # through its own "#! /bin/sh": /bin/sh is dash, which this tree
 # installs into $objtype/bin/ape, so outside apexp-sh there is no
 # /bin/sh either and the shebang would fail before the script began.
+# The three files the yacc.$O and lex.$O rules rename into place.
+# mkmany's clean removes y.tab.? and lex.yy.c, which are what bison and
+# flex write, but not what those rules copy them to -- so a failed build
+# left yacc.m and yacc.h behind, and the next one compiled them instead
+# of regenerating.
+CLEANFILES=yacc.m yacc.h lex.m
+
 OBJC=$APEXPROOT/$objtype/bin/ape/sh $APEXPROOT/rc/bin/ape/objc
 OBJCBIN=$APEXPROOT/$objtype/bin/ape
 OBJCLIB=$APEXPROOT/$objtype/lib/ape


### PR DESCRIPTION
	objc1: unknown option -noTags

objc1 has never had a -noTags option. Neither the bootstrap one nor src/objc/objc1.m has it; both take -nolinetags and -shortTags. The driver knows this -- its own option table translates the spelling,

	-nolinetags|-noTags) ocargs="$ocargs -nolinetags";;

-- so -noTags is something this script accepts from a caller and converts. What it did not convert was its own default, which goes to objc1 verbatim. configure.in:409 is where the default comes from: it appends -noTags when the C compiler turns out not to handle long #line tags.

Nothing had noticed because stage 2 is the first thing here that has ever run the driver.

Also, mk clean left yacc.m, yacc.h and lex.m behind. mkmany's clean removes y.tab.? and lex.yy.c -- what bison and flex write -- but not what the rules copy them to. The rules rm them on success, so this only showed up after a failure, and the leftovers are worse than untidy: a stale yacc.m would be compiled in place of a regenerated one.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs