### PR TITLE
tk/plan9: fix leftover return types in tkPlan9Stubs.c

### DIFF
--- a/sys/src/external/tk/plan9/tkPlan9Stubs.c
+++ b/sys/src/external/tk/plan9/tkPlan9Stubs.c
@@ -491,7 +491,6 @@ Tk_SetCaretPos(Tk_Window tkwin, int x, int y, int height)
     (void)tkwin; (void)x; (void)y; (void)height;
 }
 
-const char *
 /*
  * The characters a key event stands for -- Tk's %A substitution.
  *
@@ -500,7 +499,7 @@ const char *
  * function and cursor keys and stand for no character at all, and
  * neither does a keysym of 0.
  */
-char *
+const char *
 TkpGetString(TkWindow *winPtr, XEvent *eventPtr, Tcl_DString *dsPtr)
 {
     KeySym sym;
@@ -523,7 +522,6 @@ TkpGetString(TkWindow *winPtr, XEvent *eventPtr, Tcl_DString *dsPtr)
     return Tcl_DStringValue(dsPtr);
 }
 
-void
 /*
  * Fill in a synthetic key event's keycode from its keysym.
  *


### PR DESCRIPTION
The previous commit put the new comments between each function's return type and its declarator, leaving the old return type stranded above -- "const char * /* comment */ char * TkpGetString(...)", which pcc reports as

	tkPlan9Stubs.c:503 syntax error, last name: char

TkpGetString returns const char * (tkInt.decls:364), not char *.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs