### PR TITLE
libap: isatty must follow the descriptor across dup2 and exec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,8 @@ itself are `bool-test.c`, `bitfield-test.c`, `compound-assign-test.c`,
 `compound-literal-test.c`, `designated-init-test.c`, `charptr-test.c`,
 `rol64-test.c` and `u64float-test.c`, and for libap `locale-test.c`,
 `sigset-test.c`, `posix-spawn-test.c`, `limits-test.c`,
-`format-arg-test.c`, `unget-pipe-test.c` and `stdio-test.c`. `sys/src/ape/lib/libressl/test/` is separate: it is
+`format-arg-test.c`, `unget-pipe-test.c`, `isatty-test.c` and
+`stdio-test.c`. `sys/src/ape/lib/libressl/test/` is separate: it is
 upstream's own ML-KEM and SHA-3 vectors, run by `mk test` there.
 
 Beyond that, testing is still mostly ad-hoc — compile a program under
@@ -818,6 +819,45 @@ halves of the m4 line this came from — printf's `%*.*s` with a zero width
 and a negative precision, and the `ARG_STR` idiom (a comma expression in
 the second arm of a conditional, passed to a variadic function). Both
 were suspects; only the library was at fault.
+
+### isatty must follow the descriptor, across dup2 and exec
+
+APE caches the answer in `_fdinfo[fd].flags` as `FD_ISTTY`, and the flag
+travels across an exec in the `$_fdinfo` environment variable.
+`sfdinit()` in `plan9/_fdinfo.c` restored the inherited value and then
+only ever OR'd `FD_ISTTY` back in from the real descriptor -- it never
+cleared it:
+
+```c
+fi->flags = fl;			/* inherited, may say ISTTY */
+if(_isatty(fd))
+	fi->flags |= FD_ISTTY;	/* sets, never clears */
+```
+
+So a descriptor that was the console in the parent and a pipe in the
+child kept `FD_ISTTY`, and `isatty()` lied. Note `readprocfdinit()`
+gets this right -- it rebuilds the flags from `/proc/$pid/fd` -- and
+then `sfdinit()` runs afterwards and overwrites its work.
+
+Tcl decides whether it is interactive with `isatty(0)`
+(`tclMain.c:365`). Tk's test suite drives a child `wish` over a pipe, so
+the child believed it had a terminal and wrote its `"% "` prompt into
+the pipe the parent was reading results from:
+
+```
+Error in startup script: unexpected output from background
+process: "% foo"
+```
+
+which names neither isatty nor the pipe. The descriptor is the
+authority and now wins in both directions.
+
+Covered by `sys/lib/tests/isatty-test.c`, whose three cases -- a pipe, a
+pipe moved onto descriptor 0 by dup2, and the same across an exec --
+fail independently. Only the third involves `$_fdinfo`, so it is the
+one that was broken; run it from an interactive shell, where descriptor
+0 really is the console, or the inherited flag is absent and the bug
+cannot reproduce.
 
 ### Three lines of flex, and three stdio bugs behind them
 

--- a/sys/lib/tests/isatty-test.c
+++ b/sys/lib/tests/isatty-test.c
@@ -1,0 +1,140 @@
+/*
+ * isatty must follow the descriptor, including across dup2 and exec.
+ *
+ * APE caches the answer in _fdinfo[fd].flags as FD_ISTTY, and the flag
+ * is inherited across an exec through the $_fdinfo environment
+ * variable. sfdinit() in plan9/_fdinfo.c restored that inherited value
+ * and then only ever OR'd FD_ISTTY back in from the real descriptor --
+ * it never cleared it. So a descriptor that was the console in the
+ * parent and a pipe in the child kept FD_ISTTY, and isatty() lied.
+ *
+ * Tcl decides whether it is interactive with isatty(0)
+ * (tclMain.c:365). Tk's test suite drives a child wish over a pipe, so
+ * the child believed it had a terminal and wrote its "% " prompt into
+ * the pipe, where the parent was reading results:
+ *
+ *	Error in startup script: unexpected output from background
+ *	process: "% foo"
+ *
+ * Nothing about that names isatty, or stdio, or even Tk.
+ *
+ * The three cases below are the three places the answer can go wrong,
+ * and they fail independently: a plain pipe, a pipe moved onto
+ * descriptor 0 by dup2, and the same across an exec -- which is the one
+ * that was broken, and the only one $_fdinfo is involved in.
+ *
+ * Correct on gcc, which is where the expected values come from.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+#define RESULT	"/tmp/isatty-test.out"
+
+static int failures;
+
+static void
+check(const char *what, int got, int want)
+{
+	if(got == want){
+		printf("PASS %s: isatty = %d\n", what, got);
+	}else{
+		printf("FAIL %s: isatty = %d, want %d\n", what, got, want);
+		failures++;
+	}
+}
+
+/*
+ * The child half: re-executed with one argument, it reports isatty(0)
+ * for whatever descriptor 0 it was given. Writing to a file rather than
+ * stdout because stdout is where the harness prints, and because the
+ * point of the exercise is that descriptor 0 is a pipe.
+ */
+static int
+child_main(void)
+{
+	FILE *f;
+
+	f = fopen(RESULT, "w");
+	if(f == NULL)
+		return 2;
+	fprintf(f, "%d\n", isatty(0));
+	fclose(f);
+	return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+	int p[2], pid, status, fd0, r;
+	FILE *f;
+
+	if(argc > 1 && strcmp(argv[1], "--child") == 0)
+		return child_main();
+
+	/* 1. A pipe is not a terminal. */
+	if(pipe(p) < 0){
+		printf("FAIL pipe failed\n");
+		return 1;
+	}
+	check("pipe read end", isatty(p[0]), 0);
+	check("pipe write end", isatty(p[1]), 0);
+
+	/*
+	 * 2. Still not a terminal after being moved onto descriptor 0.
+	 * Save the real descriptor 0 first so the rest of the test, and
+	 * anything after it, still has one.
+	 */
+	fd0 = dup(0);
+	if(fd0 < 0){
+		printf("FAIL dup(0) failed\n");
+		return 1;
+	}
+	if(dup2(p[0], 0) < 0){
+		printf("FAIL dup2 onto 0 failed\n");
+		return 1;
+	}
+	check("pipe dup2'd onto stdin", isatty(0), 0);
+
+	/*
+	 * 3. And still not a terminal on the far side of an exec. This
+	 * is the case $_fdinfo carries the stale flag through.
+	 */
+	fflush(stdout);
+	if((pid = fork()) < 0){
+		printf("FAIL fork failed\n");
+		return 1;
+	}
+	if(pid == 0){
+		execl(argv[0], argv[0], "--child", (char *)NULL);
+		_exit(3);
+	}
+	if(waitpid(pid, &status, 0) < 0 || status != 0){
+		printf("FAIL exec'd child: status %#x\n", status);
+		failures++;
+	}else{
+		f = fopen(RESULT, "r");
+		if(f == NULL || fscanf(f, "%d", &r) != 1){
+			printf("FAIL exec'd child wrote no result\n");
+			failures++;
+			if(f != NULL)
+				fclose(f);
+		}else{
+			fclose(f);
+			check("pipe on stdin across exec", r, 0);
+		}
+	}
+
+	/* Put descriptor 0 back. */
+	dup2(fd0, 0);
+	close(fd0);
+	close(p[0]);
+	close(p[1]);
+	remove(RESULT);
+
+	printf("%d failure(s)\n", failures);
+	return failures;
+}

--- a/sys/src/ape/lib/ap/plan9/_fdinfo.c
+++ b/sys/src/ape/lib/ap/plan9/_fdinfo.c
@@ -120,8 +120,29 @@ sfdinit(int usedproc, char *s, char *se)
 				continue;	/* should probably ignore all of $_fdinit */
 			fi->flags = fl;
 			fi->oflags = ofl;
+			/*
+			 * The descriptor itself is the authority on
+			 * whether it is a terminal, and it has to win
+			 * in both directions. fl is inherited through
+			 * $_fdinfo across an exec, so a descriptor that
+			 * was the console in the parent and is a pipe
+			 * in the child arrives here still carrying
+			 * FD_ISTTY -- and this used to only ever OR the
+			 * flag in, never clear it.
+			 *
+			 * Tcl asks isatty(0) to decide whether it is
+			 * interactive (tclMain.c:365). Tk's test suite
+			 * drives a child wish over a pipe, so the child
+			 * believed it had a terminal and printed its
+			 * "% " prompt into the pipe:
+			 *
+			 *	unexpected output from background
+			 *	process: "% foo"
+			 */
 			if(_isatty(fd))
 				fi->flags |= FD_ISTTY;
+			else
+				fi->flags &= ~FD_ISTTY;
 		}
 	}
 

--- a/sys/src/external/tk/generic/tkFont.c
+++ b/sys/src/external/tk/generic/tkFont.c
@@ -13,10 +13,6 @@
 
 #include "tkInt.h"
 #include "tkFont.h"
-
-/* APExp diagnostic (temporary) -- see Tk_AllocFontFromObj below. */
-#include <stdio.h>
-#include <stdint.h>
 #if defined(MAC_OSX_TK)
 #include "tkMacOSXInt.h"    /* Defines TK_DRAW_IN_CONTEXT */
 #endif
@@ -1160,46 +1156,6 @@ Tk_AllocFontFromObj(
 	cacheHashPtr = Tcl_CreateHashEntry(&fiPtr->fontCache,
 		Tcl_GetString(objPtr), &isNew);
     }
-    /*
-     * APExp diagnostic -- temporary, remove once the wish crash is
-     * understood. cacheHashPtr is null here on every Tk test:
-     *
-     *	wish: suicide: sys: trap: fault read addr=0x18
-     *
-     * 0x18 is clientData in Tcl_HashEntry, which is what
-     * Tcl_GetHashValue reads. Fires only in the broken case, and only
-     * just before the fault, so it costs nothing when things work.
-     */
-    if (cacheHashPtr == NULL) {
-	fprintf(stderr, "APExp: Tk_AllocFontFromObj: cacheHashPtr is NULL\n");
-	fprintf(stderr, "  font        = \"%s\"\n", Tcl_GetString(objPtr));
-	fprintf(stderr, "  branch      = %s\n",
-		(oldFontPtr != NULL) ? "oldFontPtr->cacheHashPtr"
-				     : "Tcl_CreateHashEntry");
-	fprintf(stderr, "  oldFontPtr  = %llx\n",
-		(unsigned long long) (uintptr_t) oldFontPtr);
-	fprintf(stderr, "  fiPtr       = %llx\n",
-		(unsigned long long) (uintptr_t) fiPtr);
-	fprintf(stderr, "  isNew       = %d\n", isNew);
-	fprintf(stderr, "  fontCache.buckets    = %llx\n",
-		(unsigned long long) (uintptr_t) fiPtr->fontCache.buckets);
-	fprintf(stderr, "  fontCache.numBuckets = %lld\n",
-		(long long) fiPtr->fontCache.numBuckets);
-	fprintf(stderr, "  fontCache.numEntries = %lld\n",
-		(long long) fiPtr->fontCache.numEntries);
-	fprintf(stderr, "  fontCache.keyType    = %d\n",
-		fiPtr->fontCache.keyType);
-	fprintf(stderr, "  fontCache.findProc   = %llx\n",
-		(unsigned long long) (uintptr_t) fiPtr->fontCache.findProc);
-	fprintf(stderr, "  fontCache.createProc = %llx\n",
-		(unsigned long long) (uintptr_t) fiPtr->fontCache.createProc);
-	fprintf(stderr, "  fontCache.typePtr    = %llx\n",
-		(unsigned long long) (uintptr_t) fiPtr->fontCache.typePtr);
-	fprintf(stderr, "  sizeof(Tcl_HashTable)=%d sizeof(Tcl_HashEntry)=%d\n",
-		(int) sizeof(Tcl_HashTable), (int) sizeof(Tcl_HashEntry));
-	fflush(stderr);
-    }
-
     firstFontPtr = (TkFont *)Tcl_GetHashValue(cacheHashPtr);
     for (fontPtr = firstFontPtr; (fontPtr != NULL);
 	    fontPtr = fontPtr->nextPtr) {


### PR DESCRIPTION
APE caches the answer as FD_ISTTY in _fdinfo, and the flag is inherited across an exec through $_fdinfo.  sfdinit() restored that inherited value and then only ever OR'd FD_ISTTY back in from the real descriptor, never clearing it -- so a descriptor that was the console in the parent and a pipe in the child kept FD_ISTTY and isatty() lied. readprocfdinit() gets this right by rebuilding from /proc/$pid/fd, and sfdinit() then ran afterwards and overwrote its work.

Tcl decides whether it is interactive with isatty(0) (tclMain.c:365), and Tk's test suite drives a child wish over a pipe, so the child believed it had a terminal and wrote its "% " prompt into the pipe the parent was reading results from:

	unexpected output from background process: "% foo"

Also drops the tkFont.c diagnostic, which stayed silent once TkpDeleteFont stopped freeing the struct, confirming that fix.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs