### PR TITLE
tk/plan9: key events -- keycodes, the tkBind hooks, and a focus window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1195,6 +1195,45 @@ create/destroy, one at a time). The technique that actually worked, all
 three times, was a `fprintf(stderr, ...)` at each step of the suspect
 function -- not acid, which fights `wish` for the rio window.
 
+### Tk on Plan 9: a keycode here is a keysym, whole
+
+There is no keyboard map on Plan 9. `/dev/cons` gives a **rune**, not a
+scan code, so the X two-step of keycode -> keysym has nothing to do and
+the two are the same thing. Every function in `plan9/` that converts
+between them is therefore the identity, and the one that was not is the
+one that broke.
+
+`XKeysymToKeycode` masked with `0xFF`. That is fine for Latin-1 and
+wrong for everything else, because **every special key lives in the
+0xFF00 page**: `XK_Up` is 0xFF52, so it arrived as 0x52, `R`. Down was
+`T`, Return 0x0D, and the whole page collapsed onto ASCII. `KeyCode` is
+an `unsigned int` in this shim (`xlib/X11/X.h:112`, widened for the Mac
+IME) and `XKeyEvent.keycode` is one too, so there was never a reason to
+narrow it.
+
+Three hooks `tkBind.c` needs were empty stubs, in
+`plan9/tkPlan9Stubs.c`:
+
+- `TkpSetKeycodeAndState` -- `event generate` calls it at
+  `tkBind.c:4156` and then refuses the event if `keycode == 0`. Doing
+  nothing is how `event generate .f <Key-a>` became
+  `no keycode for keysym "a"`, and it is why `bind.test` alone had 146
+  failures, all of them key events.
+- `TkpGetKeySym` -- returned `NoSymbol` for anything that was not a
+  `KeyPress`, so the release half of every binding was lost.
+- `TkpGetString` -- `%A` in a binding script.
+
+**A key event must name a window Tk knows.** `GenerateKeyEvent` sent
+every keystroke to the root, and `Tk_HandleEvent` drops an event whose
+window has no `TkWindow` -- so real typing was discarded before
+`TkFocusKeyEvent` could redirect it to the focus widget. Nothing here
+can ask who has focus (rio owns the keyboard), so Tk is the authority:
+`TkpChangeFocus` records the toplevel through `XSetInputFocus`, and
+`TkP9FocusWindow` hands it back, falling back to the first mapped child
+of the root. Note this is invisible to `event generate`, which names its
+own window -- so the synthetic and the real path fail separately, and
+`tk-bind-test.tcl` only covers the synthetic one.
+
 ### Build order for compiler changes
 ```
 cd sys/src/cmd/cc && mk nuke && mk install   # regenerates y.tab.h

--- a/sys/src/external/tk/plan9/tkPlan9Event.c
+++ b/sys/src/external/tk/plan9/tkPlan9Event.c
@@ -198,7 +198,7 @@ static void
 GenerateKeyEvent(Display *dpy, int rune, int press)
 {
     XEvent ev;
-    Window focus = TKP9_ROOT_XID;
+    Window focus = TkP9FocusWindow();
     KeySym sym;
 
     sym = RuneToKeySym(rune);
@@ -208,12 +208,9 @@ GenerateKeyEvent(Display *dpy, int rune, int press)
     ev.xkey.display       = dpy;
     ev.xkey.window        = focus;
     ev.xkey.root          = TKP9_ROOT_XID;
-    ev.xkey.keycode       = (KeyCode)(rune & 0xFF);
     ev.xkey.state         = ButtonToMask(gP9.lastmouse.buttons);
     ev.xkey.time          = (Time)(gP9.lastmouse.msec);
-
-    /* Store keysym in the upper bits of keycode for TkpGetKeySym */
-    ev.xkey.keycode = XKeysymToKeycode(dpy, sym);
+    ev.xkey.keycode       = XKeysymToKeycode(dpy, sym);
     TkP9EnqueueEvent(&ev);
 
     /* Auto-generate KeyRelease for non-modifier keys */
@@ -422,9 +419,22 @@ KeyCode
 XKeysymToKeycode(Display *display, KeySym sym)
 {
     (void)display;
-    /* Simple mapping: use low byte of keysym as keycode */
-    if (sym < 0x100) return (KeyCode)sym;
-    return (KeyCode)(sym & 0xFF);
+    /*
+     * There is no keyboard map on Plan 9 -- /dev/cons hands us a rune,
+     * not a scan code -- so a keycode here is simply a keysym, and this
+     * is the identity. Tk's own KeyCode is an unsigned int (X.h:112,
+     * widened for the Mac IME), and XKeyEvent.keycode is unsigned int
+     * too, so every keysym fits.
+     *
+     * It used to mask with 0xFF, which is only harmless for Latin-1.
+     * Every special key shares the 0xFF00 page -- XK_Up is 0xFF52 --
+     * so the mask turned Up into 'R', Down into 'T', Return into 0x0D,
+     * and collapsed the whole page onto the ASCII range. Anything
+     * reading the keysym back (TkpGetKeySym, XKeycodeToKeysym,
+     * XmbLookupString, all of which are the identity in the other
+     * direction) then got a different key than the one pressed.
+     */
+    return (KeyCode)sym;
 }
 
 KeySym

--- a/sys/src/external/tk/plan9/tkPlan9Init.c
+++ b/sys/src/external/tk/plan9/tkPlan9Init.c
@@ -815,10 +815,45 @@ XWithdrawWindow(Display *display, Window w, int screen)
     return XUnmapWindow(display, w);
 }
 
+/*
+ * rio owns the keyboard, so there is no focus server to ask and nothing
+ * tells us which window a keystroke was meant for. Tk tells us instead:
+ * TkpChangeFocus calls XSetInputFocus with the toplevel it wants, and
+ * GenerateKeyEvent addresses the event to whatever we last recorded.
+ *
+ * The event has to name a window Tk knows, not the root: Tk_HandleEvent
+ * looks the window up and drops the event when there is no TkWindow for
+ * it, and the root is not one -- so with the root hardwired as the
+ * destination, as it was, every keystroke was discarded before
+ * TkFocusKeyEvent could redirect it to the focus widget. Until Tk sets
+ * a focus, fall back to the first mapped child of the root, which is
+ * the one toplevel a wish normally has.
+ */
+Window
+TkP9FocusWindow(void)
+{
+    P9Window *pw;
+    int i;
+
+    if (gP9.focuswin != None && gP9.focuswin != TKP9_ROOT_XID) {
+        pw = TkP9FindWindow(gP9.focuswin);
+        if (pw != NULL && pw->mapped && !pw->ispixmap)
+            return gP9.focuswin;
+    }
+    for (i = 0; i < gP9.nwins; i++) {
+        pw = &gP9.wins[i];
+        if (pw->inuse && pw->mapped && !pw->ispixmap &&
+            pw->xid != TKP9_ROOT_XID && pw->parent == TKP9_ROOT_XID)
+            return pw->xid;
+    }
+    return TKP9_ROOT_XID;
+}
+
 int
 XSetInputFocus(Display *display, Window w, int revert, Time t)
 {
-    (void)display; (void)w; (void)revert; (void)t;
+    (void)display; (void)revert; (void)t;
+    gP9.focuswin = w;
     return 0;
 }
 
@@ -826,7 +861,7 @@ int
 XGetInputFocus(Display *display, Window *focus_return, int *revert_return)
 {
     (void)display;
-    if (focus_return)  *focus_return  = TKP9_ROOT_XID;
+    if (focus_return)  *focus_return  = TkP9FocusWindow();
     if (revert_return) *revert_return = RevertToParent;
     return 0;
 }

--- a/sys/src/external/tk/plan9/tkPlan9Int.h
+++ b/sys/src/external/tk/plan9/tkPlan9Int.h
@@ -78,6 +78,8 @@ typedef struct P9DisplayState {
     /* Last known mouse state */
     TkP9Mouse    lastmouse;
     int          lastbuttons;
+    /* Window that keyboard input is delivered to (see TkP9FocusWindow) */
+    Window       focuswin;
     /* Display/screen pointers (set by XkbOpenDisplay) */
     Display     *xdisplay;
     /* Tcl event source state */
@@ -92,6 +94,7 @@ extern P9DisplayState gP9;
 
 extern P9Window *TkP9FindWindow(Window xid);
 extern void      TkP9WindowOffset(Window xid, int *ox, int *oy);
+extern Window    TkP9FocusWindow(void);
 extern P9Window *TkP9AllocWindow(void);
 extern void      TkP9FreeWindow(Window xid);
 

--- a/sys/src/external/tk/plan9/tkPlan9Stubs.c
+++ b/sys/src/external/tk/plan9/tkPlan9Stubs.c
@@ -492,26 +492,90 @@ Tk_SetCaretPos(Tk_Window tkwin, int x, int y, int height)
 }
 
 const char *
+/*
+ * The characters a key event stands for -- Tk's %A substitution.
+ *
+ * The keysym is the Unicode code point for anything printable, so the
+ * string is just its UTF-8 encoding. Keysyms in the 0xFF00 range are
+ * function and cursor keys and stand for no character at all, and
+ * neither does a keysym of 0.
+ */
+char *
 TkpGetString(TkWindow *winPtr, XEvent *eventPtr, Tcl_DString *dsPtr)
 {
-    (void)winPtr; (void)eventPtr;
+    KeySym sym;
+    char buf[TCL_UTF_MAX + 1];
+    int n;
+
+    (void)winPtr;
     Tcl_DStringSetLength(dsPtr, 0);
+
+    if (eventPtr == NULL ||
+        (eventPtr->type != KeyPress && eventPtr->type != KeyRelease))
+	return Tcl_DStringValue(dsPtr);
+
+    sym = (KeySym) eventPtr->xkey.keycode;
+    if (sym == 0 || (sym >= 0xFF00 && sym <= 0xFFFF))
+	return Tcl_DStringValue(dsPtr);
+
+    n = Tcl_UniCharToUtf((int) sym, buf);
+    Tcl_DStringAppend(dsPtr, buf, n);
     return Tcl_DStringValue(dsPtr);
 }
 
 void
+/*
+ * Fill in a synthetic key event's keycode from its keysym.
+ *
+ * "event generate . <Key-a>" goes through here (tkBind.c:4156) and then
+ * checks the result:
+ *
+ *	TkpSetKeycodeAndState(tkwin, keysym, &event.general);
+ *	if (event.general.xkey.keycode == 0) {
+ *	    ... "no keycode for keysym \"%s\"" ...
+ *	}
+ *
+ * so an empty stub failed every key event in the suite -- 146 of the
+ * 196 remaining failures in bind.test were this one function.
+ *
+ * This port keeps keycode and keysym identical: XKeycodeToKeysym and
+ * TkpGetKeySym both hand the value straight back. That works for every
+ * keysym rather than only the ASCII ones because KeyCode here is an
+ * unsigned int, not X11's 8-bit type, and XKeyEvent.keycode is an
+ * unsigned int too. No modifier state is needed either, since the
+ * keysym is carried exactly rather than being recovered from a keyboard
+ * map -- which is what tkUnixKey.c's loop over shift levels is for.
+ */
+void
 TkpSetKeycodeAndState(Tk_Window tkwin, KeySym keySym, XEvent *eventPtr)
 {
-    (void)tkwin; (void)keySym; (void)eventPtr;
+    (void)tkwin;
+
+    if (eventPtr == NULL)
+	return;
+    eventPtr->xkey.keycode = (keySym == NoSymbol) ? 0 : (unsigned int) keySym;
 }
 
+/*
+ * The inverse of TkpSetKeycodeAndState: keycode and keysym are the same
+ * value here.
+ *
+ * This used to answer NoSymbol for anything that was not a KeyPress,
+ * which loses the release half of every binding -- Tk matches <KeyRelease>
+ * patterns through this same call.
+ */
 KeySym
 TkpGetKeySym(TkDisplay *dispPtr, XEvent *eventPtr)
 {
     (void)dispPtr;
-    if (eventPtr && eventPtr->type == KeyPress)
-        return (KeySym)eventPtr->xkey.keycode;
-    return NoSymbol;
+
+    if (eventPtr == NULL)
+	return NoSymbol;
+    if (eventPtr->type != KeyPress && eventPtr->type != KeyRelease)
+	return NoSymbol;
+    if (eventPtr->xkey.keycode == 0)
+	return NoSymbol;
+    return (KeySym) eventPtr->xkey.keycode;
 }
 
 /* ------------------------------------------------------------------ */

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -68,10 +68,20 @@ TkpWmConfigure(TkWindow *winPtr, int w, int h)
 /* Focus management (trivial — no separate focus server)              */
 /* ------------------------------------------------------------------ */
 
+/*
+ * Record where keyboard input should go. Returning 0 tells tkFocus.c to
+ * generate the FocusIn/FocusOut events itself rather than waiting for
+ * ones from a server -- there is no server here to send them. That is
+ * also what tkUnixWm.c's TkpChangeFocus returns when it does not call
+ * XSetInputFocus.
+ */
 int
 TkpChangeFocus(TkWindow *winPtr, int claim)
 {
-    (void)winPtr; (void)claim;
+    (void)claim;
+    if (winPtr != NULL && winPtr->window != None)
+	XSetInputFocus(winPtr->display, winPtr->window, RevertToParent,
+	               CurrentTime);
     return 0;
 }
 


### PR DESCRIPTION
A keycode on Plan 9 is a keysym: /dev/cons hands over a rune, there is no keyboard map, and the X two-step has nothing to do. Every conversion between the two in plan9/ was already the identity except XKeysymToKeycode, which masked with 0xFF -- fine for Latin-1, wrong for every special key, since they all share the 0xFF00 page. XK_Up (0xFF52) came out as 'R', Down as 'T', Return as 0x0D. KeyCode is an unsigned int in this shim and XKeyEvent.keycode is one too, so nothing was gained by narrowing it.

Three hooks tkBind.c needs were empty stubs. TkpSetKeycodeAndState is called by "event generate" (tkBind.c:4156), which then refuses the event if the keycode is still zero -- that is the whole of

	event generate .f <Key-a>  ->  no keycode for keysym "a"

and of bind.test's 146 failures, which are all key events. TkpGetKeySym returned NoSymbol for anything that was not a KeyPress, losing the release half of every binding, and TkpGetString (%A) did nothing.

Real keystrokes had a separate problem: GenerateKeyEvent addressed them to the root window, and Tk_HandleEvent drops an event whose window has no TkWindow, so they were discarded before TkFocusKeyEvent could redirect them to the focus widget. rio owns the keyboard and there is no focus server to ask, so Tk is the authority -- TkpChangeFocus records the toplevel through XSetInputFocus and TkP9FocusWindow reads it back, falling back to the first mapped child of the root.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs