### PR TITLE
tk: TkpDeleteFont must not free the TkFont struct

### DIFF
--- a/sys/src/external/tk/plan9/tkPlan9Font.c
+++ b/sys/src/external/tk/plan9/tkPlan9Font.c
@@ -148,12 +148,42 @@ TkpGetFontFromAttributes(
 /* TkpDeleteFont                                                      */
 /* ------------------------------------------------------------------ */
 
+/*
+ * Release the platform resources only. The TkFont struct itself belongs
+ * to generic Tk, which frees it in Tk_FreeFont immediately after this
+ * returns:
+ *
+ *	TkpDeleteFont(fontPtr);
+ *	if (fontPtr->objRefCount == 0) {
+ *	    ckfree(fontPtr);
+ *	}
+ *
+ * This used to ckfree(p9f), so that read of objRefCount was already a
+ * read of freed memory and the ckfree a double free. Worse, a font with
+ * objRefCount > 0 -- one a Tcl_Obj still refers to -- is deliberately
+ * kept by Tk with a stale cacheHashPtr, and the guard that catches such
+ * a stale reference is "oldFontPtr->resourceRefCount == 0". Reading
+ * that field out of recycled memory gave a nonzero answer, so the guard
+ * did not fire and Tk_AllocFontFromObj went on to dereference the null
+ * cacheHashPtr:
+ *
+ *	wish: suicide: sys: trap: fault read addr=0x18
+ *
+ * (0x18 is clientData in Tcl_HashEntry, what Tcl_GetHashValue reads.)
+ * Every Tk test died this way on the first use of TkDefaultFont.
+ *
+ * tkUnixFont.c and tkWinFont.c both do platform cleanup alone; see
+ * their ReleaseFont.
+ */
 void
 TkpDeleteFont(TkFont *tkFontPtr)
 {
     P9Font *p9f = (P9Font *)tkFontPtr;
-    if (p9f->p9font) tkp9_closefont(p9f->p9font);
-    ckfree(p9f);
+
+    if (p9f->p9font) {
+	tkp9_closefont(p9f->p9font);
+	p9f->p9font = NULL;
+    }
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Every Tk test died on the first use of TkDefaultFont with

	wish: suicide: sys: trap: fault read addr=0x18

0x18 is clientData in Tcl_HashEntry, which is what Tcl_GetHashValue reads, so cacheHashPtr was null at tkFont.c:1159.  The instrumented run showed it came from the oldFontPtr->cacheHashPtr branch, with the font cache empty (numEntries 0) -- a TkFont that was not in the cache, yet had a nonzero resourceRefCount.

The Plan 9 backend's TkpDeleteFont did ckfree(p9f).  It must not: the struct belongs to generic Tk, which frees it in Tk_FreeFont immediately after the hook returns, reading objRefCount in between --

	TkpDeleteFont(fontPtr);
	if (fontPtr->objRefCount == 0) {
	    ckfree(fontPtr);
	}

-- so that read was already of freed memory and the ckfree a double free.  Worse, Tk deliberately keeps a font whose objRefCount is still positive, leaving it with a stale cacheHashPtr, and relies on "oldFontPtr->resourceRefCount == 0" to detect such a stale reference later.  Read out of recycled memory that field came back nonzero, the guard did not fire, and Tk_AllocFontFromObj dereferenced the null.

tkUnixFont.c and tkWinFont.c both release platform resources only; see their ReleaseFont.  This now does the same, and nulls p9font so a repeated call is harmless.

The tkFont.c diagnostic stays for one more build to confirm it goes quiet, and comes out next.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs