### PR TITLE
tk: TkpFreeColor must not free the TkColor struct

### DIFF
--- a/sys/src/external/tk/generic/tk3d.c
+++ b/sys/src/external/tk/generic/tk3d.c
@@ -12,7 +12,6 @@
  */
 
 #include "tkInt.h"
-#include <stdio.h>
 #include "tk3d.h"
 
 /*
@@ -420,80 +419,36 @@ Tk_Free3DBorder(
     Tk_3DBorder border)		/* Token for border to be released. */
 {
     TkBorder *borderPtr = (TkBorder *) border;
-    Display *display;
+    Display *display = DisplayOfScreen(borderPtr->screen);
     TkBorder *prevPtr;
 
-    /* APExp diagnostic -- temporary, chasing the label destroy. */
-    fprintf(stderr, "APExp: Tk_Free3DBorder border=%llx screen=%llx"
-	    " hashPtr=%llx resourceRefCount=%lld objRefCount=%lld\n",
-	    (unsigned long long)(uintptr_t) borderPtr,
-	    (unsigned long long)(uintptr_t) borderPtr->screen,
-	    (unsigned long long)(uintptr_t) borderPtr->hashPtr,
-	    (long long) borderPtr->resourceRefCount,
-	    (long long) borderPtr->objRefCount);
-    fflush(stderr);
-
-    display = DisplayOfScreen(borderPtr->screen);
-
-    fprintf(stderr, "APExp: Tk_Free3DBorder display=%llx\n",
-	    (unsigned long long)(uintptr_t) display);
-    fflush(stderr);
-
     if (borderPtr->resourceRefCount-- > 1) {
-	fprintf(stderr, "APExp: Tk_Free3DBorder still referenced, returning\n");
-	fflush(stderr);
 	return;
     }
 
     prevPtr = (TkBorder *)Tcl_GetHashValue(borderPtr->hashPtr);
-
-    fprintf(stderr, "APExp: Tk_Free3DBorder prevPtr=%llx, freeing\n",
-	    (unsigned long long)(uintptr_t) prevPtr);
-    fflush(stderr);
-#define B3DBG(m) do { \
-	fprintf(stderr, "APExp: Tk_Free3DBorder: %s\n", (m)); \
-	fflush(stderr); \
-} while (0)
-
-    B3DBG("before TkpFreeBorder");
     TkpFreeBorder(borderPtr);
-    B3DBG("after TkpFreeBorder");
 
-    B3DBG("before bgColorPtr");
     Tk_FreeColor(borderPtr->bgColorPtr);
-    B3DBG("after bgColorPtr");
 
     if (borderPtr->darkColorPtr != NULL) {
-	B3DBG("before darkColorPtr");
 	Tk_FreeColor(borderPtr->darkColorPtr);
-	B3DBG("after darkColorPtr");
     }
     if (borderPtr->lightColorPtr != NULL) {
-	B3DBG("before lightColorPtr");
 	Tk_FreeColor(borderPtr->lightColorPtr);
-	B3DBG("after lightColorPtr");
     }
     if (borderPtr->shadow != None) {
-	B3DBG("before shadow bitmap");
 	Tk_FreeBitmap(display, borderPtr->shadow);
-	B3DBG("after shadow bitmap");
     }
     if (borderPtr->bgGC != NULL) {
-	B3DBG("before bgGC");
 	Tk_FreeGC(display, borderPtr->bgGC);
-	B3DBG("after bgGC");
     }
     if (borderPtr->darkGC != NULL) {
-	B3DBG("before darkGC");
 	Tk_FreeGC(display, borderPtr->darkGC);
-	B3DBG("after darkGC");
     }
     if (borderPtr->lightGC != NULL) {
-	B3DBG("before lightGC");
 	Tk_FreeGC(display, borderPtr->lightGC);
-	B3DBG("after lightGC");
     }
-    B3DBG("before hash unlink");
     if (prevPtr == borderPtr) {
 	if (borderPtr->nextPtr == NULL) {
 	    Tcl_DeleteHashEntry(borderPtr->hashPtr);
@@ -506,13 +461,9 @@ Tk_Free3DBorder(
 	}
 	prevPtr->nextPtr = borderPtr->nextPtr;
     }
-    B3DBG("after hash unlink");
     if (borderPtr->objRefCount == 0) {
-	B3DBG("ckfree borderPtr");
 	ckfree(borderPtr);
     }
-    B3DBG("done");
-#undef B3DBG
 }
 
 /*

--- a/sys/src/external/tk/generic/tkButton.c
+++ b/sys/src/external/tk/generic/tkButton.c
@@ -14,13 +14,6 @@
 
 #include "tkInt.h"
 #include "tkButton.h"
-
-/* APExp diagnostic -- temporary, chasing the destroy-a-label death. */
-#include <stdio.h>
-#define BDBG(m) do { \
-	fprintf(stderr, "APExp: DestroyButton: %s\n", (m)); \
-	fflush(stderr); \
-} while (0)
 #include "default.h"
 
 typedef struct {
@@ -944,9 +937,7 @@ DestroyButton(
     TkButton *butPtr)		/* Info about button widget. */
 {
     butPtr->flags |= BUTTON_DELETED;
-    BDBG("enter");
     TkpDestroyButton(butPtr);
-    BDBG("after TkpDestroyButton");
 
     if (butPtr->flags & REDRAW_PENDING) {
 	Tcl_CancelIdleCall(TkpDisplayButton, butPtr);
@@ -957,9 +948,7 @@ DestroyButton(
      * Tk_FreeOptions handle all the standard option-related stuff.
      */
 
-    BDBG("before DeleteCommandFromToken");
     Tcl_DeleteCommandFromToken(butPtr->interp, butPtr->widgetCmd);
-    BDBG("after DeleteCommandFromToken");
     if (butPtr->textVarNamePtr != NULL) {
 	Tcl_UntraceVar2(butPtr->interp, Tcl_GetString(butPtr->textVarNamePtr),
 		NULL, TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS,
@@ -974,11 +963,9 @@ DestroyButton(
     if (butPtr->tristateImage != NULL) {
 	Tk_FreeImage(butPtr->tristateImage);
     }
-    BDBG("before normalTextGC");
     if (butPtr->normalTextGC != NULL) {
 	Tk_FreeGC(butPtr->display, butPtr->normalTextGC);
     }
-    BDBG("after normalTextGC");
     if (butPtr->activeTextGC != NULL) {
 	Tk_FreeGC(butPtr->display, butPtr->activeTextGC);
     }
@@ -988,28 +975,22 @@ DestroyButton(
     if (butPtr->stippleGC != NULL) {
 	Tk_FreeGC(butPtr->display, butPtr->stippleGC);
     }
-    BDBG("before gray bitmap");
     if (butPtr->gray != None) {
 	Tk_FreeBitmap(butPtr->display, butPtr->gray);
     }
-    BDBG("after gray bitmap");
     if (butPtr->copyGC != NULL) {
 	Tk_FreeGC(butPtr->display, butPtr->copyGC);
     }
-    BDBG("before textLayout");
     if (butPtr->textLayout != NULL) {
 	Tk_FreeTextLayout(butPtr->textLayout);
     }
-    BDBG("after textLayout");
     if (butPtr->selVarNamePtr != NULL) {
 	Tcl_UntraceVar2(butPtr->interp, Tcl_GetString(butPtr->selVarNamePtr),
 		NULL, TCL_GLOBAL_ONLY|TCL_TRACE_WRITES|TCL_TRACE_UNSETS,
 		ButtonVarProc, butPtr);
     }
-    BDBG("before FreeConfigOptions");
     Tk_FreeConfigOptions(butPtr, butPtr->optionTable,
 	    butPtr->tkwin);
-    BDBG("after FreeConfigOptions");
     butPtr->tkwin = NULL;
     Tcl_EventuallyFree(butPtr, TCL_DYNAMIC);
 }

--- a/sys/src/external/tk/generic/tkConfig.c
+++ b/sys/src/external/tk/generic/tkConfig.c
@@ -24,7 +24,6 @@
 #endif
 
 #include "tkInt.h"
-#include <stdio.h>
 #include "tkFont.h"
 
 #ifdef _WIN32
@@ -1809,13 +1808,6 @@ Tk_FreeConfigOptions(
 	    } else {
 		oldInternalPtr = NULL;
 	    }
-	    /* APExp diagnostic -- temporary, chasing the label destroy. */
-	    fprintf(stderr, "APExp: FreeConfigOptions: %s type=%d free=%d\n",
-		    specPtr->optionName ? specPtr->optionName : "(null)",
-		    (int) specPtr->type,
-		    (optionPtr->flags & OPTION_NEEDS_FREEING) ? 1 : 0);
-	    fflush(stderr);
-
 	    if (optionPtr->flags & OPTION_NEEDS_FREEING) {
 		FreeResources(optionPtr, oldPtr, oldInternalPtr, tkwin);
 	    }
@@ -1823,9 +1815,6 @@ Tk_FreeConfigOptions(
 		Tcl_DecrRefCount(oldPtr);
 	    }
 
-	    fprintf(stderr, "APExp: FreeConfigOptions: %s done\n",
-		    specPtr->optionName ? specPtr->optionName : "(null)");
-	    fflush(stderr);
 	}
     }
 }

--- a/sys/src/external/tk/plan9/tkPlan9Color.c
+++ b/sys/src/external/tk/plan9/tkPlan9Color.c
@@ -147,8 +147,36 @@ TkpGetColorByValue(Tk_Window tkwin, XColor *colorPtr)
 /* TkpFreeColor                                                       */
 /* ------------------------------------------------------------------ */
 
+/*
+ * Release the platform's hold on the colour, and nothing else. The
+ * TkColor struct belongs to generic Tk, which goes on using it the
+ * moment this returns (tkColor.c, Tk_FreeColor):
+ *
+ *	TkpFreeColor(tkColPtr);
+ *	prevPtr = Tcl_GetHashValue(tkColPtr->hashPtr);
+ *	...
+ *	prevPtr->nextPtr = tkColPtr->nextPtr;
+ *	if (tkColPtr->objRefCount == 0) {
+ *	    ckfree(tkColPtr);
+ *	}
+ *
+ * This used to ckfree(tkColPtr), so all of that read freed memory and
+ * the final ckfree was a double free. Destroying any widget that had
+ * actually released a colour killed wish, which meant every Tk test
+ * file: constraints.tcl builds a label, and the first border genuinely
+ * freed takes its background colour down with it.
+ *
+ * There is nothing to release here. XAllocColor above allocates no
+ * server resource -- it packs the RGB triple into a pixel value and
+ * returns -- so unlike tkUnixColor.c, which calls XFreeColors and
+ * DeleteStressedCmap, this has no platform work to do.
+ *
+ * The same mistake was in TkpDeleteFont; see the note there. Any Tkp*
+ * hook that is handed a generic Tk struct owns the platform resources
+ * hanging off it and never the struct itself.
+ */
 void
 TkpFreeColor(TkColor *tkColPtr)
 {
-    ckfree(tkColPtr);
+    (void)tkColPtr;
 }


### PR DESCRIPTION
Same bug as TkpDeleteFont, in a different hook, and found the same way. The instrumentation walked it down: every Tk test file dies inside constraints.tcl, in Tk_FreeConfigOptions, on the label's -activebackground, inside Tk_Free3DBorder, at Tk_FreeColor for the border's background colour.

Generic Tk goes on using the struct the moment the hook returns (tkColor.c, Tk_FreeColor):

	TkpFreeColor(tkColPtr);
	prevPtr = Tcl_GetHashValue(tkColPtr->hashPtr);
	...
	prevPtr->nextPtr = tkColPtr->nextPtr;
	if (tkColPtr->objRefCount == 0) {
	    ckfree(tkColPtr);
	}

so ckfree(tkColPtr) in the hook made all of that read freed memory, and the final ckfree a double free.  tkUnixColor.c's TkpFreeColor releases the server's colour allocation and never touches the struct; ours has nothing at all to release, because XAllocColor here allocates no server resource -- it packs the RGB triple into a pixel value and returns.

Why a frame survived and a label did not: the frame's -background border had resourceRefCount 2, so Tk_Free3DBorder returned early and never freed a colour.  The label's -activebackground was the first border genuinely released in the whole session.

Swept the rest of the backend for the same shape.  Every other ckfree is legitimate -- temporary arrays, XDestroyImage, XFreeModifiermap, and TkpCloseDisplay freeing the Display it allocated -- so this was the last instance.  The rule: a Tkp* hook handed a generic Tk struct owns the platform resources hanging off it, never the struct.

All instrumentation removed.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs