### PR TITLE
pcc: accept .i, already-preprocessed C

### DIFF
--- a/sys/src/cmd/pcc.c
+++ b/sys/src/cmd/pcc.c
@@ -202,7 +202,28 @@ main(int argc, char *argv[])
 			suf = utfrrune(s, '.');
 			if(suf) {
 				suf++;
-				if(strcmp(suf, "c") == 0) {
+				/*
+				 * .i is C that has already been through
+				 * the preprocessor. gcc and clang both
+				 * take it, and a driver that runs cpp
+				 * itself and hands on the result relies
+				 * on it: objc(1) writes cpp's output,
+				 * feeds it to objc1, and gives what
+				 * comes back to the C compiler as
+				 * <name>.i. Without this that argument
+				 * matched nothing here and was dropped
+				 * without a word, leaving
+				 *
+				 *	cc: no files to compile or load
+				 *
+				 * 6c preprocesses it a second time,
+				 * which costs a pass and changes
+				 * nothing: what objc1 emits carries
+				 * #line directives and no other
+				 * directives at all.
+				 */
+				if(strcmp(suf, "c") == 0 ||
+				   strcmp(suf, "i") == 0) {
 					append(&srcs, s);
 					append(&objs, changeext(s, objext));
 				} else if(strcmp(suf, "o") == 0 ||


### PR DESCRIPTION
	cc: no files to compile or load

pcc classified its file arguments by suffix and knew c, o, the object suffix, a, and a<objsuffix>. A suffix in allos ("2678kqv") drew a "wrong architecture" complaint. Anything else matched nothing and was dropped without a word, so objs.n stayed 0 and pcc reported having been given no files at all -- naming neither the argument it ignored nor the reason.

.i is C that has already been through the preprocessor. gcc and clang both take it, and a driver that runs cpp itself and hands on the result depends on it. objc(1) is one: it writes cpp's output, feeds that to objc1, and gives what comes back to the C compiler as <name>.i. That argument vanished here.

Treated as C now. pcc pipes /bin/cpp into 6c, so a .i goes through the preprocessor a second time; that costs a pass and changes nothing, since what objc1 emits carries #line directives and no other directives. The object name comes from -o, or from changeext(), which gives e.i -> e.6 like any other source.

Noted while here, not fixed: running the objc driver under bash rather than sh killed the shell with "Insufficient physical memory". The driver is #!/bin/sh and dash runs it, so nothing in the build depends on this, but it is a bash bug worth its own look.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs