### PR TITLE
tests: tk-font-test.tcl -- ask whether cos(0.0) is exactly 1.0

### DIFF
--- a/sys/lib/tests/tk-font-test.tcl
+++ b/sys/lib/tests/tk-font-test.tcl
@@ -85,8 +85,10 @@ check "family of {Times 10}" \
     [string tolower [font actual {Times 10} -family]] "times"
 check "an unknown family resolves to something else" \
     [expr {[font actual {avantgarde 12} -family] ne "avantgarde"}] 1
+# In POINTS, so a request for -12 pixels at scaling 1.0 reads back as 12.
+# font-44.1 is the same rule with scaling 0.5, in section 5b.
 check "size of {Helvetica -12}" \
-    [font actual {Helvetica -12} -size] "-12"
+    [font actual {Helvetica -12} -size] "12"
 check "size of {Courier 10}" \
     [font actual {Courier 10} -size] "10"
 check "weight of {Helvetica 12 bold}" \
@@ -174,10 +176,39 @@ update
 .t.c insert text 0 "000\n000\n000"
 update
 note "canvas bbox of 3 lines: [.t.c bbox text]"
-foreach probe [list 0 [expr {$ay - 1}] $ay [expr {$ay + 1}] [expr {2 * $ay}]] {
+note "canvas item coords: [.t.c coords text], angle [.t.c itemcget text -angle]"
+foreach probe [list 0 [expr {$ay - 1}] $ay [expr {$ay + 1}] \
+                    [expr {2 * $ay}] [expr {2 * $ay + 1}]] {
     note "  index @0,$probe -> [.t.c index text @0,$probe]"
 }
 check "index at the start of line 2" [.t.c index text @0,$ay] 4
+
+# The boundaries land one pixel late -- at 13 and 25 where the metrics
+# allow only 12 and 24. That cannot come from the metrics: the bbox says
+# the layout is 3 * 12 tall, and ascent+descent is 12, so the two
+# disagree with each other. What sits between "@0,12" and Tk_PointToChar
+# is tkCanvText.c:1529
+#
+#	Tk_PointToChar(layout, (int)(x*cs - y*s), (int)(y*cs + x*s));
+#
+# with cs/s the item's cosine and sine. For an unrotated item they must
+# be exactly 1.0 and 0.0 -- and if cs were a hair under 1.0, (int)(12*cs)
+# truncates to 11 and (int)(13*cs) to 12, which is precisely the shift
+# seen. Tcl's expr calls libap's libm, so this asks the same question
+# directly.
+note "cos(0.0) = [expr {cos(0.0)}]   (must be exactly 1.0)"
+note "sin(0.0) = [expr {sin(0.0)}]   (must be exactly 0.0)"
+check "cos(0.0) is exactly 1.0" [expr {cos(0.0) == 1.0}] 1
+check "sin(0.0) is exactly 0.0" [expr {sin(0.0) == 0.0}] 1
+
+# And separate the item's origin from any scaling of y: move the item
+# down and see whether the boundary moves by the same amount or by more.
+.t.c coords text 0 100
+update
+note "item moved to y=100; bbox now [.t.c bbox text]"
+foreach probe [list 100 [expr {100 + $ay}] [expr {100 + $ay + 1}]] {
+    note "  index @0,$probe -> [.t.c index text @0,$probe]"
+}
 destroy .t
 
 # 6. A real Plan 9 font path is a native name and must still work.

--- a/tmp/tk-all.out
+++ b/tmp/tk-all.out
@@ -6,7 +6,7 @@ Test files sourced into current interpreter
 Running tests that match:  *
 Skipping test files that match:  l.*.test
 Only running test files that match:  *.test
-Tests began at 2026-09-05 18:23:17 +0200
+Tests began at 2026-09-09 04:54:21 +0200
 bell.test
 Bell should ring now ...
 bgerror.test
@@ -324,7 +324,6 @@ event.test
 .top1
 ==== event-9.2 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
 
 
 ==== event-9.11 pointer window container = parent FAILED
@@ -342,7 +341,6 @@ wait for <Enter> event on .one timed out (> 1000 ms)
 |<Enter> NotifyInferior .one.f1|
 ==== event-9.11 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
 
 
 ==== event-9.12 pointer window container != parent FAILED
@@ -360,9 +358,6 @@ wait for <Enter> event on .one timed out (> 1000 ms)
 |<Enter> NotifyNonlinearVirtual .one.f1|<Enter> NotifyNonlinear .one.f1.f2|
 ==== event-9.12 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
-wait for <Enter> event on .two timed out (> 1000 ms)
-wait for <Enter> event on .one timed out (> 1000 ms)
 
 
 ==== event-9.13 pointer window is a toplevel, toplevel destination FAILED
@@ -381,9 +376,6 @@ wait for <Enter> event on .one timed out (> 1000 ms)
 |<Enter> NotifyNonlinear .one|
 ==== event-9.13 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
-wait for <Enter> event on .two timed out (> 1000 ms)
-wait for <Enter> event on .one.f1.f2 timed out (> 1000 ms)
 
 
 ==== event-9.14 pointer window is a toplevel, tk internal destination FAILED
@@ -401,9 +393,6 @@ wait for <Enter> event on .one.f1.f2 timed out (> 1000 ms)
 |<Enter> NotifyNonlinearVirtual .one|<Enter> NotifyNonlinearVirtual .one.f1|<Enter> NotifyNonlinear .one.f1.f2|
 ==== event-9.14 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
-wait for <Enter> event on .two timed out (> 1000 ms)
-wait for <Enter> event on .one timed out (> 1000 ms)
 
 
 ==== event-9.16 Successive destructions (pointer window + parent), single generation of crossing events FAILED
@@ -421,7 +410,6 @@ wait for <Enter> event on .one timed out (> 1000 ms)
 |<Enter> NotifyInferior .one|
 ==== event-9.16 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
 
 
 ==== event-9.17 Successive destructions (pointer window + parent), separate crossing events FAILED
@@ -441,9 +429,6 @@ wait for <Enter> event on .one timed out (> 1000 ms)
 |<Enter> NotifyInferior .one.f1|<Enter> NotifyInferior .one|
 ==== event-9.17 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
-wait for <Enter> event on .two.f1.f2 timed out (> 1000 ms)
-wait for <Enter> event on .one timed out (> 1000 ms)
 
 
 ==== event-9.18 Successive destructions (pointer window + ancestors including its toplevel), destination is non-root toplevel FAILED
@@ -461,9 +446,6 @@ wait for <Enter> event on .one timed out (> 1000 ms)
 |<Enter> NotifyNonlinear .one|
 ==== event-9.18 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
-wait for <Enter> event on .three.f1.f2 timed out (> 1000 ms)
-wait for <Enter> event on .two.f1.f2 timed out (> 1000 ms)
 
 
 ==== event-9.19 Successive destructions (pointer window + ancestors including its toplevel), destination is internal window, bypass root win FAILED
@@ -482,8 +464,6 @@ wait for <Enter> event on .two.f1.f2 timed out (> 1000 ms)
 |<Enter> NotifyNonlinearVirtual .two|<Enter> NotifyNonlinearVirtual .two.f1|<Enter> NotifyNonlinear .two.f1.f2|
 ==== event-9.19 FAILED
 
-wait for <Enter> event on .one timed out (> 1000 ms)
-wait for <Enter> event on .two.f1.f2 timed out (> 1000 ms)
 filebox.test
 
 
@@ -524,14 +504,14 @@ focusTcl.test
 font.test
 
 
-==== font-21.7 Tk_PostscriptFontName procedure: exhaustive FAILED
+==== font-21.19 Tk_PostscriptFontName procedure: exhaustive FAILED
 ==== Contents of test case:
 
-    set name {avantgarde 12 roman normal}
-    if {[font actual {avantgarde 12 roman normal} -family] == "avantgarde"} {
+    set name {helvetica 12 roman normal}
+    if {[font actual {avantgarde 12 roman normal} -family] == "helvetica"} {
 	set x [psfontname avantgarde 12 roman normal]
     } else {
-	set x AvantGarde-Book
+	set x Helvetica
     }
 
 ---- Test generated error; Return code was: 1
@@ -543,18 +523,18 @@ font.test
     invoked from within
 "uplevel 1 $script"
 ---- errorCode: TCL WRONGARGS
-==== font-21.7 FAILED
+==== font-21.19 FAILED
 
 
 
-==== font-21.8 Tk_PostscriptFontName procedure: exhaustive FAILED
+==== font-21.20 Tk_PostscriptFontName procedure: exhaustive FAILED
 ==== Contents of test case:
 
-    set name {avantgarde 12 roman bold}
-    if {[font actual {avantgarde 12 roman normal} -family] == "avantgarde"} {
+    set name {helvetica 12 roman bold}
+    if {[font actual {avantgarde 12 roman normal} -family] == "helvetica"} {
 	set x [psfontname avantgarde 12 roman normal]
     } else {
-	set x AvantGarde-Demi
+	set x Helvetica-Bold
     }
 
 ---- Test generated error; Return code was: 1
@@ -566,18 +546,18 @@ font.test
     invoked from within
 "uplevel 1 $script"
 ---- errorCode: TCL WRONGARGS
-==== font-21.8 FAILED
+==== font-21.20 FAILED
 
 
 
-==== font-21.9 Tk_PostscriptFontName procedure: exhaustive FAILED
+==== font-21.21 Tk_PostscriptFontName procedure: exhaustive FAILED
 ==== Contents of test case:
 
-    set name {avantgarde 12 italic normal}
-    if {[font actual {avantgarde 12 roman normal} -family] == "avantgarde"} {
+    set name {helvetica 12 italic normal}
+    if {[font actual {avantgarde 12 roman normal} -family] == "helvetica"} {
 	set x [psfontname avantgarde 12 roman normal]
     } else {
-	set x AvantGarde-BookOblique
+	set x Helvetica-Oblique
     }
 
 ---- Test generated error; Return code was: 1
@@ -589,18 +569,18 @@ font.test
     invoked from within
 "uplevel 1 $script"
 ---- errorCode: TCL WRONGARGS
-==== font-21.9 FAILED
+==== font-21.21 FAILED
 
 
 
-==== font-21.10 Tk_PostscriptFontName procedure: exhaustive FAILED
+==== font-21.22 Tk_PostscriptFontName procedure: exhaustive FAILED
 ==== Contents of test case:
 
-    set name {avantgarde 12 italic bold}
-    if {[font actual {avantgarde 12 roman normal} -family] == "avantgarde"} {
+    set name {helvetica 12 italic bold}
+    if {[font actual {avantgarde 12 roman normal} -family] == "helvetica"} {
 	set x [psfontname avantgarde 12 roman normal]
     } else {
-	set x AvantGarde-DemiOblique
+	set x Helvetica-BoldOblique
     }
 
 ---- Test generated error; Return code was: 1
@@ -612,7 +592,7 @@ font.test
     invoked from within
 "uplevel 1 $script"
 ---- errorCode: TCL WRONGARGS
-==== font-21.10 FAILED
+==== font-21.22 FAILED
 
 
 
@@ -862,52 +842,6 @@ font.test
 ---- Result should have been (exact matching):
 1
 ==== font-30.13 FAILED
-
-
-
-==== font-44.1 TkFontGetPixels: size < 0 FAILED
-==== Contents of test case:
-
-    # if this test failed, start the investigations by reading ticket [8162e9b7a9]
-    tk scaling 0.5
-    font actual {times -13} -size
-
----- Result was:
--13
----- Result should have been (exact matching):
-26
-==== font-44.1 FAILED
-
-
-
-==== font-45.1 TkFontGetAliasList: no match FAILED
-==== Contents of test case:
-
-    font actual {snarky 10} -family
-
----- Result was:
-snarky
----- Result should have been (exact matching):
-
-==== font-45.1 FAILED
-
-
-
-==== font-45.3 TkFontGetAliasList: match FAILED
-==== Contents of test case:
-
-    if {[font actual {{times new roman} 10} -family] eq "Times New Roman"} {
-	# avoid test failure on systems that have a real "times new roman" font
-	set res 1
-    } else {
-	set res [expr {[font actual {{times new roman} 10} -family] eq  [font actual {times 10} -family]} ]
-    }
-
----- Result was:
-0
----- Result should have been (exact matching):
-1
-==== font-45.3 FAILED
 
 fontchooser.test
 


### PR DESCRIPTION
The layout diagnostics came back self-contradictory, which rules out the font metrics and points somewhere much more interesting.

	label reqheight (ay) = 12
	metrics: -ascent 9 -descent 3 -linespace 12
	canvas bbox of 3 lines: -1 0 19 36
	index @0,12 -> 0     (wants 4)
	index @0,13 -> 4

ay equals ascent+descent exactly, as it must, and the bbox says the layout is 3 * 12 tall -- so the metrics are consistent with themselves. But Tk_PointToChar picks a line with "y < baseline + fm.descent" and the first baseline is fm.ascent, so the boundary must be at 12, and it is observed at 13. No single (ascent, descent) pair produces both a 36-tall layout and a boundary at 13, so the shift is not in the metrics at all.

What sits between "@0,12" and Tk_PointToChar is tkCanvText.c:1529,

	Tk_PointToChar(layout, (int)(x*cs - y*s), (int)(y*cs + x*s));

where cs and s are the item's cosine and sine and must be exactly 1.0 and 0.0 for an unrotated item. If cs were a hair under 1.0 then (int)(12*cs) truncates to 11 and (int)(13*cs) to 12 -- precisely the one-pixel shift seen, at every boundary. Tcl's expr calls libap's libm, so the test now asks directly, and also moves the item to y=100 to separate a wrong origin from a scaled y.

Also corrects this test's own expectation: "font actual -size" is in points, so -12 pixels at scaling 1.0 reads back as 12, not -12. The scaling case in section 5b (font-44.1) is the same rule and already passed.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs