### PR TITLE
tk: instrument DestroyButton, exonerate the font path

### DIFF
--- a/sys/src/external/tk/generic/tkButton.c
+++ b/sys/src/external/tk/generic/tkButton.c
@@ -14,6 +14,13 @@
 
 #include "tkInt.h"
 #include "tkButton.h"
+
+/* APExp diagnostic -- temporary, chasing the destroy-a-label death. */
+#include <stdio.h>
+#define BDBG(m) do { \
+	fprintf(stderr, "APExp: DestroyButton: %s\n", (m)); \
+	fflush(stderr); \
+} while (0)
 #include "default.h"
 
 typedef struct {
@@ -937,7 +944,9 @@ DestroyButton(
     TkButton *butPtr)		/* Info about button widget. */
 {
     butPtr->flags |= BUTTON_DELETED;
+    BDBG("enter");
     TkpDestroyButton(butPtr);
+    BDBG("after TkpDestroyButton");
 
     if (butPtr->flags & REDRAW_PENDING) {
 	Tcl_CancelIdleCall(TkpDisplayButton, butPtr);
@@ -948,7 +957,9 @@ DestroyButton(
      * Tk_FreeOptions handle all the standard option-related stuff.
      */
 
+    BDBG("before DeleteCommandFromToken");
     Tcl_DeleteCommandFromToken(butPtr->interp, butPtr->widgetCmd);
+    BDBG("after DeleteCommandFromToken");
     if (butPtr->textVarNamePtr != NULL) {
 	Tcl_UntraceVar2(butPtr->interp, Tcl_GetString(butPtr->textVarNamePtr),
 		NULL, TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS,
@@ -963,9 +974,11 @@ DestroyButton(
     if (butPtr->tristateImage != NULL) {
 	Tk_FreeImage(butPtr->tristateImage);
     }
+    BDBG("before normalTextGC");
     if (butPtr->normalTextGC != NULL) {
 	Tk_FreeGC(butPtr->display, butPtr->normalTextGC);
     }
+    BDBG("after normalTextGC");
     if (butPtr->activeTextGC != NULL) {
 	Tk_FreeGC(butPtr->display, butPtr->activeTextGC);
     }
@@ -975,22 +988,28 @@ DestroyButton(
     if (butPtr->stippleGC != NULL) {
 	Tk_FreeGC(butPtr->display, butPtr->stippleGC);
     }
+    BDBG("before gray bitmap");
     if (butPtr->gray != None) {
 	Tk_FreeBitmap(butPtr->display, butPtr->gray);
     }
+    BDBG("after gray bitmap");
     if (butPtr->copyGC != NULL) {
 	Tk_FreeGC(butPtr->display, butPtr->copyGC);
     }
+    BDBG("before textLayout");
     if (butPtr->textLayout != NULL) {
 	Tk_FreeTextLayout(butPtr->textLayout);
     }
+    BDBG("after textLayout");
     if (butPtr->selVarNamePtr != NULL) {
 	Tcl_UntraceVar2(butPtr->interp, Tcl_GetString(butPtr->selVarNamePtr),
 		NULL, TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS,
 		ButtonVarProc, butPtr);
     }
+    BDBG("before FreeConfigOptions");
     Tk_FreeConfigOptions(butPtr, butPtr->optionTable,
 	    butPtr->tkwin);
+    BDBG("after FreeConfigOptions");
     butPtr->tkwin = NULL;
     Tcl_EventuallyFree(butPtr, TCL_DYNAMIC);
 }

--- a/sys/src/external/tk/generic/tkFont.c
+++ b/sys/src/external/tk/generic/tkFont.c
@@ -1499,25 +1499,10 @@ Tk_FreeFont(
 	prevPtr->nextPtr = fontPtr->nextPtr;
     }
 
-    /* APExp diagnostic -- temporary. */
-    fprintf(stderr, "APExp: Tk_FreeFont about to TkpDeleteFont"
-	    " fontPtr=%llx objRefCount=%lld cacheHashPtr=%llx\n",
-	    (unsigned long long)(uintptr_t) fontPtr,
-	    (long long) fontPtr->objRefCount,
-	    (unsigned long long)(uintptr_t) fontPtr->cacheHashPtr);
-    fflush(stderr);
-
     TkpDeleteFont(fontPtr);
-
-    fprintf(stderr, "APExp: Tk_FreeFont back from TkpDeleteFont\n");
-    fflush(stderr);
-
     if (fontPtr->objRefCount == 0) {
 	ckfree(fontPtr);
     }
-
-    fprintf(stderr, "APExp: Tk_FreeFont done\n");
-    fflush(stderr);
 }
 
 /*

--- a/sys/src/external/tk/plan9/tkPlan9Font.c
+++ b/sys/src/external/tk/plan9/tkPlan9Font.c
@@ -182,19 +182,10 @@ TkpDeleteFont(TkFont *tkFontPtr)
 {
     P9Font *p9f = (P9Font *)tkFontPtr;
 
-    /* APExp diagnostic -- temporary, chasing the destroy-a-label death. */
-    fprintf(stderr, "APExp: TkpDeleteFont enter tkFontPtr=%llx p9font=%llx\n",
-	    (unsigned long long)(uintptr_t) tkFontPtr,
-	    (unsigned long long)(uintptr_t) p9f->p9font);
-    fflush(stderr);
-
     if (p9f->p9font) {
 	tkp9_closefont(p9f->p9font);
 	p9f->p9font = NULL;
     }
-
-    fprintf(stderr, "APExp: TkpDeleteFont done\n");
-    fflush(stderr);
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
The font teardown is reached many times and works every time -- the run shows Tk_FreeFont entering and leaving TkpDeleteFont cleanly for each of the font commands.  But the death has no Tk_FreeFont line before it:

	MARK create bare label ok -> .l0
	MARK destroy bare label ...
	<dies>

So destroy dies before it reaches Tk_FreeConfigOptions, which is what would free the font.  That instrumentation is removed as noise.

DestroyButton is now marked at each stage instead.  A label is a button-family widget, and the calls it makes before the config options are freed -- TkpDestroyButton (a no-op macro here), the widget command, four Tk_FreeGCs, Tk_FreeBitmap for the disabled-state stipple, and Tk_FreeTextLayout -- are exactly what a frame does not do, which is why frames destroy cleanly and labels do not.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs