### PR TITLE
tests: tk-runtest must clear argv before sourcing

### DIFF
--- a/sys/lib/tests/tk-runtest.tcl
+++ b/sys/lib/tests/tk-runtest.tcl
@@ -50,6 +50,19 @@ if {[llength $argv] < 1} {
     _real_exit 2
 }
 set testfile [lindex $argv 0]
+
+# Clear argv before sourcing. "package require tcltest", which the test
+# file does on its first line, parses ::argv as tcltest options -- so
+# leaving the file name there makes tcltest report
+#
+#	missing value for option <path>
+#
+# and exit 1 (tcltest.tcl:1545), which is not what happens under a plain
+# "wish bell.test", where argv is empty. Clearing it keeps this wrapper
+# faithful to the real invocation.
+set argv {}
+set argc 0
+
 mark "sourcing $testfile"
 
 if {[catch {source $testfile} err]} {


### PR DESCRIPTION
The wrapper passed the test file name in argv, and the test file's first line is "package require tcltest", which parses ::argv as tcltest options.  So tcltest reported

	missing value for option <path>

and exited 1 (tcltest.tcl:1545) -- a failure of the wrapper, not of the test.  A plain "wish bell.test" leaves argv empty, so clearing it keeps this faithful to the real invocation.

The errorInfo that run reported, "child process exited abnormally" from "exec ps -e | grep gnome-session", is a red herring: library/scaling.tcl runs that inside a catch to detect a desktop environment, so failing on Plan 9 is expected and the message is only residue standing in ::errorInfo at exit.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs