### PR TITLE
readline: rlprivate.h must include <signal.h> itself

### DIFF
--- a/sys/src/external/readline/rlprivate.h
+++ b/sys/src/external/readline/rlprivate.h
@@ -28,6 +28,15 @@
 #include "posixjmp.h"	/* defines procenv_t */
 #include "rlmbutil.h"	/* for HANDLE_MULTIBYTE */
 
+/*
+ * for sigset_t (_rl_timeout_select's prototype below) and SIGINT/SIGWINCH.
+ * This file used to get all three for free through a leak in APExp's
+ * <string.h>, which reached <signal.h> by way of <wchar.h> and <time.h>;
+ * see the "<string.h> reached Plan 9's <u.h>" note in CLAUDE.md. Ask
+ * directly now that the leak is gone.
+ */
+#include <signal.h>
+
 /*************************************************************************
  *									 *
  * Convenience definitions						 *


### PR DESCRIPTION
	rlprivate.h:347 syntax error, last name: sigset_t

rlprivate.h declares _rl_timeout_select's prototype with a sigset_t argument but never included <signal.h> -- it lived entirely off the transitive leak through <string.h> -> <wchar.h> -> <time.h> -> <signal.h> that the "<string.h> reached Plan 9's <u.h>" fix in CLAUDE.md removed. Cutting that leak was correct; readline just needs to ask for what it uses, the same as every other header touched by that cleanup.

Swept the rest of readline and bash for the same shape (sigset_t, SIGINT, SIGWINCH without a signal.h in reach) and found nothing else relying on it.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs