### PR TITLE
tk/plan9: send VisibilityNotify on map, so a deferred focus completes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1234,6 +1234,54 @@ of the root. Note this is invisible to `event generate`, which names its
 own window -- so the synthetic and the real path fail separately, and
 `tk-bind-test.tcl` only covers the synthetic one.
 
+### Tk on Plan 9: no VisibilityNotify, so `focus -force` before `update` did nothing
+
+`focus -force .w` on a window that is not yet mapped cannot set the
+focus, so `TkSetFocusWin` does not fail -- it **defers**:
+
+```c
+if (!allMapped) {
+	Tk_CreateEventHandler((Tk_Window) winPtr, VisibilityChangeMask,
+	        FocusMapProc, winPtr);
+	displayFocusPtr->focusOnMapPtr = winPtr;
+	return;
+}
+```
+
+and `FocusMapProc` finishes the job when the window turns up. `XMapWindow`
+here sent `MapNotify` and `Expose` but no `VisibilityNotify`, so that
+handler never fired and the focus was never set.
+
+The idiom this breaks is the one every Tk test file opens with:
+
+```tcl
+pack .t.f
+focus -force .t.f
+update
+```
+
+`pack` maps on the idle queue, so at the moment of the focus command
+`.t.f` is still unmapped and the deferred path is the *only* path.
+
+**Key events are the only thing that notices.** They alone are
+redirected through the focus -- `InvokeFocusHandlers` (`tkEvent.c:255`)
+calls `TkFocusKeyEvent`, which returns NULL when there is no focus
+window, and `Tk_HandleEvent` then discards the event. So a `<Button-1>`
+binding on a widget worked while every `<Key>` binding on the *same*
+widget silently did nothing, and `bind.test` failed 134 cases with empty
+results and no errors anywhere.
+
+Reordering the two lines makes it work, which is what made this hard to
+see: `sys/lib/tests/tk-bind-test.tcl` passed its key cases because it
+had `update` before `focus -force`, the one order bind.test never uses.
+`focus` answering `.f` rather than empty was the tell -- neither
+clearing path in `TkFocusFilterEvent` leaves a name behind, both assign
+NULL, so the focus had never moved in the first place.
+
+`TkP9EnqueueEvent`'s ring is 1024 entries now (`TKP9_EVQUEUE`, and the
+wrap derives from it rather than a hardcoded `& 255`): mapping one
+window costs three events, and a full ring is dropped silently.
+
 ### Build order for compiler changes
 ```
 cd sys/src/cmd/cc && mk nuke && mk install   # regenerates y.tab.h

--- a/sys/lib/tests/tk-bind-test.tcl
+++ b/sys/lib/tests/tk-bind-test.tcl
@@ -127,74 +127,50 @@ mark "virtual event: [expr {[llength $::hits] ? "FIRED" : "not delivered"}]"
 
 # 5. The same key test, but inside a second toplevel.
 #
-# Everything above uses a frame in "." and now works, while bind.test
-# still fails every key case -- and its one structural difference is
-# that it builds .t.f inside a toplevel .t:
+# Everything above uses a frame in "." and works, while bind.test failed
+# every key case -- and the difference is not the toplevel, it is the
+# ORDER of two lines. Every Tk test file opens with
 #
-#	toplevel .t -width 100 -height 50
-#	frame .t.f -class Test -width 150 -height 100
 #	pack .t.f
 #	focus -force .t.f
+#	update
 #
-# Tk_HandleEvent hands a key event to TkFocusKeyEvent, which redirects
-# it to displayFocusPtr->focusWinPtr and returns NULL -- dropping the
-# event -- when there is no focus window. TkSetFocusWin refuses to set
-# one unless the target AND every ancestor up to the toplevel have
-# TK_MAPPED (tkFocus.c, the allMapped loop); it silently defers instead,
-# arming a VisibilityChange handler. So a toplevel this port never marks
-# mapped would lose every key event and nothing else, which is exactly
-# the failure shape.
+# and pack maps on the idle queue, so at the moment of the focus command
+# .t.f is still unmapped. TkSetFocusWin does not fail on that; it defers
+# (tkFocus.c):
 #
-# "focus" reporting .t.f is the discriminator: if it answers empty or
-# ".", the focus was never set and the mapping is why.
+#	if (!allMapped) {
+#	    Tk_CreateEventHandler((Tk_Window) winPtr, VisibilityChangeMask,
+#		    FocusMapProc, winPtr);
+#	    displayFocusPtr->focusOnMapPtr = winPtr;
+#	    return;
+#	}
+#
+# and FocusMapProc finishes the job when the window turns up. XMapWindow
+# in this port sent MapNotify and Expose but no VisibilityNotify, so that
+# handler never fired and the focus was simply never set.
+#
+# Key events are the only thing that notices, because they alone are
+# redirected through the focus: InvokeFocusHandlers (tkEvent.c:255) calls
+# TkFocusKeyEvent, which returns NULL when there is no focus window, and
+# Tk_HandleEvent discards the event. Hence a Button-1 binding working on
+# the very widget whose Key bindings do nothing -- the control at the end
+# of this section.
+#
+# Order matters here, so keep it exactly as bind.test has it. Writing
+# "update" before "focus -force" makes this pass whether the bug is fixed
+# or not, which is how it hid for a round trip.
 toplevel .t -width 100 -height 50
 wm geom .t +0+0
 frame .t.f -class Test -width 150 -height 100
 pack .t.f
+focus -force .t.f
+mark "focus before update:      '[focus]'"
+mark "focus -lastfor .t.f:      '[focus -lastfor .t.f]' (.t.f = TkSetFocusWin got past the mapped test)"
 update
 mark "toplevel .t: exists [winfo exists .t], mapped [winfo ismapped .t], id [winfo id .t]"
 mark ".t.f:       exists [winfo exists .t.f], mapped [winfo ismapped .t.f], id [winfo id .t.f]"
-
-# Which of the two possible stories is it: the focus was never set, or it
-# was set and something during "update" took it away again? The observed
-# answer is ".f" -- the frame in "." from section 1c -- and that is not
-# what either clearing path in TkFocusFilterEvent leaves behind; both
-# assign NULL, which "focus" reports as empty. A real FocusIn arriving
-# for toplevel "." would restore exactly ".f", since that is what its
-# ToplevelFocusInfo remembers.
-#
-# Two probes separate the cases, with no C to rebuild:
-#
-#   "focus" before update       -- did TkSetFocusWin assign at all?
-#   "focus -lastfor .t.f"       -- reads .t's ToplevelFocusInfo, which
-#                                  TkSetFocusWin fills in *after* the
-#                                  allMapped test and *before* the
-#                                  assignment. .t.f here means it got
-#                                  past the mapped check; .t means it
-#                                  bailed there.
-#
-# A <FocusIn> binding on . and on .f then says whether anything really
-# is handing the focus back during update.
-bind . <FocusIn>    {mark "  ... FocusIn on . (%d)"}
-bind .f <FocusIn>   {mark "  ... FocusIn on .f (%d)"}
-bind .t.f <FocusIn> {mark "  ... FocusIn on .t.f (%d)"}
-bind .t.f <FocusOut> {mark "  ... FocusOut on .t.f (%d)"}
-
-focus -force .t.f
-mark "focus before update:      '[focus]' (want .t.f)"
-mark "focus -lastfor .t.f:      '[focus -lastfor .t.f]' (.t.f = passed the mapped test)"
-update
 mark "focus after update:       '[focus]' (want .t.f)"
-
-bind . <FocusIn> {}
-bind .f <FocusIn> {}
-bind .t.f <FocusIn> {}
-bind .t.f <FocusOut> {}
-
-# Re-assert the focus with nothing running in between, so the key cases
-# below test delivery rather than whatever update did to the focus.
-focus -force .t.f
-mark "focus for the key cases:  '[focus]'"
 
 set ::hits {}
 bind .t.f <Key> {lappend ::hits "K=%K k=%k N=%N"}

--- a/sys/src/external/tk/plan9/tkPlan9Init.c
+++ b/sys/src/external/tk/plan9/tkPlan9Init.c
@@ -100,7 +100,7 @@ TkP9FreeWindow(Window xid)
 void
 TkP9EnqueueEvent(XEvent *ev)
 {
-    int next = (gP9.evtail + 1) & 255;
+    int next = (gP9.evtail + 1) & TKP9_EVQMASK;
     if (next == gP9.evhead) return; /* drop if full */
     gP9.evqueue[gP9.evtail] = *ev;
     gP9.evtail = next;
@@ -111,7 +111,7 @@ TkP9DequeueEvent(XEvent *ev)
 {
     if (gP9.evhead == gP9.evtail) return 0;
     *ev = gP9.evqueue[gP9.evhead];
-    gP9.evhead = (gP9.evhead + 1) & 255;
+    gP9.evhead = (gP9.evhead + 1) & TKP9_EVQMASK;
     return 1;
 }
 
@@ -422,6 +422,46 @@ XMapWindow(Display *display, Window w)
     ev.xmap.event              = w;
     ev.xmap.window             = w;
     ev.xmap.override_redirect  = False;
+    TkP9EnqueueEvent(&ev);
+
+    /*
+     * Send VisibilityNotify. X sends one when a window becomes viewable,
+     * and Tk waits for it in more than one place -- most importantly
+     * FocusMapProc (tkFocus.c). "focus -force .w" on a window that is
+     * not yet mapped cannot set the focus, so TkSetFocusWin defers:
+     *
+     *	if (!allMapped) {
+     *	    Tk_CreateEventHandler((Tk_Window) winPtr, VisibilityChangeMask,
+     *		    FocusMapProc, winPtr);
+     *	    displayFocusPtr->focusOnMapPtr = winPtr;
+     *	    displayFocusPtr->forceFocus = force;
+     *	    return;
+     *	}
+     *
+     * and FocusMapProc finishes the job when the window turns up. With
+     * no VisibilityNotify ever sent, that handler never fired and the
+     * focus was simply never set.
+     *
+     * The idiom this breaks is the one every Tk test file opens with:
+     *
+     *	pack .t.f
+     *	focus -force .t.f
+     *	update
+     *
+     * pack maps on the idle queue, so at the moment of the focus command
+     * .t.f is still unmapped and the deferred path is the only path. Key
+     * events are the only thing that notices, since they alone are
+     * redirected through the focus (tkEvent.c InvokeFocusHandlers, which
+     * discards the event when there is no focus window) -- which is why
+     * a button binding on the very same widget worked while every key
+     * binding on it silently did nothing, and why bind.test failed 134
+     * cases with empty results and no errors.
+     */
+    memset(&ev, 0, sizeof(ev));
+    ev.type                 = VisibilityNotify;
+    ev.xvisibility.display  = display;
+    ev.xvisibility.window   = w;
+    ev.xvisibility.state    = VisibilityUnobscured;
     TkP9EnqueueEvent(&ev);
 
     /* Send Expose so the window gets repainted */

--- a/sys/src/external/tk/plan9/tkPlan9Int.h
+++ b/sys/src/external/tk/plan9/tkPlan9Int.h
@@ -37,6 +37,18 @@
 /* Root window XID */
 #define TKP9_ROOT_XID   10
 
+/*
+ * Pending-event ring size. Must be a power of two: TkP9EnqueueEvent and
+ * TkP9DequeueEvent wrap with TKP9_EVQMASK.
+ *
+ * Mapping one window enqueues three events (MapNotify, VisibilityNotify,
+ * Expose) and the ring drops silently when it is full, so this has to
+ * comfortably exceed the number of windows a single "update" can map --
+ * a Tk test file builds a widget tree and maps all of it at once.
+ */
+#define TKP9_EVQUEUE    1024
+#define TKP9_EVQMASK    (TKP9_EVQUEUE - 1)
+
 /* ------------------------------------------------------------------ */
 /* Per-window record                                                   */
 /* ------------------------------------------------------------------ */
@@ -72,7 +84,7 @@ typedef struct P9DisplayState {
     P9Window     wins[TKP9_MAX_WINDOWS];
     int          nwins;
     /* Pending X events queue (simple ring buffer) */
-    XEvent       evqueue[256];
+    XEvent       evqueue[TKP9_EVQUEUE];
     int          evhead;
     int          evtail;
     /* Last known mouse state */


### PR DESCRIPTION
"focus -force .w" on a window that is not yet mapped cannot set the focus, and TkSetFocusWin does not fail on that -- it defers, arming a VisibilityChangeMask handler and letting FocusMapProc finish the job when the window turns up. XMapWindow here sent MapNotify and Expose but never VisibilityNotify, so that handler never fired and the focus was simply never set.

The idiom this breaks is the one every Tk test file opens with:

	pack .t.f
	focus -force .t.f
	update

pack maps on the idle queue, so at the moment of the focus command .t.f is still unmapped and the deferred path is the only path.

Key events are the only thing that notices, because they alone are redirected through the focus: InvokeFocusHandlers (tkEvent.c:255) calls TkFocusKeyEvent, which returns NULL when there is no focus window, and Tk_HandleEvent then discards the event. So a Button-1 binding worked on the very widget whose Key bindings silently did nothing, and bind.test failed 134 cases with empty results and no errors.

Reordering those two lines makes it work, which is what hid it: tk-bind-test.tcl passed its key cases because it had update before focus -force. Section 5 now uses bind.test's order and says so.

Mapping a window costs three events now, and the ring dropped silently when full, so it holds 1024 rather than 256 and the wrap derives from TKP9_EVQUEUE instead of a hardcoded & 255.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs