### PR TITLE
tests: trace every source in tk-runtest

### DIFF
--- a/sys/lib/tests/tk-runtest.tcl
+++ b/sys/lib/tests/tk-runtest.tcl
@@ -43,6 +43,23 @@ proc exit {{code 0}} {
     _real_exit $code
 }
 
+# Trace every file the test pulls in. The process dies part way through
+# sourcing bell.test without calling exit and without raising an error,
+# so the last "source begin" without a matching "source end" is the file
+# it died in.
+rename source _real_source
+proc source {args} {
+    set f [lindex $args end]
+    mark "source begin: $f"
+    set code [catch {uplevel 1 [linsert $args 0 _real_source]} result options]
+    if {$code == 0} {
+	mark "source end: $f"
+	return $result
+    }
+    mark "source FAILED: $f -- $result"
+    return -options $options $result
+}
+
 mark "start, parent is [info nameofexecutable]"
 
 if {[llength $argv] < 1} {


### PR DESCRIPTION
With argv cleared, bell.test now gets as far as "MARK sourcing bell.test" and the process then dies: no exit mark, so Tcl's exit was never called; no error mark, so nothing catchable was raised; status 1 and not a word on stderr.  That is a C-level termination part way through the source.

Wrapping source reports each file as it is entered and left, so the last "source begin" without a matching "source end" names the file it dies in -- main.tcl, testutils.tcl or constraints.tcl, which is as far as bell.test gets before its own tests.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs