### PR TITLE
libap: freopen must reopen the stream it is given

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -819,7 +819,7 @@ and a negative precision, and the `ARG_STR` idiom (a comma expression in
 the second arm of a conditional, passed to a variadic function). Both
 were suspects; only the library was at fault.
 
-### Three lines of flex, and two stdio bugs behind them
+### Three lines of flex, and three stdio bugs behind them
 
 flex sends its output through a chain of filter processes,
 
@@ -887,6 +887,33 @@ up, so those were fine. Left unfixed it would have cost the `fgetc`
 after it a *real read on a pipe nothing had written to yet* -- every
 filter blocking there, and the one that goes on to `execvp("m4")`
 swallowing a bufferful into a `FILE` the exec was about to discard.
+
+**`freopen` returned a new stream instead of reopening the given one.**
+The third bug, and the one that sent the whole scanner to the terminal.
+C99 7.19.5.4p2 makes `freopen` associate the *named file with the
+stream it is given*; it returns that stream. This did
+
+```c
+if (f && f->fd >= 0) fclose(f);
+fd = open(name, flags, 0666);
+return __fdopen(fd, mode);
+```
+
+so the caller's stream was untouched. On a permanent stream it did
+nothing at all: `fclose()` on `F_PERM` -- stdin, stdout, stderr --
+flushes and returns *without closing the descriptor*, by design. fd 1
+stayed on the terminal, `open()` took a fresh descriptor, and the new
+`FILE` was discarded by every caller, since the return value is checked
+against NULL and otherwise thrown away.
+
+flex's `main.c:333` is `freopen (outfilename, "w+", stdout)` followed by
+writing the scanner to `stdout`, so `lex.yy.c` was created by that
+`open()` and never written to again. Now it is musl's: open the file as
+a separate stream, `dup2` its descriptor onto the one the caller's
+stream already uses, adopt its flags and hooks, close the temporary.
+**`fileno(f)` must not change** -- flex then does
+`dup2(pipe, fileno(stdout))` and forks children that inherit descriptor
+1 expecting it to be the output file.
 
 **What it cost:** an empty `lex.yy.c`, or flex killed by
 

--- a/sys/lib/tests/unget-pipe-test.c
+++ b/sys/lib/tests/unget-pipe-test.c
@@ -157,7 +157,78 @@ unread_pipe(void)
 }
 
 /*
- * 3. flex's filter idiom end to end: the child re-points stdin at a
+ * 3. freopen reopens the stream it is given (C99 7.19.5.4p2), keeping
+ * its identity and its descriptor number. flex does
+ *
+ *	freopen (outfilename, "w+", stdout);
+ *
+ * at main.c:333 and then writes the scanner to stdout, and its filter
+ * chain later does dup2(pipe, fileno(stdout)) and forks children that
+ * inherit descriptor 1 expecting it to be the output file. A freopen
+ * that returns some other stream leaves stdout on the terminal.
+ *
+ * Done in a child so the test's own stdout is not disturbed. stdout is
+ * a permanent stream (F_PERM), which is the case that was broken:
+ * fclose() on such a stream flushes without closing the descriptor.
+ */
+static void
+freopen_stdout(void)
+{
+	int pid, status, fd;
+	FILE *res;
+	char detail[128];
+	char got[64];
+
+	/*
+	 * Flush before forking. When stdout is not a terminal it is
+	 * fully buffered, and the child would inherit everything printed
+	 * so far and write it out a second time.
+	 */
+	fflush(stdout);
+
+	if((pid = fork()) < 0){
+		check("freopen keeps the stream", 0, "fork failed");
+		return;
+	}
+	if(pid == 0){
+		if(freopen(RESULT, "w", stdout) == NULL)
+			_exit(2);
+		/* fileno must not change: flex's dup2 relies on it. */
+		printf("fd=%d hello\n", fileno(stdout));
+		fflush(stdout);
+		_exit(0);
+	}
+	if(waitpid(pid, &status, 0) < 0 || status != 0){
+		snprintf(detail, sizeof detail, "child status %#x", status);
+		check("freopen keeps the stream", 0, detail);
+		return;
+	}
+
+	res = fopen(RESULT, "r");
+	if(!res || !fgets(got, sizeof got, res)){
+		check("freopen keeps the stream", 0,
+			"nothing was written to the file");
+		if(res)
+			fclose(res);
+		return;
+	}
+	fclose(res);
+	got[strcspn(got, "\n")] = '\0';
+
+	if(sscanf(got, "fd=%d", &fd) != 1){
+		snprintf(detail, sizeof detail, "file holds \"%s\"", got);
+		check("freopen keeps the stream", 0, detail);
+		return;
+	}
+	snprintf(detail, sizeof detail, "file holds \"%s\"", got);
+	check("freopen writes reach the file", strstr(got, "hello") != NULL,
+		detail);
+	snprintf(detail, sizeof detail, "fileno(stdout) became %d, want 1", fd);
+	check("freopen keeps the descriptor", fd == 1, detail);
+}
+
+/*
+ * 4. flex's filter idiom end to end: the child re-points stdin at a
  * pipe and reads every line the parent writes. A lost or duplicated
  * character shows up as a wrong count or a wrong byte total.
  */
@@ -176,6 +247,8 @@ filter_child(void)
 		check("flex filter idiom", 0, "pipe failed");
 		return;
 	}
+
+	fflush(stdout);
 
 	if((pid = fork()) < 0){
 		check("flex filter idiom", 0, "fork failed");
@@ -294,6 +367,7 @@ main(void)
 
 	unread_file();
 	unread_pipe();
+	freopen_stdout();
 	filter_child();
 	remove(RESULT);
 

--- a/sys/src/ape/lib/ap/stdio/freopen.c
+++ b/sys/src/ape/lib/ap/stdio/freopen.c
@@ -2,27 +2,100 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+/*
+ * freopen reopens *the stream it is given*. C99 7.19.5.4p2: it "first
+ * attempts to close any file that is associated with the specified
+ * stream", then opens the new file and associates it with that same
+ * stream, returning the stream itself.
+ *
+ * This used to fclose(f), open the file, and return a *new* FILE from
+ * __fdopen:
+ *
+ *	if (f && f->fd >= 0) fclose(f);
+ *	fd = open(name, flags, 0666);
+ *	return __fdopen(fd, mode);
+ *
+ * which is not freopen at all. The caller's stream is the whole point:
+ * every use of freopen is "make stdout (or stdin) be this file from now
+ * on", and the return value is checked against NULL and otherwise
+ * discarded.
+ *
+ * On a permanent stream it did nothing whatever. fclose() on a stream
+ * with F_PERM -- stdin, stdout, stderr -- flushes and returns without
+ * closing the descriptor, by design. So fd 1 stayed on the terminal,
+ * open() got a fresh descriptor for the new file, __fdopen wrapped that
+ * in a FILE nobody kept, and stdout still pointed at the terminal.
+ *
+ * flex is where it showed. main.c:333 does
+ *
+ *	prev_stdout = freopen (outfilename, "w+", stdout);
+ *
+ * and then writes the scanner to stdout, so the whole of lex.yy.c went
+ * to the terminal and the file itself -- created by that open() and
+ * never written to again -- was left at zero bytes.
+ *
+ * Now it is musl's: open the new file as a separate stream, dup2 its
+ * descriptor onto the one the caller's stream already uses so that
+ * fileno(f) does not change, adopt its flags and hooks, and close the
+ * temporary. F_PERM is preserved, so stdout stays permanent.
+ *
+ * fileno(f) not changing is not a detail. flex's filter chain does
+ * dup2(pipe, fileno(stdout)) afterwards, and forks children that
+ * inherit descriptor 1 expecting it to be the output file.
+ */
 FILE *freopen(const char *name, const char *mode, FILE *f){
-	int fd, flags;
+	int fl;
+	FILE *f2;
 
-	if (f && f->fd >= 0) {
-		fclose(f);
-	}
-
-	if (!name) {
-		return NULL;
-	}
-
-	flags = __fmodeflags(mode);
-	fd = open(name, flags, 0666);
-	if (fd < 0)
+	if(!f)
 		return NULL;
 
-	FILE *result = __fdopen(fd, mode);
-	if (!result) {
-		close(fd);
-		return NULL;
+	fflush(f);
+
+	/*
+	 * A null name means "change the mode of the stream that is
+	 * already open" (POSIX). Only the access-mode bits can change;
+	 * creation and truncation are meaningless here.
+	 */
+	if(!name){
+		fl = __fmodeflags(mode) & ~(O_CREAT|O_EXCL|O_TRUNC|O_CLOEXEC);
+		if(f->fd < 0 || fcntl(f->fd, F_SETFL, fl) < 0)
+			goto fail;
+		return f;
 	}
-	return result;
+
+	f2 = fopen(name, mode);
+	if(!f2)
+		goto fail;
+
+	if(f2->fd == f->fd){
+		f2->fd = -1;		/* so fclose(f2) leaves it open */
+	}else if(f->fd < 0 || dup2(f2->fd, f->fd) < 0){
+		fclose(f2);
+		goto fail;
+	}
+
+	/*
+	 * Take on the new file's nature, keeping this stream's identity:
+	 * F_PERM says whether the FILE itself may be freed, and belongs
+	 * to f, not to the file it happens to be open on. Copying the
+	 * rest of the flags also clears any error and end-of-file left
+	 * over from the old file, which 7.19.5.4 requires.
+	 */
+	f->flags = (f->flags & F_PERM) | f2->flags;
+	f->read = f2->read;
+	f->write = f2->write;
+	f->seek = f2->seek;
+	f->close = f2->close;
+
+	/* Nothing buffered for the old file carries over. */
+	f->rpos = f->rend = 0;
+	f->wpos = f->wbase = f->wend = 0;
+
+	fclose(f2);
+	return f;
+
+fail:
+	fclose(f);
+	return NULL;
 }
-


### PR DESCRIPTION
C99 7.19.5.4p2: freopen associates the named file with the stream passed to it, and returns that stream.  This closed the stream, opened the file, and returned a brand new FILE from __fdopen -- so the caller's stream was left as it was.  Every caller checks the result against NULL and otherwise discards it, because the point is the side effect on stdout or stdin.

On a permanent stream it did nothing whatever: fclose() on F_PERM flushes and returns without closing the descriptor, by design.  So fd 1 stayed on the terminal, open() took a fresh descriptor, and the FILE wrapping it was thrown away.

flex's main.c:333 is

	prev_stdout = freopen (outfilename, "w+", stdout);

followed by writing the scanner to stdout, so the whole of lex.yy.c went to the terminal and the file, created by that open() and never written to again, was left at zero bytes.

Now it is musl's: open the file as a separate stream, dup2 its descriptor onto the one the caller's stream already uses so fileno(f) does not change, adopt its flags and hooks, close the temporary, keep F_PERM.  fileno not changing is not a detail -- flex's filter chain then does dup2(pipe, fileno(stdout)) and forks children that inherit descriptor 1 expecting it to be the output file.

The test grows a case for it, and both forks now flush stdout first: a child inherits an unflushed buffer and writes it out a second time when stdout is not a terminal.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs