### PR TITLE
headers: <string.h> no longer reaches Plan 9's <u.h>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -828,6 +828,48 @@ returns 0 without doing anything — so each `_unlocked` function is its
 locked counterpart today. They are separate entry points so that the day
 `flockfile` becomes real, `unlocked.c` is the one file to change.
 
+### <string.h> reached Plan 9's <u.h>
+
+The same shape as the `<stdio.h>` leak above, and found the same way —
+by a port whose own names collided:
+
+```
+string.h -> wchar.h -> time.h -> signal.h -> pthread.h -> lock.h -> u.h
+```
+
+`<u.h>` is Plan 9's, and defines `nil`, `uchar`, `ushort`, `ulong` and
+`uint`. So asking for `strlen` brought all of them. The Portable Object
+Compiler is where it showed:
+
+```
+Object.m:28 ... Object.h:32 ... string.h:70 ... u.h:4
+  Macro redefinition of nil
+```
+
+`objcrt.h:83` defines `nil` as `((id)0)`, as every Objective-C runtime
+does, and guards it — so the unguarded definition in `u.h` simply lost
+to whichever of the two came second.
+
+**Every link in that chain existed for a pointer parameter**, and each
+is now a forward declaration, which is the idiom `signal.h` was already
+using one line above the offending include (`struct timespec; /* avoid
+pulling in time.h */`):
+
+- `string.h` wanted `wchar_t` for three APExp additions, and
+  `<stddef.h>` — already included — provides it. This was also circular:
+  `wchar.h` includes `string.h` back, so which definitions a file saw
+  depended on which of the two it asked for first.
+- `wchar.h` wanted `struct tm` for `wcsftime`.
+- `time.h` wanted `struct sigevent` for `timer_create`.
+- `signal.h` wanted `pthread_attr_t` for `struct sigevent`. That one is a
+  typedef rather than a tag, so it is repeated under a `_PTHREAD_ATTR_T`
+  guard in both headers.
+
+`nil` in `u.h` is guarded now as well. `<pthread.h>` still reaches
+`<lock.h>` and so `<u.h>` legitimately — `pthread_mutex_t` is built on
+`Lock` — so that path stays, and a name as common as `nil` should not
+be defined unconditionally at the end of it.
+
 ### Build order for compiler changes
 ```
 cd sys/src/cmd/cc && mk nuke && mk install   # regenerates y.tab.h

--- a/sys/include/ape/pthread.h
+++ b/sys/include/ape/pthread.h
@@ -3,7 +3,10 @@
 #pragma lib "/$M/lib/ape/libap.a"
 
 typedef struct pthread_once pthread_once_t;
-typedef int pthread_attr_t;
+#ifndef _PTHREAD_ATTR_T
+#define _PTHREAD_ATTR_T
+typedef int pthread_attr_t;	/* also in <signal.h>, for struct sigevent */
+#endif
 typedef struct pthread_mutex pthread_mutex_t;
 typedef int pthread_mutexattr_t;
 typedef struct pthread_cond pthread_cond_t;

--- a/sys/include/ape/signal.h
+++ b/sys/include/ape/signal.h
@@ -135,7 +135,16 @@ struct timespec;	/* avoid pulling in time.h */
 extern int sigtimedwait(const sigset_t *restrict, siginfo_t *restrict, const struct timespec *restrict);
 extern int sigqueue(pid_t, int, const union sigval);
 
-#include <pthread.h>
+/*
+ * struct sigevent's only use of it is a pointer, so the typedef is all
+ * that is wanted here -- and <pthread.h> reaches <lock.h> and so Plan
+ * 9's <u.h>, which defines nil, uchar, ushort, ulong and uint. See the
+ * note in <string.h>.
+ */
+#ifndef _PTHREAD_ATTR_T
+#define _PTHREAD_ATTR_T
+typedef int pthread_attr_t;
+#endif
 
 /* sigev_notify values */
 #define SIGEV_NONE    0   /* no notification */

--- a/sys/include/ape/string.h
+++ b/sys/include/ape/string.h
@@ -67,7 +67,29 @@ size_t strlcat(char *, const char *, size_t);
 char *index(const char *s, int c);
 void swab(const void *src, void *dst, ssize_t n);
 
-#include <wchar.h>
+/*
+ * These three are APExp additions, and they need wchar_t and nothing
+ * else -- which <stddef.h>, included at the top, already provides.
+ *
+ * This used to say "#include <wchar.h>", which made <string.h> the head
+ * of a chain reaching all the way into Plan 9's own headers:
+ *
+ *	string.h -> wchar.h -> time.h -> signal.h -> pthread.h
+ *	  -> lock.h -> u.h
+ *
+ * and u.h defines nil, uchar, ushort, ulong and uint. So every
+ * translation unit that asked for strlen got those too. The Portable
+ * Object Compiler is where it surfaced -- Object.h defines nil as
+ * ((id)0), as any Objective-C runtime does, and u.h then redefined it:
+ *
+ *	Object.m:28 ... Object.h:32 ... string.h:70 ... u.h:4
+ *	  Macro redefinition of nil
+ *
+ * It was also circular: <wchar.h> includes <string.h> back. Each of the
+ * four links has been cut where it was needed only for a pointer
+ * parameter; see the forward declarations in wchar.h, time.h and
+ * signal.h.
+ */
 extern size_t wcsnlen(const wchar_t *, size_t);
 extern int wcscasecmp(const wchar_t *, const wchar_t *);
 extern int wcsncasecmp(const wchar_t *, const wchar_t *, size_t);

--- a/sys/include/ape/time.h
+++ b/sys/include/ape/time.h
@@ -99,7 +99,7 @@ extern void tzset(void);
 extern int nanosleep(const struct timespec *req, struct timespec *rem);
 extern int clock_nanosleep(clockid_t, int, const struct timespec *, struct timespec *);
 
-#include <signal.h>
+struct sigevent;	/* avoid pulling in signal.h */
 extern int timer_create(clockid_t, struct sigevent *, timer_t *);
 extern int timer_delete(timer_t);
 extern int timer_settime(timer_t, int, const struct itimerspec *, struct itimerspec *);

--- a/sys/include/ape/u.h
+++ b/sys/include/ape/u.h
@@ -1,7 +1,16 @@
 #ifndef __U_H
 #define __U_H
 
+/*
+ * Guarded because nil is not a reserved name, and this header arrives
+ * through <lock.h> under <pthread.h> where a caller has no reason to
+ * expect it. Every Objective-C runtime defines nil as ((id)0) -- the
+ * Portable Object Compiler's objcrt.h:83 does, and guards it, so an
+ * unguarded definition here simply lost to whichever came second.
+ */
+#ifndef nil
 #define nil		((void*)0)
+#endif
 typedef	unsigned short	ushort;
 typedef	unsigned char	uchar;
 typedef unsigned long	ulong;

--- a/sys/include/ape/wchar.h
+++ b/sys/include/ape/wchar.h
@@ -20,7 +20,7 @@
 #include <stdio.h>  /* provides FILE */
 #include <stdlib.h> /* provides: mbtowc wctomb mbstowcs wcstombs */
 #include <string.h>
-#include <time.h>
+struct tm;	/* for wcsftime; avoid pulling in time.h */
 #include <langinfo.h>
 
 /*


### PR DESCRIPTION
	string.h -> wchar.h -> time.h -> signal.h -> pthread.h
	  -> lock.h -> u.h

and u.h defines nil, uchar, ushort, ulong and uint, so every translation unit that asked for strlen got those too.  The Portable Object Compiler is where it surfaced: objcrt.h:83 defines nil as ((id)0), as every Objective-C runtime does, and guards it, so the unguarded definition in u.h simply lost to whichever came second.

	Object.m:28 ... Object.h:32 ... string.h:70 ... u.h:4
	  Macro redefinition of nil

Every link existed for a pointer parameter, and each is now a forward declaration -- the idiom signal.h was already using one line above the offending include.  string.h wanted wchar_t, which <stddef.h> already provides; wchar.h wanted struct tm; time.h wanted struct sigevent; signal.h wanted pthread_attr_t, a typedef rather than a tag, so that one is repeated under a _PTHREAD_ATTR_T guard in both headers.

string.h and wchar.h included each other, so this also retires a circularity where what a file saw depended on which it asked for first.

nil in u.h is guarded too.  <pthread.h> reaches <lock.h> and so <u.h> legitimately -- pthread_mutex_t is built on Lock -- and a name that common should not be defined unconditionally at the end of it.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs