### PR TITLE
tk: instrument the font teardown, chasing the destroy-a-label death

### DIFF
--- a/sys/lib/tests/tk-widget-test.tcl
+++ b/sys/lib/tests/tk-widget-test.tcl
@@ -75,6 +75,8 @@ try "font actual Helvetica"		{font actual {Helvetica -12}}
 
 try "create frame"			{frame .f}
 try "destroy frame"			{destroy .f}
+try "create bare label"			{label .l0}
+try "destroy bare label"		{destroy .l0}
 try "create label"			{label .l -text hi}
 try "destroy label"			{destroy .l}
 try "create plain entry"		{entry .e2}

--- a/sys/src/external/tk/generic/tkFont.c
+++ b/sys/src/external/tk/generic/tkFont.c
@@ -13,6 +13,8 @@
 
 #include "tkInt.h"
 #include "tkFont.h"
+#include <stdio.h>
+#include <stdint.h>
 #if defined(MAC_OSX_TK)
 #include "tkMacOSXInt.h"    /* Defines TK_DRAW_IN_CONTEXT */
 #endif
@@ -1497,10 +1499,25 @@ Tk_FreeFont(
 	prevPtr->nextPtr = fontPtr->nextPtr;
     }
 
+    /* APExp diagnostic -- temporary. */
+    fprintf(stderr, "APExp: Tk_FreeFont about to TkpDeleteFont"
+	    " fontPtr=%llx objRefCount=%lld cacheHashPtr=%llx\n",
+	    (unsigned long long)(uintptr_t) fontPtr,
+	    (long long) fontPtr->objRefCount,
+	    (unsigned long long)(uintptr_t) fontPtr->cacheHashPtr);
+    fflush(stderr);
+
     TkpDeleteFont(fontPtr);
+
+    fprintf(stderr, "APExp: Tk_FreeFont back from TkpDeleteFont\n");
+    fflush(stderr);
+
     if (fontPtr->objRefCount == 0) {
 	ckfree(fontPtr);
     }
+
+    fprintf(stderr, "APExp: Tk_FreeFont done\n");
+    fflush(stderr);
 }
 
 /*

--- a/sys/src/external/tk/plan9/tkPlan9Font.c
+++ b/sys/src/external/tk/plan9/tkPlan9Font.c
@@ -18,6 +18,8 @@
  */
 
 #include "tkPlan9Int.h"
+#include <stdio.h>
+#include <stdint.h>
 #include "tkFont.h"
 
 /* ------------------------------------------------------------------ */
@@ -180,10 +182,19 @@ TkpDeleteFont(TkFont *tkFontPtr)
 {
     P9Font *p9f = (P9Font *)tkFontPtr;
 
+    /* APExp diagnostic -- temporary, chasing the destroy-a-label death. */
+    fprintf(stderr, "APExp: TkpDeleteFont enter tkFontPtr=%llx p9font=%llx\n",
+	    (unsigned long long)(uintptr_t) tkFontPtr,
+	    (unsigned long long)(uintptr_t) p9f->p9font);
+    fflush(stderr);
+
     if (p9f->p9font) {
 	tkp9_closefont(p9f->p9font);
 	p9f->p9font = NULL;
     }
+
+    fprintf(stderr, "APExp: TkpDeleteFont done\n");
+    fflush(stderr);
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
tk-widget-test.tcl narrowed it to one call.  All the font commands pass -- font families, measure, metrics, actual -- and a frame creates and destroys cleanly.  A label creates cleanly and then dies on destroy, with no suicide message and no Broken process.

The difference between a frame and a label is the font, so this instruments both ends of that teardown: Tk_FreeFont around its call to the hook, reporting fontPtr, objRefCount and cacheHashPtr, and TkpDeleteFont on entry and exit reporting the Plan 9 Font it is about to close.  Both temporary.

The test also tries a bare label before the one with -text, to separate the font from the text layout.

Noted in passing, and a separate bug: "font actual {Helvetica -12}" answers -family {Helvetica -12} -size 18.  TkpGetNativeFont is supposed to return NULL when the string is not a platform font name, so that Tk falls through to ParseFontNameObj and reads family and size; ours cannot fail, because tkp9_openfont falls back to the default face, so every specification is swallowed as a native name and the size is ignored.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs