### PR TITLE
tk/plan9: fix a stranded return type, and two prototype mismatches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1314,6 +1314,46 @@ Covered by `sys/lib/tests/tk-selection-test.tcl`, which tests the two
 directions separately and skips itself when `/dev/snarf` cannot be
 opened (there is no snarf file without rio).
 
+### Syntax-check Tk's Plan 9 backend on the host before shipping it
+
+A round trip to the VM costs a full rebuild, and twice now it has been
+spent on a typo. gcc will parse these files on the build host -- it
+never links, and it does not need Plan 9 -- so a bad edit is caught in
+a second instead of a rebuild:
+
+```sh
+cd sys/src/external/tk
+for f in plan9/*.c; do
+	[ "$f" = plan9/tkPlan9DrawImpl.c ] && continue	# needs <draw.h>
+	gcc -fsyntax-only -w -Igeneric -Igeneric/ttk -Ixlib -Ibitmaps \
+	    -Iplan9 -I../tcl/generic -I../tcl/plan9 \
+	    -DHAVE_TCL_CONFIG_H -DHAVE_TK_CONFIG_H -DPLAN9 \
+	    -DMODULE_SCOPE=extern -DWCHAR=char -DTK_PLATFORM='"plan9"' \
+	    -DSTATIC_BUILD "$f" || echo "FAILED $f"
+done
+```
+
+All seven files are clean today, so any output is a regression. Note
+gcc is *stricter* than pcc here and that is the point: it rejects the
+prototype mismatches `rsametype()` waves through, which is how
+`TkpBuildRegionFromAlphaData` was found taking a `const unsigned char *`
+against a declaration with no `const`, and `XCreateGlyphCursor` taking
+non-const `XColor *` against Xlib's `_Xconst`.
+
+The mistake it would have caught both times is putting a comment
+*between* a function's return type and its declarator, which strands the
+old return type above it:
+
+```c
+const char *
+/* ... comment ... */
+char *
+TkpGetString(...)
+```
+
+pcc reports that as `syntax error, last name: char`, which names neither
+the function nor the real problem.
+
 ### Tk on Plan 9: modifier keys are not events of their own
 
 `tkBind.c` consults `dispPtr->modKeyCodes` twice, and both uses are

--- a/sys/src/external/tk/plan9/tkPlan9Draw.c
+++ b/sys/src/external/tk/plan9/tkPlan9Draw.c
@@ -477,7 +477,7 @@ XCreatePixmapCursor(Display *d, Pixmap p1, Pixmap p2,
 Cursor
 XCreateGlyphCursor(Display *d, Font f1, Font f2,
                    unsigned int ch1, unsigned int ch2,
-                   XColor *c1, XColor *c2)
+                   const XColor *c1, const XColor *c2)
 {
     (void)d; (void)f1; (void)f2; (void)ch1; (void)ch2; (void)c1; (void)c2;
     return P9NextCursorId();

--- a/sys/src/external/tk/plan9/tkPlan9Event.c
+++ b/sys/src/external/tk/plan9/tkPlan9Event.c
@@ -415,7 +415,6 @@ TkpSync(Display *display)
 /* Key mapping stubs (minimal)                                         */
 /* ------------------------------------------------------------------ */
 
-void
 /*
  * Does producing this keysym require Shift?
  *

--- a/sys/src/external/tk/plan9/tkPlan9Stubs.c
+++ b/sys/src/external/tk/plan9/tkPlan9Stubs.c
@@ -147,7 +147,7 @@ void
 TkpBuildRegionFromAlphaData(Region region,
     unsigned x, unsigned y,
     unsigned width, unsigned height,
-    const unsigned char *dataPtr,
+    unsigned char *dataPtr,
     unsigned pixelStride,
     unsigned lineStride)
 {


### PR DESCRIPTION
TkpInitKeymapInfo's "void" was left above the comment introducing the new TkP9KeysymShifted, so pcc saw "void /*...*/ int TkP9KeysymShifted" and reported

	tkPlan9Event.c:411 illegal combination of types INT VOID

Same shape as the tkPlan9Stubs.c slip two commits ago, so CLAUDE.md now carries the host syntax check that catches it: gcc -fsyntax-only parses every file in plan9/ except tkPlan9DrawImpl.c (which needs <draw.h>) without linking or needing Plan 9, in about a second.

Running it turned up two real prototype mismatches that pcc waves through, since rsametype() ignores const: TkpBuildRegionFromAlphaData took a const unsigned char * against a declaration with none, and XCreateGlyphCursor took non-const XColor * against Xlib's _Xconst. All seven files are clean now, so any output from that loop is a regression.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs