### PR TITLE
tk: instrument Tk_Free3DBorder, the label dies freeing -activebackground

### DIFF
--- a/sys/src/external/tk/generic/tk3d.c
+++ b/sys/src/external/tk/generic/tk3d.c
@@ -12,6 +12,7 @@
  */
 
 #include "tkInt.h"
+#include <stdio.h>
 #include "tk3d.h"
 
 /*
@@ -419,14 +420,36 @@ Tk_Free3DBorder(
     Tk_3DBorder border)		/* Token for border to be released. */
 {
     TkBorder *borderPtr = (TkBorder *) border;
-    Display *display = DisplayOfScreen(borderPtr->screen);
+    Display *display;
     TkBorder *prevPtr;
 
+    /* APExp diagnostic -- temporary, chasing the label destroy. */
+    fprintf(stderr, "APExp: Tk_Free3DBorder border=%llx screen=%llx"
+	    " hashPtr=%llx resourceRefCount=%lld objRefCount=%lld\n",
+	    (unsigned long long)(uintptr_t) borderPtr,
+	    (unsigned long long)(uintptr_t) borderPtr->screen,
+	    (unsigned long long)(uintptr_t) borderPtr->hashPtr,
+	    (long long) borderPtr->resourceRefCount,
+	    (long long) borderPtr->objRefCount);
+    fflush(stderr);
+
+    display = DisplayOfScreen(borderPtr->screen);
+
+    fprintf(stderr, "APExp: Tk_Free3DBorder display=%llx\n",
+	    (unsigned long long)(uintptr_t) display);
+    fflush(stderr);
+
     if (borderPtr->resourceRefCount-- > 1) {
+	fprintf(stderr, "APExp: Tk_Free3DBorder still referenced, returning\n");
+	fflush(stderr);
 	return;
     }
 
     prevPtr = (TkBorder *)Tcl_GetHashValue(borderPtr->hashPtr);
+
+    fprintf(stderr, "APExp: Tk_Free3DBorder prevPtr=%llx, freeing\n",
+	    (unsigned long long)(uintptr_t) prevPtr);
+    fflush(stderr);
     TkpFreeBorder(borderPtr);
     Tk_FreeColor(borderPtr->bgColorPtr);
     if (borderPtr->darkColorPtr != NULL) {


### PR DESCRIPTION
The per-option marks name it exactly.  A frame frees its whole table, including -background (type 8, a border) and -cursor, without trouble. A label dies on the first option it touches:

	APExp: FreeConfigOptions: -activebackground type=8 free=1
	<dies>

So it is not borders in general -- the frame freed one -- but this one.

Tk_Free3DBorder has the same shape as Tk_FreeFont, which is where the last Tk bug was: it reads Tcl_GetHashValue(borderPtr->hashPtr), calls a platform hook, and then ckfrees the struct guarded by objRefCount.  It also dereferences borderPtr->screen through DisplayOfScreen before any of that, on the very first line.

This reports border, screen, hashPtr and both refcounts on entry, then the display, then prevPtr, so a null hashPtr or a bogus screen is visible before the fault rather than inferred from it.

TkpFreeBorder is upstream's tkUnix3d.c here, not ours -- the Plan 9 backend does not override it -- so if the struct is intact the fault is further in.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs