### PR TITLE
tk: instrument the Tk_AllocFontFromObj null, drop the -N probe

### DIFF
--- a/sys/src/ape/lib/tk/mkfile
+++ b/sys/src/ape/lib/tk/mkfile
@@ -228,37 +228,6 @@ $DRAWIMPL_OBJ: $TKSRC/plan9/tkPlan9DrawImpl.c
 tkImgPhInstance.$O: $TKSRC/generic/tkImgPhInstance.c
 	$CC $CFLAGS -N $TKSRC/generic/tkImgPhInstance.c
 
-# DIAGNOSTIC PROBE, not a fix -- remove once the question below is answered.
-#
-# wish dies on every Tk test with
-#
-#	wish 515: suicide: sys: trap: fault read addr=0x18 pc=0x274fca
-#
-# which acid places at tkFont.c:1159, in Tk_AllocFontFromObj:
-#
-#	cacheHashPtr = Tcl_CreateHashEntry(&fiPtr->fontCache,
-#		Tcl_GetString(objPtr), &isNew);
-#	firstFontPtr = (TkFont *)Tcl_GetHashValue(cacheHashPtr);
-#
-# Tcl_GetHashValue(h) is ((h)->clientData), and clientData sits at 0x18
-# in Tcl_HashEntry (nextPtr 0, tablePtr 8, hash 0x10) -- so cacheHashPtr
-# is null on that line.
-#
-# CreateHashEntry returns null in exactly one place, "if (!newPtr ||
-# (newPtr == TCL_HASH_FIND))", and the caller passes &isNew, a stack
-# address that is neither. So either the third argument arrives
-# corrupted or cacheHashPtr is clobbered between the two lines. Note the
-# statement nests two calls in one expression -- Tcl_GetString and the
-# indirect call through tablePtr->createProc -- which is the shape of
-# the 6c bug fixed earlier this cycle, where a value live across a call
-# was truncated.
-#
-# If -N makes wish run, it is codegen and we have a small reproducer.
-# If it still faults, the null is real and the fault is in the hash
-# table or in fiPtr, and this rule should just be deleted.
-tkFont.$O: $TKSRC/generic/tkFont.c
-	$CC $CFLAGS -N $TKSRC/generic/tkFont.c
-
 %.$O: $TKSRC/generic/%.c
 	$CC $CFLAGS $TKSRC/generic/$stem.c
 

--- a/sys/src/external/tk/generic/tkFont.c
+++ b/sys/src/external/tk/generic/tkFont.c
@@ -13,6 +13,10 @@
 
 #include "tkInt.h"
 #include "tkFont.h"
+
+/* APExp diagnostic (temporary) -- see Tk_AllocFontFromObj below. */
+#include <stdio.h>
+#include <stdint.h>
 #if defined(MAC_OSX_TK)
 #include "tkMacOSXInt.h"    /* Defines TK_DRAW_IN_CONTEXT */
 #endif
@@ -1156,6 +1160,46 @@ Tk_AllocFontFromObj(
 	cacheHashPtr = Tcl_CreateHashEntry(&fiPtr->fontCache,
 		Tcl_GetString(objPtr), &isNew);
     }
+    /*
+     * APExp diagnostic -- temporary, remove once the wish crash is
+     * understood. cacheHashPtr is null here on every Tk test:
+     *
+     *	wish: suicide: sys: trap: fault read addr=0x18
+     *
+     * 0x18 is clientData in Tcl_HashEntry, which is what
+     * Tcl_GetHashValue reads. Fires only in the broken case, and only
+     * just before the fault, so it costs nothing when things work.
+     */
+    if (cacheHashPtr == NULL) {
+	fprintf(stderr, "APExp: Tk_AllocFontFromObj: cacheHashPtr is NULL\n");
+	fprintf(stderr, "  font        = \"%s\"\n", Tcl_GetString(objPtr));
+	fprintf(stderr, "  branch      = %s\n",
+		(oldFontPtr != NULL) ? "oldFontPtr->cacheHashPtr"
+				     : "Tcl_CreateHashEntry");
+	fprintf(stderr, "  oldFontPtr  = %llx\n",
+		(unsigned long long) (uintptr_t) oldFontPtr);
+	fprintf(stderr, "  fiPtr       = %llx\n",
+		(unsigned long long) (uintptr_t) fiPtr);
+	fprintf(stderr, "  isNew       = %d\n", isNew);
+	fprintf(stderr, "  fontCache.buckets    = %llx\n",
+		(unsigned long long) (uintptr_t) fiPtr->fontCache.buckets);
+	fprintf(stderr, "  fontCache.numBuckets = %lld\n",
+		(long long) fiPtr->fontCache.numBuckets);
+	fprintf(stderr, "  fontCache.numEntries = %lld\n",
+		(long long) fiPtr->fontCache.numEntries);
+	fprintf(stderr, "  fontCache.keyType    = %d\n",
+		fiPtr->fontCache.keyType);
+	fprintf(stderr, "  fontCache.findProc   = %llx\n",
+		(unsigned long long) (uintptr_t) fiPtr->fontCache.findProc);
+	fprintf(stderr, "  fontCache.createProc = %llx\n",
+		(unsigned long long) (uintptr_t) fiPtr->fontCache.createProc);
+	fprintf(stderr, "  fontCache.typePtr    = %llx\n",
+		(unsigned long long) (uintptr_t) fiPtr->fontCache.typePtr);
+	fprintf(stderr, "  sizeof(Tcl_HashTable)=%d sizeof(Tcl_HashEntry)=%d\n",
+		(int) sizeof(Tcl_HashTable), (int) sizeof(Tcl_HashEntry));
+	fflush(stderr);
+    }
+
     firstFontPtr = (TkFont *)Tcl_GetHashValue(cacheHashPtr);
     for (fontPtr = firstFontPtr; (fontPtr != NULL);
 	    fontPtr = fontPtr->nextPtr) {


### PR DESCRIPTION
-N did not change the crash, so it is not regopt and the null is real. Removed the probe rule from the libtk mkfile.

Added a temporary diagnostic at tkFont.c:1159 that fires only when cacheHashPtr is null -- immediately before the fault, so it costs nothing when things work.  It reports which of the two branches produced the null (oldFontPtr->cacheHashPtr, or the Tcl_CreateHashEntry call), the font name being looked up, and the whole fontCache table: buckets, numBuckets, numEntries, keyType, findProc, createProc, typePtr, plus sizeof(Tcl_HashTable) and sizeof(Tcl_HashEntry).

The sizes are worth having because Tcl_HashTable's layout is guarded by #if TCL_MAJOR_VERSION > 8, so a mismatch between the tcl.h Tk saw and the one Tcl was built with would move createProc and is one of the few ways the call could return null cleanly.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs