### PR TITLE
tk: map toplevels -- TkWmMapWindow was a no-op

### DIFF
--- a/sys/lib/tests/tk-bind-test.tcl
+++ b/sys/lib/tests/tk-bind-test.tcl
@@ -59,6 +59,18 @@ foreach {label ev} {
     bind .f $ev {}
 }
 
+# 1b. Key events again, with the focus set. Tk_HandleEvent redirects
+# KeyPress/KeyRelease to the focus window and drops them when there is
+# none, so a bare "event generate .f <Key-a>" proves nothing on its own.
+focus -force .f
+update
+mark "focus is now [focus]"
+set ::hits {}
+bind .f <Key-a> {lappend ::hits fired}
+event generate .f <Key-a>
+mark "KeyA with focus: [expr {[llength $::hits] ? "FIRED" : "not delivered"}]"
+bind .f <Key-a> {}
+
 # 2. Queued delivery, to see whether the two paths differ.
 set ::hits {}
 bind .f <Enter> {lappend ::hits fired}

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -228,16 +228,44 @@ TkWmNewWindow(TkWindow *winPtr)
     (void)winPtr;
 }
 
+/*
+ * Tk_MapWindow hands a toplevel entirely to us and returns:
+ *
+ *	if (winPtr->flags & TK_TOP_HIERARCHY) {
+ *	    TkWmMapWindow(winPtr);
+ *	    return;
+ *	}
+ *	winPtr->flags |= TK_MAPPED;
+ *	XMapWindow(winPtr->display, winPtr->window);
+ *
+ * so a no-op here means the toplevel is never marked mapped and never
+ * mapped, and since the geometry managers only map children of a mapped
+ * parent, nothing in the whole application is ever mapped. Tk draws only
+ * mapped windows, so wish showed a blank white window whatever it was
+ * doing, and "winfo ismapped .f" answered 0 after pack and update.
+ *
+ * There is no window manager here -- rio owns the window and there is
+ * exactly one -- so the right behaviour is what Tk_MapWindow does for an
+ * ordinary window: mark it mapped and map it. tkUnixWm.c does a great
+ * deal more, but all of it concerns wrapper windows, WM hints and
+ * icons, none of which exist on Plan 9.
+ */
 void
 TkWmMapWindow(TkWindow *winPtr)
 {
-    (void)winPtr;
+    if (winPtr->flags & TK_MAPPED)
+	return;
+    winPtr->flags |= TK_MAPPED;
+    XMapWindow(winPtr->display, winPtr->window);
 }
 
 void
 TkWmUnmapWindow(TkWindow *winPtr)
 {
-    (void)winPtr;
+    if (!(winPtr->flags & TK_MAPPED))
+	return;
+    winPtr->flags &= ~TK_MAPPED;
+    XUnmapWindow(winPtr->display, winPtr->window);
 }
 
 void


### PR DESCRIPTION
wish showed a blank white window whatever Tk was doing, and "winfo ismapped .f" answered 0 after pack and update.

Tk_MapWindow hands a toplevel entirely to the platform and returns:

	if (winPtr->flags & TK_TOP_HIERARCHY) {
	    TkWmMapWindow(winPtr);
	    return;
	}
	winPtr->flags |= TK_MAPPED;
	XMapWindow(winPtr->display, winPtr->window);

so a no-op TkWmMapWindow meant the toplevel was never marked mapped and never mapped; the geometry managers only map children of a mapped parent, so nothing in the application was ever mapped, and Tk draws only mapped windows.

There is no window manager here -- rio owns the window and there is one of them -- so the right behaviour is what Tk_MapWindow does for an ordinary window: mark it mapped and map it.  tkUnixWm.c does much more, but all of it concerns wrapper windows, WM hints and icons, none of which exist on Plan 9.  TkWmUnmapWindow is the mirror.

Also extends tk-bind-test.tcl: event generate turns out to deliver Enter, Leave, Button, Motion, Configure, Expose, FocusIn, queued events, class and "all" bindings and virtual events -- everything except <Key-a>.  Tk_HandleEvent redirects key events to the focus window and drops them when there is none, so the test now sets focus first, which tells us whether that is all it was.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs