### PR TITLE
tk/plan9: font actual reports the resolved family, and the size in po…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1393,6 +1393,24 @@ against. A wrong entry costs size accuracy and nothing else.
 Tk uses it to skip measuring character by character, so claiming it for
 a proportional font mislays every string.
 
+**`font actual` reports what was resolved, not what was asked for.**
+`tkUnixFont.c` reports the family of the X font it actually found, and
+code relies on that: font.test asks
+
+```tcl
+if {[font actual {avantgarde 12 roman normal} -family] eq "avantgarde"}
+```
+
+to decide whether the machine really has that family, and took the wrong
+branch while every request answered with its own name. There are three
+families here -- courier, times, helvetica -- whatever was requested.
+
+The **size is reported in points**, which is what makes `font actual
+-size` depend on `tk scaling`: Tk stores a negative size as pixels, so at
+scaling 0.5 a request for `-13` pixels is 26 points (font-44.1).
+`TkFontGetPixels` on the way in, `TkFontGetPoints` on the way out, as
+`tkUnixFont.c` does.
+
 ### Tk on Plan 9: stacking order, and the two coordinate spaces
 
 Three separate things were missing here, and they hide each other:

--- a/sys/lib/tests/tk-font-test.tcl
+++ b/sys/lib/tests/tk-font-test.tcl
@@ -71,11 +71,20 @@ if {[catch {.l configure -font {}} err]} {
 }
 
 # 2. A "{family} size style" list must be parsed, not swallowed whole.
-# Tk keeps the family as written when the platform cannot resolve it to
-# a real font name -- X11 answers lowercase because the X font name is
-# lowercase. Either is defensible, so compare without case.
+#
+# "font actual" reports the family that was RESOLVED, not the one asked
+# for, as tkUnixFont.c does -- there are three families here whatever
+# was requested. font.test relies on that: it asks whether
+# "font actual {avantgarde 12} -family" is still "avantgarde" to decide
+# whether the machine really has that family.
 check "family of {Helvetica -12}" \
     [string tolower [font actual {Helvetica -12} -family]] "helvetica"
+check "family of {Courier 10}" \
+    [string tolower [font actual {Courier 10} -family]] "courier"
+check "family of {Times 10}" \
+    [string tolower [font actual {Times 10} -family]] "times"
+check "an unknown family resolves to something else" \
+    [expr {[font actual {avantgarde 12} -family] ne "avantgarde"}] 1
 check "size of {Helvetica -12}" \
     [font actual {Helvetica -12} -size] "-12"
 check "size of {Courier 10}" \
@@ -117,6 +126,59 @@ if {[dict get $m20 -linespace] > [dict get $m8 -linespace]} {
     note "FAIL linespace does not follow size"
     incr fail
 }
+
+# 5b. "font actual -size" is in POINTS, so it follows "tk scaling"; Tk
+# stores a negative size as pixels. At scaling 0.5 a request for -13
+# pixels is 26 points. This is font-44.1.
+set oldscaling [tk scaling]
+tk scaling 0.5
+check "size in points follows tk scaling" [font actual {times -13} -size] 26
+tk scaling $oldscaling
+
+# 5c. Text layout across lines.
+#
+# font-28.* and font-30.* ask a canvas text item which character is at a
+# given point, and get 0 where they want the start of line 2. Both the
+# label that defines the reference height and the canvas item use
+# "Courier -12", so they should agree.
+#
+# Tk_PointToChar picks a line with
+#
+#	if (y < baseline + fontPtr->fm.descent)
+#
+# and the first line's baseline is fm.ascent, so line 1 is chosen for
+# y < ascent+descent. Returning 0 therefore means ay came out SMALLER
+# than the font's own ascent+descent -- but ay is the reqheight of a
+# label with no padding, which is exactly one line. These numbers say
+# which of the two is wrong.
+destroy .t 2>/dev/null
+toplevel .t
+label .t.l -padx 0 -pady 0 -bd 0 -highlightthickness 0 -justify left \
+    -text "0" -font "Courier -12"
+pack .t.l
+update
+set ax [winfo reqwidth .t.l]
+set ay [winfo reqheight .t.l]
+note "label reqwidth  (ax) = $ax"
+note "label reqheight (ay) = $ay"
+note "metrics of Courier -12: [font metrics "Courier -12"]"
+note "  ascent+descent = [expr {[font metrics {Courier -12} -ascent] + \
+    [font metrics {Courier -12} -descent]}] (ay must equal this)"
+note "  actual: [font actual "Courier -12"]"
+
+canvas .t.c -closeenough 0
+.t.c create text 0 0 -tags text -anchor nw -just left -font "Courier -12"
+pack .t.c
+update
+.t.c dchars text 0 end
+.t.c insert text 0 "000\n000\n000"
+update
+note "canvas bbox of 3 lines: [.t.c bbox text]"
+foreach probe [list 0 [expr {$ay - 1}] $ay [expr {$ay + 1}] [expr {2 * $ay}]] {
+    note "  index @0,$probe -> [.t.c index text @0,$probe]"
+}
+check "index at the start of line 2" [.t.c index text @0,$ay] 4
+destroy .t
 
 # 6. A real Plan 9 font path is a native name and must still work.
 set p /lib/font/bit/fixed/unicode.6x13.font

--- a/sys/src/external/tk/plan9/tkPlan9Font.c
+++ b/sys/src/external/tk/plan9/tkPlan9Font.c
@@ -235,7 +235,8 @@ FontIsFixed(void *fnt)
 }
 
 static void *
-ChooseFont(Tk_Window tkwin, const TkFontAttributes *faPtr)
+ChooseFont(Tk_Window tkwin, const TkFontAttributes *faPtr,
+           const char **familyPtr)
 {
     const P9FontFile *table, *variant = NULL;
     int pixels;
@@ -247,14 +248,17 @@ ChooseFont(Tk_Window tkwin, const TkFontAttributes *faPtr)
 
     if (IsMonoFamily(faPtr->family)) {
         table = monoFonts;
+        *familyPtr = "courier";
         if (faPtr->weight == TK_FW_BOLD)      variant = monoBoldFonts;
         else if (faPtr->slant != TK_FS_ROMAN) variant = monoItalicFonts;
     } else if (IsSerifFamily(faPtr->family)) {
         table = serifFonts;
+        *familyPtr = "times";
         if (faPtr->weight == TK_FW_BOLD)      variant = serifBoldFonts;
         else if (faPtr->slant != TK_FS_ROMAN) variant = serifItalicFonts;
     } else {
         table = propFonts;
+        *familyPtr = "helvetica";
         if (faPtr->weight == TK_FW_BOLD)      variant = propBoldFonts;
         else if (faPtr->slant != TK_FS_ROMAN) variant = propItalicFonts;
     }
@@ -316,7 +320,6 @@ TkpGetNativeFont(Tk_Window tkwin, const char *name)
 {
     P9Font *p9f;
     void *fnt;
-    (void)tkwin;
 
     if (name == NULL || name[0] != '/')
         return NULL;
@@ -332,7 +335,8 @@ TkpGetNativeFont(Tk_Window tkwin, const char *name)
     p9f->height  = tkp9_fontheight(fnt);
 
     p9f->header.fa.family     = Tk_GetUid(name);
-    p9f->header.fa.size       = -p9f->height;	/* negative == pixels */
+    /* Stored negative (pixels), reported in points, as above. */
+    p9f->header.fa.size       = TkFontGetPoints(tkwin, -p9f->height);
     p9f->header.fa.weight     = TK_FW_NORMAL;
     p9f->header.fa.slant      = TK_FS_ROMAN;
     p9f->header.fa.underline  = 0;
@@ -357,8 +361,9 @@ TkpGetFontFromAttributes(
 {
     P9Font *p9f;
     void *fnt;
+    const char *family = "helvetica";
 
-    fnt = ChooseFont(tkwin, faPtr);
+    fnt = ChooseFont(tkwin, faPtr, &family);
     if (fnt == NULL)
         return NULL;
 
@@ -377,12 +382,25 @@ TkpGetFontFromAttributes(
     p9f->height  = tkp9_fontheight(fnt);
 
     /*
-     * Report back what was asked for, not what was found: Tk caches on
-     * these attributes, and answering with the file's own size would
-     * make "font actual" disagree with the request for every size that
-     * has no exact bitmap.
+     * "font actual" reports what was RESOLVED, not what was asked for.
+     * tkUnixFont.c does the same -- it reports the family of the X font
+     * it actually found -- and code relies on it: font.test asks
+     *
+     *	if {[font actual {avantgarde 12 roman normal} -family] eq "avantgarde"}
+     *
+     * to decide whether this machine really has that family, and took
+     * the wrong branch when every request answered with its own name.
+     * There are three families here, whatever was asked for.
+     *
+     * The size is reported in points. Tk stores a negative size as
+     * pixels, and "font actual -size" must give points, which is what
+     * makes it depend on "tk scaling": at scaling 0.5, a request for
+     * -13 pixels is 26 points (font-44.1). tkUnixFont.c is the same
+     * pair of calls.
      */
     p9f->header.fa          = *faPtr;
+    p9f->header.fa.family   = Tk_GetUid(family);
+    p9f->header.fa.size     = TkFontGetPoints(tkwin, faPtr->size);
     p9f->header.fm.ascent   = p9f->ascent;
     p9f->header.fm.descent  = p9f->descent;
     p9f->header.fm.fixed    = FontIsFixed(fnt);

--- a/tmp/tk-all.out
+++ b/tmp/tk-all.out
@@ -6,7 +6,7 @@ Test files sourced into current interpreter
 Running tests that match:  *
 Skipping test files that match:  l.*.test
 Only running test files that match:  *.test
-Tests began at 2026-09-05 10:45:37 +0200
+Tests began at 2026-09-05 18:23:17 +0200
 bell.test
 Bell should ring now ...
 bgerror.test
@@ -616,65 +616,6 @@ font.test
 
 
 
-==== font-24.5 Tk_ComputeTextLayout: break line FAILED
-==== Contents of test case:
-
-    .t.l config -text "000\t00000" -wrap [expr 9 * $ax]
-    update
-    list [expr {[winfo reqwidth .t.l] eq [expr {$ax * 8}]}]  [expr {[winfo reqheight .t.l] eq [expr {$ay * 2}]}]
-
----- Result was:
-0 1
----- Result should have been (exact matching):
-1 1
-==== font-24.5 FAILED
-
-
-
-==== font-24.11 Tk_ComputeTextLayout: absorb spaces at eol FAILED
-==== Contents of test case:
-
-    set x {}
-    .t.l config -text "000            000" -wrap [expr {$ax * 5}]
-    update
-    lappend x [expr {[winfo reqwidth .t.l] eq [expr {$ax * 3}]}]
-    lappend x [expr {[winfo reqheight .t.l] eq [expr {$ay * 2}]}]
-    .t.l config -text "000            "
-    update
-    lappend x [expr {[winfo reqwidth .t.l] eq [expr {$ax * 3}]}]
-    lappend x [expr {[winfo reqheight .t.l] eq $ay}]
-    return $x
-
----- Result was:
-0 1 0 1
----- Result should have been (exact matching):
-1 1 1 1
-==== font-24.11 FAILED
-
-
-
-==== font-24.12 Tk_ComputeTextLayout: append non-printing spaces to chunk FAILED
-==== Contents of test case:
-
-    set x {}
-    .t.l config -text "000            0000" -wrap [expr {$ax * 5}]
-    update
-    lappend x [expr {[winfo reqwidth .t.l] eq [expr {$ax * 4}]}]
-    lappend x [expr {[winfo reqheight .t.l] eq [expr {$ay * 2}]}]
-    .t.l config -text "000\t00            0000" -wrap [expr {$ax * 12}]
-    update
-    lappend x [expr {[winfo reqwidth .t.l] eq [expr {$ax * 10}]}]
-    lappend x [expr {[winfo reqheight .t.l] eq [expr {$ay * 2}]}]
-    return $x
-
----- Result was:
-0 1 0 1
----- Result should have been (exact matching):
-1 1 1 1
-==== font-24.12 FAILED
-
-
-
 ==== font-24.15 Tk_ComputeTextLayout: justification FAILED
 ==== Contents of test case:
 
@@ -777,23 +718,6 @@ font.test
 ---- Result should have been (exact matching):
 7
 ==== font-28.9 FAILED
-
-
-
-==== font-28.10 Tk_PointToChar procedure: past all chars in chunk FAILED
-==== Contents of test case:
-
-    csetup "000 0000000"
-    .t.c itemconfig text -width [expr $ax*5]
-    set x [.t.c index text @[expr $ax*5],0]
-    .t.c itemconfig text -width 0
-    return $x
-
----- Result was:
-4
----- Result should have been (exact matching):
-3
-==== font-28.10 FAILED
 
 
 
@@ -938,23 +862,6 @@ font.test
 ---- Result should have been (exact matching):
 1
 ==== font-30.13 FAILED
-
-
-
-==== font-31.6 Tk_IntersectTextLayout procedure: ignore spaces at eol FAILED
-==== Contents of test case:
-
-    csetup "000\n000      000000000"
-    .t.c itemconfig text -width [expr $ax*10]
-    set x [.t.c find overlapping [expr $ax*5] $ay [expr $ax*5] $ay]
-    .t.c itemconfig text -width 0
-    return $x
-
----- Result was:
-1
----- Result should have been (exact matching):
-
-==== font-31.6 FAILED
 
 
 


### PR DESCRIPTION
…ints

Two things "font actual" is required to answer, and this port answered neither.

It reports the family that was RESOLVED, not the one asked for -- tkUnixFont.c reports the family of the X font it actually found. Code relies on it: font.test asks whether

	font actual {avantgarde 12 roman normal} -family

is still "avantgarde" to decide whether the machine really has that family, and took the wrong branch while every request answered with its own name, so font-21.7..10 called a test helper with four arguments where it takes one. There are three families here -- courier, times, helvetica -- whatever was requested, and ChooseFont now says which one it picked.

The size is reported in points, which is what makes it follow "tk scaling": Tk stores a negative size as pixels, so at scaling 0.5 a request for -13 pixels is 26 points. That is font-44.1, and font-45.* beside it. TkFontGetPixels on the way in, TkFontGetPoints on the way out, the same pair tkUnixFont.c uses.

tk-font-test.tcl follows the family change and gains the scaling case, plus diagnostics for the one cluster I cannot pin from here: font-28.* and font-30.* ask a canvas text item which character is at a point and get 0 where they want the start of line 2. Tk_PointToChar picks a line with "y < baseline + fm.descent" and the first baseline is fm.ascent, so 0 means the reference height came out smaller than the font's own ascent+descent -- while that reference is the reqheight of an unpadded one-line label in the same font, which should be exactly equal. The test now prints both numbers and probes the index either side of the boundary.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs