### PR TITLE
libap: vsnprintf must terminate the buffer, and must not clamp its re…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -739,6 +739,53 @@ ship.
 identity for the other types, and prints which of these headers were actually
 read.
 
+### stdio/ — vsnprintf wrote nothing when there was nothing to write
+
+`vsnprintf` was a wrapper over `fmemopen(buf, nbuf, "w")` plus
+`vfprintf`. `fmemopen`'s `mwrite` writes the terminating NUL *after* a
+write, so formatting **zero** characters — `snprintf(buf, n, "%s", "")` —
+touched the buffer not at all and left whatever was there before. C99
+7.19.6.5p2 requires a null-terminated result whenever `n` is nonzero.
+
+Found through GNU m4. `format()` formats each conversion into a fresh
+`xasprintf` buffer, and a specifier with no argument left formats the
+empty string — so it came back holding the *previous* conversion. bison's
+`data/skeletons/c.m4:557` formats `"%s = %s%s%s"` with three arguments,
+the last being the separating comma or nothing:
+
+```
+YYEOF = 0,,		/* wrong */
+YYEOF = 0,		/* right */
+```
+
+so every token of every parser bison generated had a doubled comma. Most
+C compilers accept `, ,` in an enumerator list often enough that nothing
+noticed; the Portable Object Compiler is the first thing in the tree that
+*parses* a `y.tab.c` rather than compiling it, and it said
+`y.tab.c:138: fatal: syntax error ","`.
+
+The same file had a second bug: `mwrite` short-writes at the end of the
+buffer, which makes `vfprintf` count short *and* set the error flag, so
+the return value was the truncated length or -1 rather than the length
+that would have been written (7.19.6.5p3). That silently breaks the
+measure-allocate-format-again idiom.
+
+Now musl's own implementation, which is a cookie writer rather than a
+`FILE`: `sn_write` reports every byte as written and copies only what
+fits, so the count is right however small `nbuf` is, and the buffer is
+terminated before `vfprintf` is called at all. This also retires the
+`nbuf > 65536` `open_memstream` path that existed to keep `sprintf`'s
+`nbuf = INT_MAX` from overflowing a length computation.
+
+`fmemopen` was fixed alongside: POSIX says `w` and `w+` set the first
+byte of the buffer to NUL, and musl did it for `w+` alone.
+
+Covered by `sys/lib/tests/format-arg-test.c`, which separates the two
+halves of the m4 line this came from — printf's `%*.*s` with a zero width
+and a negative precision, and the `ARG_STR` idiom (a comma expression in
+the second arm of a conditional, passed to a variadic function). Both
+were suspects; only the library was at fault.
+
 ### <stdio.h> used to drag errno, unistd, fcntl and pthread in
 
 `<stdio.h>` included `<stdio_impl.h>` — musl's *internal* header, which

--- a/RELEASE-NOTES-0.6.md
+++ b/RELEASE-NOTES-0.6.md
@@ -241,6 +241,16 @@ Other header work:
   with everything discarded, so `posix_spawn_file_actions_adddup2()`
   returned 0 and did nothing. Undetectable by the caller, and gnulib's
   `spawn-pipe.c` wires its pipe to the child entirely through `adddup2`.
+- **`vsnprintf` left the buffer untouched when it formatted nothing**,
+  and reported a truncated length when it ran out of room. It was built
+  on `fmemopen`, whose write hook only lays down the terminating NUL
+  *after* a write, so `snprintf(buf, n, "%s", "")` returned whatever the
+  buffer held before; and the same hook's short write at the end of the
+  buffer made the return value the length written rather than the length
+  that would have been (C99 7.19.6.5p2 and p3), which quietly breaks
+  measure-allocate-format-again. musl's own implementation replaces it.
+  GNU m4's `format()` is what found it, and every parser bison generated
+  had a doubled comma after each token as a result.
 - **`sigset_t` held three signals.** `sigaddset`/`sigdelset` were gated on
   a mask built by ORing signal *numbers* together, so only 0, 1 and 2 were
   accepted; `sigfillset()` produced a set naming SIGHUP and SIGINT alone.

--- a/sys/lib/tests/format-arg-test.c
+++ b/sys/lib/tests/format-arg-test.c
@@ -61,6 +61,17 @@ check(const char *what, const char *got, const char *want)
 	}
 }
 
+static void
+checkn(const char *what, int got, int want)
+{
+	if(got == want){
+		printf("PASS %s: %d\n", what, got);
+	}else{
+		printf("FAIL %s: got %d, want %d\n", what, got, want);
+		failures++;
+	}
+}
+
 /* m4's macro, with TOKEN_DATA_TEXT collapsed to the array element. */
 #define ARG_STR(argc, argv) \
 	((argc == 0) ? "" : \
@@ -155,6 +166,38 @@ main(void)
 	args[2] = "";
 	fetchf(buf, sizeof buf, 3, args, 3);
 	check("bison c.m4 token, last", buf, "YYEOF|0|");
+
+	/*
+	 * 5. snprintf's return is the length it would have written,
+	 * not the length it did (C99 7.19.6.5p3).  The two-pass idiom
+	 * -- measure, allocate, format again -- is built on it, and
+	 * gets a silent truncation instead of a second pass when the
+	 * count comes back clamped.
+	 *
+	 * gcc warns about the deliberate truncations here
+	 * (-Wformat-truncation); that is it agreeing with the test.
+	 */
+	{
+		int n;
+
+		strcpy(buf, "untouched");
+		n = snprintf(buf, 4, "%s", "abcdefg");
+		checkn("snprintf return, truncated", n, 7);
+		check("snprintf buffer, truncated", buf, "abc");
+
+		n = snprintf(NULL, 0, "%s", "abcdefg");
+		checkn("snprintf return, sizing pass", n, 7);
+
+		strcpy(buf, "untouched");
+		n = snprintf(buf, 1, "x");
+		checkn("snprintf return, room for NUL only", n, 1);
+		check("snprintf buffer, room for NUL only", buf, "");
+
+		strcpy(buf, "untouched");
+		n = snprintf(buf, sizeof buf, "%s", "");
+		checkn("snprintf return, empty", n, 0);
+		check("snprintf buffer, empty", buf, "");
+	}
 
 	printf("%d failure(s)\n", failures);
 	return failures;

--- a/sys/src/ape/lib/ap/stdio/fmemopen.c
+++ b/sys/src/ape/lib/ap/stdio/fmemopen.c
@@ -119,7 +119,16 @@ FILE *fmemopen(void *restrict buf, size_t size, const char *restrict mode)
 	if (!plus) f->f.flags = (*mode == 'r') ? F_NOWR : F_NORD;
 	if (*mode == 'r') f->c.len = size;
 	else if (*mode == 'a') f->c.len = f->c.pos = strnlen(buf, size);
-	else if (plus) *f->c.buf = 0;
+	/*
+	 * POSIX: "If mode is w or w+ ... the first byte of the buffer
+	 * shall be set to the null byte."  musl does it for w+ alone,
+	 * on the reasoning that a stream you cannot read from cannot
+	 * tell -- but the caller can, and does: mwrite only writes the
+	 * terminator after a write, so a "w" stream that formats
+	 * nothing leaves the caller's buffer holding whatever it held
+	 * before.  See vsnprintf.c, which used to be built on this.
+	 */
+	else if (size) *f->c.buf = 0;
 
 	f->f.read = mread;
 	f->f.write = mwrite;

--- a/sys/src/ape/lib/ap/stdio/vsnprintf.c
+++ b/sys/src/ape/lib/ap/stdio/vsnprintf.c
@@ -1,37 +1,104 @@
 #include "stdio_impl.h"
+#include <errno.h>
+#include <limits.h>
 #include <string.h>
-#include <stdlib.h>
 
-int vsnprintf(char *buf, size_t nbuf, const char *fmt, va_list args){
-	int n;
-	FILE *f;
+/*
+ * musl's own vsnprintf, restored.
+ *
+ * This used to be a wrapper over fmemopen(buf, nbuf, "w") plus
+ * vfprintf, with a second path through open_memstream for nbuf above
+ * 64K.  Two things were wrong with it, and both are the sort that show
+ * up a long way from here:
+ *
+ * 1. An empty result left the buffer untouched.  fmemopen's mwrite
+ *    writes the terminating NUL *after* a write, so formatting zero
+ *    characters -- snprintf(buf, n, "%s", "") -- wrote nothing at all
+ *    and buf kept whatever it held before.  C99 7.19.6.5p2 says the
+ *    result is always null-terminated when n is nonzero.
+ *
+ *    GNU m4's format() builtin is where this surfaced.  It formats each
+ *    conversion into a fresh xasprintf buffer and, for a specifier with
+ *    no argument left, formats the empty string -- so the buffer came
+ *    back holding the previous conversion instead.  bison's skeleton
+ *    (data/skeletons/c.m4:557) formats "%s = %s%s%s" with three
+ *    arguments, the last being the separating comma or nothing, so
+ *    every token of every generated parser came out as
+ *
+ *	YYEOF = 0,,
+ *
+ *    The Portable Object Compiler was the first thing in the tree to
+ *    parse a y.tab.c rather than compile it, and so the first to say
+ *    so: "y.tab.c:138: fatal: syntax error \",\"".
+ *
+ * 2. The return value was truncated.  C99 7.19.6.5p3 requires the
+ *    number of characters that *would* have been written.  fmemopen's
+ *    mwrite short-writes at the end of the buffer, which makes vfprintf
+ *    both count short and set the error flag -- so the return was
+ *    wrong, and could be -1.  That breaks the standard two-pass idiom
+ *    (measure with a small buffer, allocate, format again), which
+ *    quietly truncates instead of growing.
+ *
+ * sn_write reports every byte as written and copies only what fits, so
+ * the count stays right however small nbuf is.  A zero buf_size means
+ * vfprintf hands each piece straight to it rather than buffering.
+ *
+ * The old INT_MAX comment is still worth keeping in mind: sprintf calls
+ * this with nbuf = INT_MAX, so nothing here may compute nbuf-1 as a
+ * size in a way that can overflow -- c.n is a size_t and n is bounded
+ * by INT_MAX just below, so it cannot.
+ */
 
-	if (nbuf > 65536) {
-		char *mem = NULL;
-		size_t len = 0;
-		f = open_memstream(&mem, &len);
-		if (!f) return -1;
-		n = vfprintf(f, fmt, args);
-		fclose(f);
-		if (n >= 0 && mem) {
-			/* Use actual length, not nbuf-1: nbuf may be INT_MAX
-			 * (from sprintf) making strncpy/buf[] index overflow. */
-			size_t copy_len = ((size_t)n < nbuf - 1) ? (size_t)n : nbuf - 1;
-			memcpy(buf, mem, copy_len);
-			buf[copy_len] = '\0';
-			free(mem);
-		}
-		return n;
+struct cookie {
+	char *s;
+	size_t n;
+};
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+static size_t sn_write(FILE *f, const unsigned char *s, size_t l)
+{
+	struct cookie *c = f->cookie;
+	size_t k = MIN(c->n, (size_t)(f->wpos - f->wbase));
+	if (k) {
+		memcpy(c->s, f->wbase, k);
+		c->s += k;
+		c->n -= k;
 	}
-
-	f = fmemopen(buf, nbuf, "w");
-	if (!f)
-		return -1;
-
-	n=vfprintf(f, fmt, args);
-	fclose(f);
-
-	return n;
+	k = MIN(c->n, l);
+	if (k) {
+		memcpy(c->s, s, k);
+		c->s += k;
+		c->n -= k;
+	}
+	*c->s = 0;
+	f->wpos = f->wbase = f->buf;
+	return l;
 }
 
+int vsnprintf(char *buf, size_t nbuf, const char *fmt, va_list args){
+	unsigned char b[1];
+	char dummy[1];
+	struct cookie c;
+	FILE f;
 
+	if (nbuf > INT_MAX) {
+		errno = EOVERFLOW;
+		return -1;
+	}
+
+	c.s = nbuf ? buf : dummy;
+	c.n = nbuf ? nbuf-1 : 0;
+
+	memset(&f, 0, sizeof f);
+	f.lbf = EOF;
+	f.write = sn_write;
+	f.lock = -1;
+	f.buf = b;
+	f.buf_size = 0;
+	f.cookie = &c;
+	f.fd = -1;
+
+	*c.s = 0;
+	return vfprintf(&f, fmt, args);
+}


### PR DESCRIPTION
…turn

It was fmemopen(buf, nbuf, "w") plus vfprintf.  fmemopen's mwrite writes the terminating NUL after a write, so formatting zero characters -- snprintf(buf, n, "%s", "") -- touched the buffer not at all and left whatever was there before, against C99 7.19.6.5p2.  The same hook short writes at the end of the buffer, which makes vfprintf count short and set the error flag, so the return was the truncated length or -1 rather than the length that would have been written (p3) -- silently breaking measure, allocate, format again.

musl's own implementation replaces it: sn_write reports every byte as written and copies only what fits, and the buffer is terminated before vfprintf is called.  That also retires the nbuf > 65536 open_memstream path, which existed to keep sprintf's nbuf = INT_MAX out of a length computation that could overflow; c.n is a size_t and nbuf is bounded by INT_MAX, so it cannot.

fmemopen alongside: POSIX sets the first byte of the buffer to NUL for w as well as w+, and musl does it for w+ alone.

Found through GNU m4's format(), which formats the empty string for a specifier with no argument left, so each conversion came back holding the previous one.  bison's c.m4:557 formats "%s = %s%s%s" with three arguments, so every token of every generated parser had two commas -- noticed only when the Portable Object Compiler tried to parse one.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs