### PR TITLE
libap: fclose must close the file, even on a permanent stream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -932,6 +932,43 @@ and a quiet child leaves the parent writing into a pipe with no reader,
 so it dies of SIGPIPE before printing anything -- which is the same
 mechanism that kills flex, and it hid the answer for a round trip.
 
+### fclose left the standard streams open
+
+`F_PERM` says the `FILE` is static and must not be freed. It does not
+mean the file stays open. `fclose` returned early for such a stream:
+
+```c
+if (f->flags & F_PERM) {
+	if (fflush(f) == EOF) error = EOF;
+	return error;
+}
+```
+
+so `fclose(stdout)` flushed and left descriptor 1 open. C99 7.19.5.1
+grants no exemption to the standard streams -- fclose "causes the stream
+to be flushed and the associated file to be closed" -- and musl calls
+the close hook unconditionally, skipping only the `free`.
+
+Closing stdout is how a program at the head of a pipeline says it is
+done. flex's cleanup is
+
+```c
+fflush (stdout);
+fclose (stdout);
+while (wait (&child_status) > 0) ...
+```
+
+and with the descriptor still open the first filter never saw end of
+file, nothing downstream could exit, and flex waited for children that
+could not finish. `lex.yy.c` was complete on disk and the build simply
+stopped, which `ps` showed exactly:
+
+```
+flex  Await		the parent, in wait()
+flex  Pread		filter_tee_header
+flex  Pread		filter_fix_linedirs
+```
+
 ### <stdio.h> used to drag errno, unistd, fcntl and pthread in
 
 `<stdio.h>` included `<stdio_impl.h>` — musl's *internal* header, which

--- a/sys/lib/tests/unget-pipe-test.c
+++ b/sys/lib/tests/unget-pipe-test.c
@@ -228,7 +228,74 @@ freopen_stdout(void)
 }
 
 /*
- * 4. flex's filter idiom end to end: the child re-points stdin at a
+ * 4. fclose closes the file, even on a permanent stream.
+ *
+ * C99 7.19.5.1 has no exemption for stdin/stdout/stderr: fclose
+ * "causes the stream to be flushed and the associated file to be
+ * closed". F_PERM only means the FILE itself is static and must not be
+ * freed.
+ *
+ * This is how a program at the head of a pipeline says it is done.
+ * flex's cleanup is fclose(stdout) followed by wait() for its filter
+ * children, so a descriptor left open means the first filter never sees
+ * end of file and nothing downstream can exit.
+ *
+ * Tested by writing to the descriptor afterwards, which is exact and
+ * needs no timing: if fclose closed it, the write fails. Done in a
+ * child, since it closes stdout for good.
+ */
+static void
+fclose_perm(void)
+{
+	int pid, status, fd, r;
+	FILE *res;
+	char detail[128];
+	long wrote = 0;
+
+	fflush(stdout);
+
+	if((pid = fork()) < 0){
+		check("fclose closes a permanent stream", 0, "fork failed");
+		return;
+	}
+	if(pid == 0){
+		fd = fileno(stdout);
+		fclose(stdout);
+
+		/* Must happen before anything reopens a low descriptor. */
+		r = write(fd, "x", 1);
+
+		res = fopen(RESULT, "w");
+		if(!res)
+			_exit(3);
+		fprintf(res, "%d\n", r);
+		fclose(res);
+		_exit(0);
+	}
+	if(waitpid(pid, &status, 0) < 0 || status != 0){
+		snprintf(detail, sizeof detail, "child status %#x", status);
+		check("fclose closes a permanent stream", 0, detail);
+		return;
+	}
+
+	res = fopen(RESULT, "r");
+	if(!res || fscanf(res, "%ld", &wrote) != 1){
+		check("fclose closes a permanent stream", 0,
+			"child wrote no result");
+		if(res)
+			fclose(res);
+		return;
+	}
+	fclose(res);
+
+	snprintf(detail, sizeof detail,
+		"write to the descriptor after fclose returned %ld,"
+		" want -1", wrote);
+	check("fclose closes a permanent stream", wrote == -1, detail);
+}
+
+/*
+ * 5. flex's filter idiom end to end: the child re-points stdin at a
  * pipe and reads every line the parent writes. A lost or duplicated
  * character shows up as a wrong count or a wrong byte total.
  */
@@ -368,6 +435,7 @@ main(void)
 	unread_file();
 	unread_pipe();
 	freopen_stdout();
+	fclose_perm();
 	filter_child();
 	remove(RESULT);
 

--- a/sys/src/ape/lib/ap/stdio/fclose.c
+++ b/sys/src/ape/lib/ap/stdio/fclose.c
@@ -1,19 +1,54 @@
 #include "stdio_impl.h"
+#include <stdlib.h>
+#include <unistd.h>
 
+/*
+ * F_PERM says the FILE itself is static and must not be freed. It does
+ * not mean the file stays open.
+ *
+ * This used to return early for a permanent stream:
+ *
+ *	if (f->flags & F_PERM) {
+ *		if (fflush(f) == EOF) error = EOF;
+ *		return error;
+ *	}
+ *
+ * so fclose(stdout) flushed and left descriptor 1 open. C99 7.19.5.1
+ * has no exemption for the standard streams: fclose "causes the stream
+ * to be flushed and the associated file to be closed". musl calls the
+ * close hook unconditionally and skips only the free.
+ *
+ * Closing stdout is how a program at the head of a pipeline says it is
+ * done -- the reader gets end of file. flex's cleanup path is
+ *
+ *	fflush (stdout);
+ *	fclose (stdout);
+ *	while (wait (&child_status) > 0) ...
+ *
+ * and its output goes through a chain of filter processes, so with the
+ * descriptor still open the first filter never saw end of file, nothing
+ * downstream could finish, and flex waited for children that could not
+ * exit. lex.yy.c was complete on disk and the build simply stopped:
+ *
+ *	flex  Await		(the parent, in wait())
+ *	flex  Pread		(filter_tee_header)
+ *	flex  Pread		(filter_fix_linedirs)
+ */
 int fclose(FILE *f){
 	FILE **head;
-	int error;
+	int error, perm;
 
 	if(!f) return EOF;
 
 	error = 0;
+	perm = f->flags & F_PERM;
 
 	/* Remove heap streams from the global open-file list before any
 	 * flushing or close hooks run.  __stdio_exit() walks this list, so a
 	 * closed stream must never remain linked if later cleanup allocates or
 	 * frees memory.
 	 */
-	if (!(f->flags & F_PERM)) {
+	if(!perm){
 		head = __ofl_lock();
 		if (*head == f)
 			*head = f->next;
@@ -25,29 +60,28 @@ int fclose(FILE *f){
 		__ofl_unlock();
 	}
 
-	/* Permanent streams (stdin/stdout/stderr have F_PERM): just flush,
-	 * do not close the fd or free memory. */
-	if (f->flags & F_PERM) {
-		if (fflush(f) == EOF) error = EOF;
-		return error;
+	if(fflush(f) == EOF) error = EOF;
+
+	/* Close the underlying fd (and destroy the mutex). __stdio_close
+	 * sets f->fd to -1, so the fallback below does not double close;
+	 * it is there for streams with no close hook. */
+	if(f->close && f->close(f) < 0)
+		error = EOF;
+
+	if(f->fd >= 0){
+		if(close(f->fd) < 0) error = EOF;
+		f->fd = -1;
 	}
 
-	if(fflush(f)==EOF) error=EOF;
+	/* A permanent stream keeps its FILE -- it is static, and the
+	 * standard stream pointers still refer to it. */
+	if(perm)
+		return error;
 
 	/* Free a setvbuf-allocated buffer */
 	if(f->buf && (f->flags & F_SVB)){
 		free(f->buf);
 		f->buf = NULL;
-	}
-
-	/* Close the underlying fd (and destroy the mutex) */
-	if(f->close && f->close(f) < 0)
-		error = EOF;
-
-	/* close(2) is done by __stdio_close; skip duplicate for fmemopen etc. */
-	if(f->fd >= 0){
-		if(close(f->fd) < 0) error = EOF;
-		f->fd = -1;
 	}
 
 	f->flags = 0;


### PR DESCRIPTION
F_PERM says the FILE is static and must not be freed.  It does not mean the file stays open.  fclose returned early for such a stream, flushing and leaving the descriptor open, so fclose(stdout) closed nothing.  C99 7.19.5.1 grants no exemption to the standard streams, and musl calls the close hook unconditionally and skips only the free.

Closing stdout is how a program at the head of a pipeline says it is done.  flex's cleanup is fclose(stdout) followed by wait() for its filter children, so with descriptor 1 still open the first filter never saw end of file, nothing downstream could exit, and flex waited for children that could not finish -- lex.yy.c complete on disk, the build simply stopped:

	flex  Await	the parent, in wait()
	flex  Pread	filter_tee_header
	flex  Pread	filter_fix_linedirs


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs