### PR TITLE
tests: isolate constraints.tcl's widget operations

### DIFF
--- a/sys/lib/tests/tk-widget-test.tcl
+++ b/sys/lib/tests/tk-widget-test.tcl
@@ -1,0 +1,73 @@
+# The widget operations from Tk's constraints.tcl, one at a time.
+#
+#	wish tk-widget-test.tcl
+#
+# Every Tk test file dies inside constraints.tcl. The source trace in
+# tk-runtest.tcl put it there: bell.test -> main.tcl -> testutils.tcl
+# (completes) -> constraints.tcl (never returns). The process dies at
+# the C level -- Tcl's exit is never called, nothing catchable is
+# raised, status 1, and not a word on stderr.
+#
+# constraints.tcl's first half is display and windowing-system queries
+# and the childTkProcess handshake, which is fixed and verified at 20/20
+# by tk-childproc-test.tcl. Its second half is the first thing in the
+# entire chain that builds real widgets and renders text, which is the
+# Plan 9 draw and font backend doing actual work:
+#
+#	entry .e -width 0 -font {Helvetica -12} -bd 1 -highlightthickness 1
+#	.e insert end a.bcd
+#	winfo reqwidth .e / winfo reqheight .e
+#	text .t -width 80 -height 20 -font {Times -14} -bd 1
+#	pack .t
+#	.t insert end "This is\na dot."
+#	update
+#	.t bbox 1.3 / .t bbox 2.5
+#
+# This runs exactly those, with a flushed mark between each, so the last
+# mark printed names the operation that kills wish.
+#
+# The expected values are Tk's own and will not match a Plan 9 font;
+# constraints.tcl only uses them to decide whether the "fonts"
+# constraint holds, so a mismatch is a skipped test, not a failure.
+# What matters here is surviving the calls.
+
+proc mark {m} {
+    puts "MARK $m"
+    flush stdout
+}
+
+proc try {label script} {
+    mark "$label ..."
+    if {[catch {uplevel 1 $script} result]} {
+	mark "$label RAISED: $result"
+	return ""
+    }
+    if {$result eq ""} {
+	mark "$label ok"
+    } else {
+	mark "$label ok -> $result"
+    }
+    return $result
+}
+
+mark "start, [info nameofexecutable]"
+mark "windowingsystem is [tk windowingsystem]"
+
+try "destroy .e (may not exist)"	{destroy .e}
+try "create entry"			{entry .e -width 0 -font {Helvetica -12} -bd 1 -highlightthickness 1}
+try "insert into entry"			{.e insert end a.bcd}
+try "winfo reqwidth .e"			{winfo reqwidth .e}
+try "winfo reqheight .e"		{winfo reqheight .e}
+try "destroy .e"			{destroy .e}
+
+try "destroy .t (may not exist)"	{destroy .t}
+try "create text"			{text .t -width 80 -height 20 -font {Times -14} -bd 1}
+try "pack .t"				{pack .t}
+try "insert into text"			{.t insert end "This is\na dot."}
+try "update"				{update}
+try "bbox 1.3"				{.t bbox 1.3}
+try "bbox 2.5"				{.t bbox 2.5}
+try "destroy .t"			{destroy .t}
+
+mark "all done"
+exit 0


### PR DESCRIPTION
The source trace localised the death: bell.test -> main.tcl ->
testutils.tcl (completes) -> constraints.tcl (never returns), with no exit mark, nothing catchable raised, status 1 and silence.  So it is a C-level termination inside constraints.tcl.

That file's first half is display queries and the childTkProcess handshake, which tk-childproc-test.tcl now passes 20/20.  Its second half builds an entry and a text widget, inserts text, packs, updates and asks for bboxes -- the first thing in the whole chain that makes the Plan 9 draw and font backend measure and render anything.

tk-widget-test.tcl runs exactly those calls with a flushed mark between each, so the last mark names the one that kills wish.  Tk's expected pixel values will not match a Plan 9 font, but constraints.tcl only uses them to set the "fonts" constraint -- surviving the calls is the point.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs