### PR TITLE
tests: let tk-childproc-test choose the child interpreter

### DIFF
--- a/sys/lib/tests/tk-childproc-test.tcl
+++ b/sys/lib/tests/tk-childproc-test.tcl
@@ -1,7 +1,18 @@
 # Can a running wish spawn a second wish and talk to it over a pipe?
 #
-#	wish tk-childproc-test.tcl > /tmp/p.out 2>&1; echo "status=$?"
-#	cat /tmp/p.out
+#	wish   tk-childproc-test.tcl [child-interpreter]
+#	tclsh  tk-childproc-test.tcl [child-interpreter]
+#
+# The child defaults to whatever is running the script, so
+#
+#	wish  tk-childproc-test.tcl		wish parent,  wish child
+#	tclsh tk-childproc-test.tcl		tclsh parent, tclsh child
+#	tclsh tk-childproc-test.tcl /bin/wish	tclsh parent, wish child
+#	wish  tk-childproc-test.tcl /bin/tclsh	wish parent,  tclsh child
+#
+# which is what separates "the child wish cannot start when spawned from
+# a Tcl pipe" from "the child wish cannot start while another wish holds
+# the rio window".
 #
 # This is Tk's own childTkProcess (tests/testutils.tcl:382) reduced to
 # its essentials. constraints.tcl:42 calls it, main.tcl sources
@@ -35,9 +46,16 @@ proc mark {msg} {
 mark "parent start"
 mark "parent is [info nameofexecutable]"
 
+# Which interpreter to spawn. Defaults to our own, as childTkProcess does.
+set child [info nameofexecutable]
+if {[llength $argv] > 0} {
+    set child [lindex $argv 0]
+}
+mark "child will be $child"
+
 # Same shape as childTkProcess create, minus the unique-appname counter.
 if {[catch {
-    set fd [open "|[list [info nameofexecutable] -name tkchild]" r+]
+    set fd [open "|[list $child -name tkchild]" r+]
 } err]} {
     mark "open failed: $err"
     exit 1


### PR DESCRIPTION
The first run showed wish->wish hanging (child never replies, no EOF, so it is alive and stuck) while tclsh->tclsh works.  That does not isolate the fault, because [info nameofexecutable] means the tclsh run spawned a tclsh child rather than a wish -- so the two runs differ in both the parent and the child.

An optional argument now names the child, which separates the two:

	tclsh tk-childproc-test.tcl /bin/wish	tclsh parent, wish child
	wish  tk-childproc-test.tcl /bin/tclsh	wish parent,  tclsh child

If the tclsh->wish case works, a second wish is only blocked when another wish already holds the rio window.  If it hangs, the child wish cannot start from a Tcl pipe at all, independent of graphics.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs