### PR TITLE
tk: flush libdraw on every notifier pass, so drawing appears

### DIFF
--- a/sys/src/external/tk/plan9/tkPlan9Event.c
+++ b/sys/src/external/tk/plan9/tkPlan9Event.c
@@ -329,6 +329,17 @@ DisplaySetupProc(void *clientData, int flags)
     if (!gP9.initialized) return;
 
     /*
+     * Push anything drawn since the last pass out to the screen.
+     * libdraw buffers its operations, so without this the widgets draw
+     * into the buffer and nothing ever appears -- a blank white window,
+     * whatever Tk is doing. tkUnixEvent.c's DisplaySetupProc flushes
+     * the X connection here for the same reason; XFlush and XSync were
+     * the only things calling tkp9_flush, and Tk's redraw path goes
+     * through neither.
+     */
+    tkp9_flush();
+
+    /*
      * This used to set a zero block time unconditionally, which tells
      * the notifier never to sleep -- so every wish process spun at 100%
      * CPU for its whole life. A single wish still worked, having the


### PR DESCRIPTION
wish showed a blank white window whatever Tk was doing.  libdraw buffers its operations and only puts them on the screen at flushimage(), and the sole caller of tkp9_flush was XFlush/XSync -- neither of which Tk's redraw path goes through.  So the widgets drew correctly into the buffer and nothing was ever displayed.

tkUnixEvent.c's DisplaySetupProc flushes the X connection on every pass for exactly this reason; ours now does the same before deciding the block time.  That is once per notifier wakeup, which the 20ms cap already bounds.

This is likely behind a good share of the 642 failures in the full suite: tests that check geometry, bboxes or appearance cannot pass while nothing renders.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs