### PR TITLE
tests: make tk-childproc-test repeat and tally

### DIFF
--- a/sys/lib/tests/tk-childproc-test.tcl
+++ b/sys/lib/tests/tk-childproc-test.tcl
@@ -1,7 +1,7 @@
 # Can a running wish spawn a second wish and talk to it over a pipe?
 #
-#	wish   tk-childproc-test.tcl [child-interpreter]
-#	tclsh  tk-childproc-test.tcl [child-interpreter]
+#	wish   tk-childproc-test.tcl [child-interpreter] [repeats]
+#	tclsh  tk-childproc-test.tcl [child-interpreter] [repeats]
 #
 # The child defaults to whatever is running the script, so
 #
@@ -10,9 +10,10 @@
 #	tclsh tk-childproc-test.tcl /bin/wish	tclsh parent, wish child
 #	wish  tk-childproc-test.tcl /bin/tclsh	wish parent,  tclsh child
 #
-# which is what separates "the child wish cannot start when spawned from
-# a Tcl pipe" from "the child wish cannot start while another wish holds
-# the rio window".
+# and a repeat count spawns that many children in turn, reporting how
+# many answered:
+#
+#	wish tk-childproc-test.tcl /bin/wish 20
 #
 # This is Tk's own childTkProcess (tests/testutils.tcl:382) reduced to
 # its essentials. constraints.tcl:42 calls it, main.tcl sources
@@ -20,20 +21,18 @@
 # cannot work, no Tk test file runs at all, whatever the tests
 # themselves would do.
 #
-# The symptom being chased: every Tk test file exits with status 1 and
-# produces no output whatsoever, not even on stderr. A parent that dies
-# of SIGPIPE writing to a child that has already gone would look exactly
-# like that, since SIGPIPE's default action terminates without a
-# message.
+# What is known so far. Each side works alone: tclsh->wish and
+# wish->tclsh both answer correctly, as does tclsh->tclsh. Only
+# wish->wish misbehaves, and it is **intermittent** -- one run timed out
+# with the child alive and silent, a later identical run answered
+# correctly. So this is a race between two graphical processes, not a
+# resource that is simply unavailable.
 #
-# Already ruled out, by running these from the shell:
-#
-#	wish -name tktest2 < /tmp/c.tcl	     -> prints foo, status 0
-#	printf ... | wish -name tktest2	     -> prints foo, status 0
-#
-# so a second wish reading a script from a pipe is fine on its own. What
-# is untested, and what this covers, is doing it while a parent wish is
-# already running and holding the rio window.
+# tkp9_open (tk/plan9/tkPlan9DrawImpl.c:64) takes three things that
+# belong to one rio window: initdraw's window image, /dev/mouse, and
+# /dev/cons for the keyboard. Two wish processes in the same window
+# contend for all three, which is the leading explanation -- but a race
+# is what wants measuring, so count rather than sample.
 #
 # Every step flushes, so the last MARK printed is where it stopped even
 # if the process dies without a word.
@@ -43,67 +42,79 @@ proc mark {msg} {
     flush stdout
 }
 
+# One round: spawn a child, ask it to say foo, wait up to 15s.
+# Returns ok, wrong, eof, timeout, openfail or writefail.
+proc oneround {child} {
+    global state reply fd
+
+    set state waiting
+    set reply ""
+
+    if {[catch {set fd [open "|[list $child -name tkchild]" r+]} err]} {
+	mark "open failed: $err"
+	return openfail
+    }
+
+    fconfigure $fd -blocking 0
+    fileevent $fd readable {
+	if {[gets $fd line] >= 0} {
+	    set reply $line
+	    set state got
+	} elseif {[eof $fd]} {
+	    set state eof
+	}
+    }
+
+    if {[catch {puts $fd "puts foo; flush stdout"; flush $fd} err]} {
+	mark "write to child failed: $err"
+	catch {close $fd}
+	return writefail
+    }
+
+    set timer [after 15000 {if {$state eq "waiting"} {set state timeout}}]
+    vwait state
+    after cancel $timer
+
+    catch {puts $fd exit}
+    catch {close $fd}
+
+    switch -- $state {
+	got     { if {$reply eq "foo"} { return ok } else { return wrong } }
+	eof     { return eof }
+	default { return timeout }
+    }
+}
+
 mark "parent start"
 mark "parent is [info nameofexecutable]"
 
-# Which interpreter to spawn. Defaults to our own, as childTkProcess does.
 set child [info nameofexecutable]
 if {[llength $argv] > 0} {
     set child [lindex $argv 0]
 }
-mark "child will be $child"
-
-# Same shape as childTkProcess create, minus the unique-appname counter.
-if {[catch {
-    set fd [open "|[list $child -name tkchild]" r+]
-} err]} {
-    mark "open failed: $err"
-    exit 1
+set reps 1
+if {[llength $argv] > 1} {
+    set reps [lindex $argv 1]
 }
-mark "opened"
+mark "child will be $child, $reps round(s)"
 
-# Non-blocking with a timeout, so a child that never answers reports
-# rather than hanging the test.
-fconfigure $fd -blocking 0
+foreach r {ok wrong eof timeout openfail writefail} {
+    set tally($r) 0
+}
 
-set ::state waiting
-set ::reply ""
+for {set i 1} {$i <= $reps} {incr i} {
+    set result [oneround $child]
+    incr tally($result)
+    mark "round $i: $result"
+}
 
-proc onreadable {f} {
-    if {[gets $f line] >= 0} {
-	set ::reply $line
-	set ::state got
-    } elseif {[eof $f]} {
-	set ::state eof
+puts ""
+puts "child=$child rounds=$reps"
+foreach r {ok wrong eof timeout openfail writefail} {
+    if {$tally($r) > 0} {
+	puts "  $r: $tally($r)"
     }
 }
-fileevent $fd readable [list onreadable $fd]
+flush stdout
 
-if {[catch {
-    puts $fd "puts foo; flush stdout"
-    flush $fd
-} err]} {
-    mark "write to child failed: $err"
-    exit 1
-}
-mark "wrote"
-
-after 15000 {if {$::state eq "waiting"} {set ::state timeout}}
-vwait ::state
-
-switch -- $::state {
-    got {
-	if {$::reply eq "foo"} {
-	    mark "child said: \"$::reply\" -- CORRECT"
-	} else {
-	    mark "child said: \"$::reply\" -- WRONG, expected \"foo\""
-	}
-    }
-    eof     { mark "child closed the pipe without replying" }
-    timeout { mark "child never replied (15s timeout)" }
-}
-
-catch {puts $fd exit}
-catch {close $fd}
-mark "done"
-exit 0
+exit [expr {$tally(ok) == $reps ? 0 : 1}]


### PR DESCRIPTION
wish->wish is intermittent: one run timed out with the child alive and silent, an identical later run answered correctly.  Each side works alone -- tclsh->wish, wish->tclsh and tclsh->tclsh all answer -- so this is a race between two graphical processes rather than a resource that is simply unavailable, and sampling one run at a time cannot measure it.

A repeat count now spawns that many children in turn and reports how many answered:

	wish tk-childproc-test.tcl /bin/wish 20

tkp9_open (tk/plan9/tkPlan9DrawImpl.c:64) takes three things belonging to one rio window -- initdraw's window image, /dev/mouse, and /dev/cons for the keyboard -- and two wish processes in the same window contend for all three.  That is the leading explanation, and the failure rate is what will confirm or kill it.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs