### PR TITLE
tk: a window's position is the sum up the parent chain

### DIFF
--- a/sys/src/external/tk/plan9/tkPlan9Draw.c
+++ b/sys/src/external/tk/plan9/tkPlan9Draw.c
@@ -42,9 +42,7 @@ GCBackgroundRGBA(GC gc)
 static void
 DrawableOffset(Drawable d, int *ox, int *oy)
 {
-    P9Window *pw = TkP9FindWindow((Window)d);
-    if (pw) { *ox = pw->x; *oy = pw->y; }
-    else    { *ox = 0;     *oy = 0;     }
+    TkP9WindowOffset((Window)d, ox, oy);
 }
 
 /* ------------------------------------------------------------------ */
@@ -163,9 +161,11 @@ int
 XClearWindow(Display *display, Window w)
 {
     P9Window *pw = TkP9FindWindow(w);
+    int ox, oy;
     (void)display;
     if (!pw) return 0;
-    tkp9_fillrect(pw->x, pw->y, pw->width, pw->height, pw->bg_pixel);
+    TkP9WindowOffset(w, &ox, &oy);
+    tkp9_fillrect(ox, oy, pw->width, pw->height, pw->bg_pixel);
     return 0;
 }
 
@@ -175,9 +175,11 @@ XClearArea(Display *display, Window w,
            Bool exposures)
 {
     P9Window *pw = TkP9FindWindow(w);
+    int ox, oy;
     (void)display; (void)exposures;
     if (!pw) return 0;
-    tkp9_fillrect(pw->x + x, pw->y + y, (int)width, (int)height,
+    TkP9WindowOffset(w, &ox, &oy);
+    tkp9_fillrect(ox + x, oy + y, (int)width, (int)height,
                   pw->bg_pixel);
     return 0;
 }

--- a/sys/src/external/tk/plan9/tkPlan9Font.c
+++ b/sys/src/external/tk/plan9/tkPlan9Font.c
@@ -295,13 +295,10 @@ Tk_DrawChars(
     void *fnt;
     int ox, oy;
     unsigned long rgba;
-    P9Window *pw;
     (void)display;
 
     fnt  = p9f ? p9f->p9font : NULL;
-    pw   = TkP9FindWindow((Window)d);
-    ox   = pw ? pw->x : 0;
-    oy   = pw ? pw->y : 0;
+    TkP9WindowOffset((Window)d, &ox, &oy);
     rgba = TkP9XColorStructToRGBA(gc->foreground);
 
     /* y in Tk is the baseline; Plan 9 string() also uses baseline */

--- a/sys/src/external/tk/plan9/tkPlan9Init.c
+++ b/sys/src/external/tk/plan9/tkPlan9Init.c
@@ -52,6 +52,35 @@ TkP9AllocWindow(void)
     return NULL;
 }
 
+/*
+ * Where a window actually sits on the screen.
+ *
+ * X window coordinates are relative to the *parent*, so a button inside
+ * a frame inside a toplevel is at the sum of the three, not at its own
+ * x,y. Every drawing call used one level only, so nested widgets all
+ * collapsed toward the origin and piled up in the top-left corner.
+ *
+ * The walk is bounded by the table size: a corrupt parent chain must
+ * not spin here.
+ */
+void
+TkP9WindowOffset(Window xid, int *ox, int *oy)
+{
+    P9Window *pw;
+    int x = 0, y = 0, guard;
+
+    for (pw = TkP9FindWindow(xid), guard = 0;
+         pw != NULL && guard < TKP9_MAX_WINDOWS;
+         pw = TkP9FindWindow(pw->parent), guard++) {
+        x += pw->x;
+        y += pw->y;
+        if (pw->xid == TKP9_ROOT_XID || pw->parent == pw->xid)
+            break;
+    }
+    *ox = x;
+    *oy = y;
+}
+
 void
 TkP9FreeWindow(Window xid)
 {

--- a/sys/src/external/tk/plan9/tkPlan9Int.h
+++ b/sys/src/external/tk/plan9/tkPlan9Int.h
@@ -89,6 +89,7 @@ extern P9DisplayState gP9;
 /* ------------------------------------------------------------------ */
 
 extern P9Window *TkP9FindWindow(Window xid);
+extern void      TkP9WindowOffset(Window xid, int *ox, int *oy);
 extern P9Window *TkP9AllocWindow(void);
 extern void      TkP9FreeWindow(Window xid);
 


### PR DESCRIPTION
With drawing translated into the window, widgets appear -- but nested ones piled up in the top-left corner, one clipped by the window edge.

X window coordinates are relative to the *parent*, so a button inside a frame inside a toplevel sits at the sum of the three.  DrawableOffset read one level only, so every widget was drawn at its own offset from its parent as though the parent were at the origin, and the deeper the nesting the further everything collapsed toward (0,0).

TkP9WindowOffset walks to the root and accumulates, bounded by the table size so a corrupt parent chain cannot spin.  All the users go through it now: DrawableOffset for the whole of tkPlan9Draw.c, XClearWindow and XClearArea which read pw->x/pw->y directly, and Tk_DrawChars in tkPlan9Font.c which had its own copy of the one-level version.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs