### PR TITLE
tk: instrument Tk_FreeConfigOptions per option

### DIFF
--- a/sys/src/external/tk/generic/tkConfig.c
+++ b/sys/src/external/tk/generic/tkConfig.c
@@ -24,6 +24,7 @@
 #endif
 
 #include "tkInt.h"
+#include <stdio.h>
 #include "tkFont.h"
 
 #ifdef _WIN32
@@ -1808,12 +1809,23 @@ Tk_FreeConfigOptions(
 	    } else {
 		oldInternalPtr = NULL;
 	    }
+	    /* APExp diagnostic -- temporary, chasing the label destroy. */
+	    fprintf(stderr, "APExp: FreeConfigOptions: %s type=%d free=%d\n",
+		    specPtr->optionName ? specPtr->optionName : "(null)",
+		    (int) specPtr->type,
+		    (optionPtr->flags & OPTION_NEEDS_FREEING) ? 1 : 0);
+	    fflush(stderr);
+
 	    if (optionPtr->flags & OPTION_NEEDS_FREEING) {
 		FreeResources(optionPtr, oldPtr, oldInternalPtr, tkwin);
 	    }
 	    if (oldPtr != NULL) {
 		Tcl_DecrRefCount(oldPtr);
 	    }
+
+	    fprintf(stderr, "APExp: FreeConfigOptions: %s done\n",
+		    specPtr->optionName ? specPtr->optionName : "(null)");
+	    fflush(stderr);
 	}
     }
 }


### PR DESCRIPTION
DestroyButton's marks put the death precisely:

	APExp: DestroyButton: before textLayout
	APExp: DestroyButton: after textLayout
	APExp: DestroyButton: before FreeConfigOptions
	<dies>

so every GC, the disabled-state stipple bitmap and the text layout free cleanly, and it dies inside Tk_FreeConfigOptions.  Combined with the earlier run, where no Tk_FreeFont line appeared before the death, it dies on an option that comes before -font in the label's table.

Cursors are not it: XFreeCursor is a no-op in this backend, so TkpFreeCursor cannot fault.  Rather than keep walking the table by hand, Tk_FreeConfigOptions now names each option and its type before and after freeing it, so the last one printed is the answer.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs