### PR TITLE
tk/plan9: back the selection and clipboard with /dev/snarf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1282,6 +1282,38 @@ NULL, so the focus had never moved in the first place.
 wrap derives from it rather than a hardcoded `& 255`): mapping one
 window costs three events, and a full ring is dropped silently.
 
+### Tk on Plan 9: the clipboard is /dev/snarf
+
+Plan 9 has one system-wide cut buffer, `/dev/snarf`, served by rio, so
+PRIMARY and CLIPBOARD both map onto it -- which is what a user wants
+anyway: snarf in an editor, paste into a Tk entry.
+
+Both directions were missing, and they fail independently:
+
+- `TkSelGetSelection` answered `"selection not supported"`. That is the
+  hook for a selection **this application does not own**; a locally
+  owned one is served by `tkSelect.c` from its own handlers and never
+  reaches the platform (`Tk_GetSelection`), so `clipboard get` right
+  after `clipboard append` worked and hid half the gap.
+- `TkSelUpdateClipboard` was `#define TkSelUpdateClipboard(a,b) {}` in
+  `tkPlan9Port.h`, so nothing a Tk program copied ever left the process.
+
+`tkp9_getsnarf`/`tkp9_putsnarf` in `tkPlan9DrawImpl.c` open, do their
+business and close every time: rio serves the whole buffer from offset 0
+of a freshly opened `/dev/snarf` and there is no change notification, so
+a held descriptor reads a stale copy. The contents are UTF-8, which is
+what a `UTF8_STRING` target wants and what Plan 9 uses natively, so
+nothing is converted.
+
+`TkSelUpdateClipboard` rebuilds the whole buffer from
+`dispPtr->clipTargetPtr` on every clear and every append rather than
+trying to append -- rio offers no way to append to `/dev/snarf`, and a
+clear then correctly leaves it empty.
+
+Covered by `sys/lib/tests/tk-selection-test.tcl`, which tests the two
+directions separately and skips itself when `/dev/snarf` cannot be
+opened (there is no snarf file without rio).
+
 ### Build order for compiler changes
 ```
 cd sys/src/cmd/cc && mk nuke && mk install   # regenerates y.tab.h

--- a/sys/lib/tests/tk-selection-test.tcl
+++ b/sys/lib/tests/tk-selection-test.tcl
@@ -1,0 +1,122 @@
+# Does the clipboard reach /dev/snarf, and does the snarf buffer reach Tk?
+#
+#	wish tk-selection-test.tcl
+#
+# Plan 9 has one system-wide cut buffer, /dev/snarf, served by rio, so
+# both PRIMARY and CLIPBOARD map onto it. Before this, TkSelGetSelection
+# answered "selection not supported" and TkSelUpdateClipboard was an
+# empty macro in tkPlan9Port.h -- so nothing a Tk program copied was
+# visible to anything else, and nothing snarfed elsewhere could be
+# pasted in. clipboard.test failed 12 cases on the first of those.
+#
+# The two directions fail independently and are tested separately:
+#
+#   out -- "clipboard append" then read /dev/snarf
+#   in  -- write /dev/snarf then "clipboard get"
+#
+# Note the "in" direction is the only one that exercises
+# TkSelGetSelection at all. tkSelect.c serves a selection this
+# application owns from its own handlers and never reaches the platform
+# hook (Tk_GetSelection), so a "clipboard get" straight after a
+# "clipboard append" proves nothing about it -- hence the deliberate
+# "selection clear" and the write from outside.
+
+set fail 0
+
+proc check {what got want} {
+    global fail
+    if {$got eq $want} {
+	puts "PASS $what"
+    } else {
+	puts "FAIL $what: got '$got', want '$want'"
+	incr fail
+    }
+    flush stdout
+}
+
+proc snarf {} {
+    set f [open /dev/snarf r]
+    set s [read $f]
+    close $f
+    return $s
+}
+
+proc setsnarf {s} {
+    set f [open /dev/snarf w]
+    puts -nonewline $f $s
+    close $f
+}
+
+# 0. Can we reach /dev/snarf at all? Without rio there is no snarf file,
+# and every case below would fail for a reason that has nothing to do
+# with Tk.
+if {[catch {snarf} err]} {
+    puts "SKIP: cannot read /dev/snarf ($err) -- run this under rio"
+    exit 0
+}
+
+# 1. Out: Tk's clipboard -> /dev/snarf.
+clipboard clear
+clipboard append "hello snarf"
+check "clipboard append reaches /dev/snarf" [snarf] "hello snarf"
+
+# Appends accumulate, and the whole buffer is rewritten each time.
+clipboard append " and again"
+check "second append accumulates" [snarf] "hello snarf and again"
+
+# A clear empties it: the target list is empty and there is nothing to
+# write.
+clipboard clear
+check "clipboard clear empties /dev/snarf" [snarf] ""
+
+# UTF-8 has to survive both ways; /dev/snarf is UTF-8 and so is Tk.
+clipboard clear
+clipboard append "åäö 中文"
+check "utf-8 out" [snarf] "åäö 中文"
+
+# 2. In: /dev/snarf -> Tk. This is the direction that goes through
+# TkSelGetSelection, and only when Tk does not own the selection itself.
+clipboard clear
+selection clear -selection CLIPBOARD
+selection clear -selection PRIMARY
+
+setsnarf "from the outside"
+check "clipboard get reads /dev/snarf" \
+    [selection get -selection CLIPBOARD] "from the outside"
+check "selection get reads /dev/snarf" \
+    [selection get -selection PRIMARY] "from the outside"
+
+setsnarf "åäö 中文"
+check "utf-8 in" [selection get -selection CLIPBOARD] "åäö 中文"
+
+# An empty snarf buffer is a legitimate empty answer, not an error.
+setsnarf ""
+if {[catch {selection get -selection CLIPBOARD} got]} {
+    puts "FAIL empty snarf raised: $got"
+    incr fail
+} else {
+    check "empty snarf gives empty string" $got ""
+}
+
+# 3. A target nothing can supply must still say so in the words Tk's own
+# tests expect, rather than "selection not supported".
+if {[catch {selection get -selection CLIPBOARD -type NO_SUCH_TARGET} err]} {
+    check "unknown target message" \
+	[string match "*selection doesn't exist or form*" $err] 1
+} else {
+    puts "FAIL unknown target returned '$err' instead of raising"
+    incr fail
+}
+
+# TARGETS is answered from the platform hook and must name what we can
+# actually convert to.
+if {[catch {selection get -selection CLIPBOARD -type TARGETS} got]} {
+    puts "FAIL TARGETS raised: $got"
+    incr fail
+} else {
+    check "TARGETS includes UTF8_STRING" [expr {"UTF8_STRING" in $got}] 1
+}
+
+puts "$fail failure(s)"
+flush stdout
+exit $fail

--- a/sys/src/external/tk/plan9/tkP9Draw.h
+++ b/sys/src/external/tk/plan9/tkP9Draw.h
@@ -70,6 +70,19 @@ void   tkp9_drawpoints(void *dst, int *xv, int *yv, int n, unsigned long rgba);
 void   tkp9_flush(void);
 
 /*
+ * The snarf buffer -- Plan 9's system-wide cut buffer, /dev/snarf,
+ * served by rio. There is exactly one of them, so both PRIMARY and
+ * CLIPBOARD map onto it.
+ *
+ * tkp9_getsnarf returns malloc'd NUL-terminated UTF-8 that the caller
+ * frees, or NULL if the buffer could not be read. It is reopened on
+ * every call because rio serves the whole contents from offset 0 and a
+ * held descriptor would go stale.
+ */
+char  *tkp9_getsnarf(void);
+int    tkp9_putsnarf(const char *s, int nbytes);   /* 0 on success */
+
+/*
  * Fonts (opaque handle = Plan 9 Font*)
  */
 void  *tkp9_openfont(const char *name);	  /* returns Font*, or defont */

--- a/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
+++ b/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
@@ -278,6 +278,86 @@ tkp9_flush(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Snarf buffer (/dev/snarf)                                           */
+/* ------------------------------------------------------------------ */
+
+/*
+ * rio serves the whole snarf buffer from offset 0 of a freshly opened
+ * /dev/snarf and there is no way to be told when it changes, so both of
+ * these open, do their business and close. Holding the descriptor open
+ * would read a stale copy.
+ *
+ * The contents are UTF-8, which is what Tk wants for a UTF8_STRING
+ * target and what Plan 9 uses natively, so no conversion is needed.
+ */
+char *
+tkp9_getsnarf(void)
+{
+    int fd, n;
+    long len, cap;
+    char *buf, *nbuf;
+
+    fd = open("/dev/snarf", O_RDONLY);
+    if (fd < 0)
+	return NULL;
+
+    cap = 4096;
+    len = 0;
+    buf = malloc(cap);
+    if (buf == NULL) {
+	close(fd);
+	return NULL;
+    }
+    for (;;) {
+	if (len + 1 >= cap) {
+	    cap *= 2;
+	    nbuf = realloc(buf, cap);
+	    if (nbuf == NULL) {
+		free(buf);
+		close(fd);
+		return NULL;
+	    }
+	    buf = nbuf;
+	}
+	n = read(fd, buf + len, cap - len - 1);
+	if (n < 0) {
+	    free(buf);
+	    close(fd);
+	    return NULL;
+	}
+	if (n == 0)
+	    break;
+	len += n;
+    }
+    close(fd);
+    buf[len] = '\0';
+    return buf;
+}
+
+int
+tkp9_putsnarf(const char *s, int nbytes)
+{
+    int fd, n;
+    int off = 0;
+
+    if (s == NULL)
+	return -1;
+    fd = open("/dev/snarf", O_WRONLY|O_TRUNC);
+    if (fd < 0)
+	return -1;
+    while (off < nbytes) {
+	n = write(fd, s + off, nbytes - off);
+	if (n <= 0) {
+	    close(fd);
+	    return -1;
+	}
+	off += n;
+    }
+    close(fd);
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
 /* Fonts                                                               */
 /* ------------------------------------------------------------------ */
 

--- a/sys/src/external/tk/plan9/tkPlan9Port.h
+++ b/sys/src/external/tk/plan9/tkPlan9Port.h
@@ -91,8 +91,14 @@
  */
 #define TkpButtonSetDefaults()		{}
 #define TkpDestroyButton(butPtr)	{}
-#define TkSelUpdateClipboard(a,b)	{}
 #define TkSetPixmapColormap(p,c)	{}
+
+/*
+ * TkSelUpdateClipboard used to be an empty macro here. It is a real
+ * function now (tkPlan9Wm.c), which pushes Tk's clipboard out to
+ * /dev/snarf; tkSelect.h declares it when this file does not define it
+ * as a macro.
+ */
 
 #define TkpPrintWindowId(buf,w) \
 	snprintf((buf), TCL_INTEGER_SPACE, "0x%lx", (unsigned long)(w))

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -9,7 +9,9 @@
  */
 
 #include "tkPlan9Int.h"
+#include "tkSelect.h"
 #include <time.h>
+#include <stdlib.h>
 
 /* ------------------------------------------------------------------ */
 /* TkpGetWrapperWindow / TkpMakeMenuWindow                            */
@@ -173,19 +175,105 @@ Cups_Init(Tcl_Interp *interp)
 }
 
 /* ------------------------------------------------------------------ */
-/* Selection / clipboard stubs                                        */
+/* Selection / clipboard, backed by /dev/snarf                        */
 /* ------------------------------------------------------------------ */
 
+/*
+ * Plan 9 has one system-wide cut buffer, /dev/snarf, so PRIMARY and
+ * CLIPBOARD both map onto it. That is the behaviour a user wants
+ * anyway: snarf in an editor, paste into a Tk entry.
+ *
+ * This hook is reached only for a selection Tk does *not* own --
+ * tkSelect.c serves a locally-owned one from its own handlers and never
+ * gets here (see Tk_GetSelection), so "clipboard get" right after
+ * "clipboard append" does not depend on any of this.
+ */
 int
 TkSelGetSelection(Tcl_Interp *interp, Tk_Window tkwin,
                   Atom selection, Atom target,
                   Tk_GetSelProc *proc, void *clientData)
 {
-    (void)tkwin; (void)selection; (void)target;
-    (void)proc; (void)clientData;
-    Tcl_SetObjResult(interp,
-        Tcl_NewStringObj("selection not supported", -1));
+    const char *targetName;
+    char *snarf;
+    int result;
+
+    targetName = Tk_GetAtomName(tkwin, target);
+
+    if (strcmp(targetName, "TARGETS") == 0)
+	return proc(clientData, interp, "STRING TARGETS TEXT UTF8_STRING");
+
+    if (strcmp(targetName, "STRING") != 0
+	    && strcmp(targetName, "UTF8_STRING") != 0
+	    && strcmp(targetName, "TEXT") != 0
+	    && strcmp(targetName, "COMPOUND_TEXT") != 0)
+	goto cantget;
+
+    /* /dev/snarf is UTF-8, which is what every one of those wants. */
+    snarf = tkp9_getsnarf();
+    if (snarf == NULL)
+	goto cantget;
+    result = proc(clientData, interp, snarf);
+    free(snarf);
+    return result;
+
+  cantget:
+    Tcl_SetObjResult(interp, Tcl_ObjPrintf(
+	"%s selection doesn't exist or form \"%s\" not defined",
+	Tk_GetAtomName(tkwin, selection), targetName));
+    Tcl_SetErrorCode(interp, "TK", "SELECTION", "EXISTS", (char *)NULL);
     return TCL_ERROR;
+}
+
+/*
+ * Push Tk's clipboard out to /dev/snarf.
+ *
+ * Called by tkClipboard.c after every "clipboard clear" and every
+ * "clipboard append", and it was an empty macro in tkPlan9Port.h -- so
+ * nothing a Tk application copied was ever visible to anything else on
+ * the system.
+ *
+ * Rebuild the whole buffer each time rather than trying to append: on a
+ * clear the target list is empty and snarf correctly becomes empty, and
+ * on an append the concatenation is what the clipboard now holds. rio
+ * gives no way to append to /dev/snarf in any case.
+ */
+void
+TkSelUpdateClipboard(TkWindow *winPtr, clipboardOption option)
+{
+    TkDisplay *dispPtr;
+    TkClipboardTarget *targetPtr, *bestPtr;
+    TkClipboardBuffer *cbPtr;
+    Atom utf8Atom, stringAtom;
+    Tcl_DString ds;
+
+    (void)option;
+    if (winPtr == NULL || winPtr->dispPtr == NULL)
+	return;
+    dispPtr = winPtr->dispPtr;
+
+    utf8Atom   = Tk_InternAtom((Tk_Window) winPtr, "UTF8_STRING");
+    stringAtom = Tk_InternAtom((Tk_Window) winPtr, "STRING");
+
+    /* Prefer UTF8_STRING; fall back to STRING. Both are UTF-8 here. */
+    bestPtr = NULL;
+    for (targetPtr = dispPtr->clipTargetPtr; targetPtr != NULL;
+	    targetPtr = targetPtr->nextPtr) {
+	if (targetPtr->type == utf8Atom) {
+	    bestPtr = targetPtr;
+	    break;
+	}
+	if (targetPtr->type == stringAtom && bestPtr == NULL)
+	    bestPtr = targetPtr;
+    }
+
+    Tcl_DStringInit(&ds);
+    if (bestPtr != NULL) {
+	for (cbPtr = bestPtr->firstBufferPtr; cbPtr != NULL;
+		cbPtr = cbPtr->nextPtr)
+	    Tcl_DStringAppend(&ds, cbPtr->buffer, (Tcl_Size) cbPtr->length);
+    }
+    tkp9_putsnarf(Tcl_DStringValue(&ds), (int) Tcl_DStringLength(&ds));
+    Tcl_DStringFree(&ds);
 }
 
 void


### PR DESCRIPTION
Plan 9 has one system-wide cut buffer, served by rio, so PRIMARY and CLIPBOARD both map onto it. Neither direction worked:

TkSelGetSelection answered "selection not supported" -- the message clipboard.test reported 12 times. That hook is reached only for a selection this application does not own, since tkSelect.c serves a locally owned one from its own handlers (Tk_GetSelection), so a "clipboard get" straight after a "clipboard append" worked and hid it.

TkSelUpdateClipboard was an empty macro in tkPlan9Port.h, so nothing a Tk program copied ever left the process.

tkp9_getsnarf and tkp9_putsnarf open, act and close each time: rio serves the whole buffer from offset 0 of a freshly opened /dev/snarf and gives no change notification, so a held descriptor would read a stale copy. The contents are UTF-8 both ways, so nothing is converted.

The clipboard is rewritten whole on every clear and append rather than appended to -- rio offers no way to append to /dev/snarf, and a clear then correctly leaves it empty.

Covered by sys/lib/tests/tk-selection-test.tcl, which tests the two directions separately and skips itself when /dev/snarf cannot be opened.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs