### PR TITLE
tests: reduce Tk's childTkProcess to a runnable script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,9 @@ cd sys/lib/tests && pcc -o bool-test bool-test.c && ./bool-test
 
 The convention: print `PASS`/`FAIL` per case, exit with the number of
 failures, and open with a comment saying which bug the test came from
-and what it cost. Anything testing a language or library rule should be
+and what it cost. `tk-childproc-test.tcl` is the exception to the C
+convention -- it is a Tcl script, run with `wish`, because the thing it
+reproduces is Tk spawning a second Tk. Anything testing a language or library rule should be
 correct on gcc too — checking a new test against gcc first is how you
 find out whether the test or the tree is wrong, and it has caught both.
 

--- a/sys/lib/tests/tk-childproc-test.tcl
+++ b/sys/lib/tests/tk-childproc-test.tcl
@@ -1,0 +1,91 @@
+# Can a running wish spawn a second wish and talk to it over a pipe?
+#
+#	wish tk-childproc-test.tcl > /tmp/p.out 2>&1; echo "status=$?"
+#	cat /tmp/p.out
+#
+# This is Tk's own childTkProcess (tests/testutils.tcl:382) reduced to
+# its essentials. constraints.tcl:42 calls it, main.tcl sources
+# constraints.tcl, and every Tk test file sources main.tcl -- so if this
+# cannot work, no Tk test file runs at all, whatever the tests
+# themselves would do.
+#
+# The symptom being chased: every Tk test file exits with status 1 and
+# produces no output whatsoever, not even on stderr. A parent that dies
+# of SIGPIPE writing to a child that has already gone would look exactly
+# like that, since SIGPIPE's default action terminates without a
+# message.
+#
+# Already ruled out, by running these from the shell:
+#
+#	wish -name tktest2 < /tmp/c.tcl	     -> prints foo, status 0
+#	printf ... | wish -name tktest2	     -> prints foo, status 0
+#
+# so a second wish reading a script from a pipe is fine on its own. What
+# is untested, and what this covers, is doing it while a parent wish is
+# already running and holding the rio window.
+#
+# Every step flushes, so the last MARK printed is where it stopped even
+# if the process dies without a word.
+
+proc mark {msg} {
+    puts "MARK $msg"
+    flush stdout
+}
+
+mark "parent start"
+mark "parent is [info nameofexecutable]"
+
+# Same shape as childTkProcess create, minus the unique-appname counter.
+if {[catch {
+    set fd [open "|[list [info nameofexecutable] -name tkchild]" r+]
+} err]} {
+    mark "open failed: $err"
+    exit 1
+}
+mark "opened"
+
+# Non-blocking with a timeout, so a child that never answers reports
+# rather than hanging the test.
+fconfigure $fd -blocking 0
+
+set ::state waiting
+set ::reply ""
+
+proc onreadable {f} {
+    if {[gets $f line] >= 0} {
+	set ::reply $line
+	set ::state got
+    } elseif {[eof $f]} {
+	set ::state eof
+    }
+}
+fileevent $fd readable [list onreadable $fd]
+
+if {[catch {
+    puts $fd "puts foo; flush stdout"
+    flush $fd
+} err]} {
+    mark "write to child failed: $err"
+    exit 1
+}
+mark "wrote"
+
+after 15000 {if {$::state eq "waiting"} {set ::state timeout}}
+vwait ::state
+
+switch -- $::state {
+    got {
+	if {$::reply eq "foo"} {
+	    mark "child said: \"$::reply\" -- CORRECT"
+	} else {
+	    mark "child said: \"$::reply\" -- WRONG, expected \"foo\""
+	}
+    }
+    eof     { mark "child closed the pipe without replying" }
+    timeout { mark "child never replied (15s timeout)" }
+}
+
+catch {puts $fd exit}
+catch {close $fd}
+mark "done"
+exit 0


### PR DESCRIPTION
Every Tk test file exits 1 with no output at all, not even on stderr. constraints.tcl:42 runs childTkProcess create, main.tcl sources constraints.tcl, and every test file sources main.tcl, so this gates the whole suite rather than any one test.

Running a second wish from the shell with its script on a pipe works and exits 0, so that much is not the problem.  What is untested is doing it while a parent wish is already running and holding the rio window, which is what the harness does and what this reproduces: same shape as testutils.tcl:382, non-blocking with a 15s timeout so a child that never answers reports instead of hanging, and a flush after every step so the last MARK printed says where it stopped even if the process dies without a word.

A parent dying of SIGPIPE writing to a child that has already gone would produce exactly the observed status 1 and silence, since SIGPIPE's default action terminates without a message -- but that is the hypothesis this is meant to test, not a conclusion.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs