### PR TITLE
tests: separate font operations from widget creation

### DIFF
--- a/sys/lib/tests/tk-widget-test.tcl
+++ b/sys/lib/tests/tk-widget-test.tcl
@@ -53,6 +53,37 @@ proc try {label script} {
 mark "start, [info nameofexecutable]"
 mark "windowingsystem is [tk windowingsystem]"
 
+# --- Pure font operations, no widgets -------------------------------
+#
+# These exercise TkpGetFontFromAttributes, tkp9_openfont and
+# tkp9_measuretext without creating a window, a cursor, a 3D border or
+# a GC. If one of these dies, it is the font backend; if they all pass
+# and "create entry" still dies, the font path is exonerated and the
+# fault is in one of the other things a widget allocates.
+
+try "font families"			{font families}
+try "font measure Helvetica"		{font measure {Helvetica -12} "abc"}
+try "font metrics Helvetica"		{font metrics {Helvetica -12}}
+try "font measure Times"		{font measure {Times -14} "abc"}
+try "font actual Helvetica"		{font actual {Helvetica -12}}
+
+# --- Widgets, simplest first ----------------------------------------
+#
+# A frame allocates a border and colours but no font; a label adds a
+# font; an entry adds a cursor and an insertion cursor. Whichever is
+# the first to die names what is at fault.
+
+try "create frame"			{frame .f}
+try "destroy frame"			{destroy .f}
+try "create label"			{label .l -text hi}
+try "destroy label"			{destroy .l}
+try "create plain entry"		{entry .e2}
+try "destroy plain entry"		{destroy .e2}
+try "create entry with font"		{entry .e3 -font {Helvetica -12}}
+try "destroy entry with font"		{destroy .e3}
+
+# --- Exactly what constraints.tcl does ------------------------------
+
 try "destroy .e (may not exist)"	{destroy .e}
 try "create entry"			{entry .e -width 0 -font {Helvetica -12} -bd 1 -highlightthickness 1}
 try "insert into entry"			{.e insert end a.bcd}


### PR DESCRIPTION
tk-widget-test.tcl narrowed the death to a single line:

	MARK create entry ...
	<dies>

for "entry .e -width 0 -font {Helvetica -12} -bd 1 -highlightthickness 1", with no suicide message and no Broken process left behind.

Creating an entry allocates several things at once -- a font by attributes, a cursor, a 3D border with its colours, and a GC -- so the line alone does not say which.  The font path can now be exercised on its own with font measure/metrics/actual, which touch TkpGetFontFromAttributes, tkp9_openfont and tkp9_measuretext without a window; and the widgets are tried simplest first, frame (border and colours, no font) then label (adds a font) then a plain entry (adds cursors) then one with an explicit font.

Note tkp9_openfont cannot return nil -- it falls back to libdraw's global font when openfont fails -- so a missing
/lib/font/bit/pelm/unicode.9.font is not the explanation.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs