### PR TITLE
cc, math.h: three integer rules applied to floating point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,8 @@ itself are `bool-test.c`, `bitfield-test.c`, `compound-assign-test.c`,
 `rol64-test.c` and `u64float-test.c`, and for libap `locale-test.c`,
 `sigset-test.c`, `posix-spawn-test.c`, `limits-test.c`,
 `format-arg-test.c`, `unget-pipe-test.c`, `isatty-test.c`,
-`sincos-test.c`, `explog-test.c` and `stdio-test.c`. The three `tk-*.tcl` scripts there are Tcl, run with
+`sincos-test.c`, `explog-test.c`, `fparith-test.c` and
+`stdio-test.c`. The three `tk-*.tcl` scripts there are Tcl, run with
 `wish`; see the Tk section below. `sys/src/ape/lib/libressl/test/` is separate: it is
 upstream's own ML-KEM and SHA-3 vectors, run by `mk test` there.
 
@@ -1734,6 +1735,50 @@ assembly implementations overwrite C port versions via the duplicate-skip mechan
 Adding `TVLONG`/`TUVLONG` to `typesuvinit[]` in `cc/sub.c` breaks the entire
 ABI by making vlong-returning functions use struct-return convention.
 The correct content: `{ TSTRUCT, TUNION, TCFLOAT, TCDOUBLE, -1 }`.
+
+### Integer rules applied to floating point (FIXED)
+
+Three bugs of one shape, all found by musl's `asin()`, all silent. When
+something floating-point is subtly wrong, ask whether an integer rule
+has been applied to it.
+
+**`double op float` was computed in FLOAT.** `cc/sub.c`'s promotion
+table had `tab[TDOUBLE][TFLOAT] == TFLOAT`, so the common type of a
+double and a float was the **smaller** of the two -- C99 6.3.1.8 gives
+it to the greater rank. The `TFLOAT` row was right
+(`tab[TFLOAT][TDOUBLE] == TDOUBLE`), so `float op double` always worked
+and only this direction was wrong, which is how it survived.
+
+`asin(1.0)` returns `x*pio2_hi + 0x1p-120f` -- a double plus a float
+constant whose only job is to raise `inexact` -- and the answer came
+back as **float** pi/2, `1.5707963705062866`, exactly 4.371e-08 above
+the double value. **Every mixed-precision expression in the tree was
+quietly rounded to 24 bits**, so anything built before this is suspect,
+the same warning as the 6c spill and the `bool` fix.
+
+**`0/x` was folded to 0 for floating point.** `cc/com.c`'s `ccom()`
+`ODIV` case did `if(vconst(l) == 0 && !side(r)) *n = *l;`. True for
+integers; in floating point `0.0/0.0` is NaN and `0.0/-1.0` is `-0.0`.
+Worse, `*n = *l` replaces the node with the **integer** constant, so the
+answer was a positive integer zero. The divisor-is-zero case two lines
+below already carried a `typefd` guard; this one did not.
+
+`asin(2.0)` reports its domain error with `return 0/(x-x);`, which
+folded away and returned 0.0 instead of NaN.
+
+**`INFINITY` was `DBL_MAX`.** `<math.h>` had
+`#define HUGE_VAL 1.79769313486231e+308` with `INFINITY` on top of it --
+a finite number, against C99 7.12p3/p4. `isinf(INFINITY)` was false,
+`exp(1000) == INFINITY` was false, and `cos(INFINITY)` computed a real
+cosine of a very large angle rather than NaN. It hid unusually well:
+`exp(INFINITY)` *passed*, because `exp(1.8e308)` returns `1.0+x`, which
+compares equal to that same 1.8e308. `HUGE_VAL` is `Inf(1)` now, as
+`NAN` was already `NaN()` -- neither is the constant expression the
+standard asks for, and there is no way to write one here.
+
+Covered by `sys/lib/tests/fparith-test.c`, which also reports the sign
+of `-0.0` through a call: that was still failing when these three were
+fixed, and is left named rather than rediscovered.
 
 ### Hex floating constants were silently zero (FIXED)
 

--- a/sys/include/ape/math.h
+++ b/sys/include/ape/math.h
@@ -4,7 +4,26 @@
 
 /* a HUGE_VAL appropriate for IEEE double-precision */
 /* the correct value, 1.797693134862316e+308, causes a ken overflow */
-#define HUGE_VAL 1.79769313486231e+308
+/*
+ * C99 7.12p3/p4: HUGE_VAL is positive infinity where the implementation
+ * has one, and INFINITY represents unbounded infinity. These used to be
+ * 1.79769313486231e+308 -- roughly DBL_MAX, a finite number -- so
+ * isinf(INFINITY) was false, exp(1000) == INFINITY was false, and
+ * cos(INFINITY) computed a real cosine of a very large angle instead of
+ * NaN. Plan 9's libc supplies Inf(), which NAN below already relies on
+ * for the same reason; neither is the constant expression the standard
+ * asks for, and that is the price of having no way to write one here.
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern double Inf(int);		/* Plan 9 libc; declared again below */
+extern double NaN(void);
+#ifdef __cplusplus
+}
+#endif
+
+#define HUGE_VAL Inf(1)
 
 #define INFINITY HUGE_VAL
 #define HUGE_VALF ((float)HUGE_VAL)	/* float infinity on IEEE 754 */

--- a/sys/lib/tests/fparith-test.c
+++ b/sys/lib/tests/fparith-test.c
@@ -1,0 +1,160 @@
+/*
+ * Floating-point arithmetic rules kencc used to get wrong.
+ *
+ *	pcc -o fparith-test fparith-test.c && ./fparith-test
+ *
+ * Three separate bugs, all found by musl's asin() and all silent. They
+ * are grouped here because each is a case of an integer rule applied to
+ * floating point, which is the shape to look for.
+ *
+ * 1. "double op float" was computed in FLOAT.
+ *
+ *    cc/sub.c's promotion table had tab[TDOUBLE][TFLOAT] == TFLOAT, so
+ *    the common type of a double and a float was the SMALLER of the two
+ *    -- C99 6.3.1.8 says the greater rank wins. The TFLOAT row was right
+ *    (tab[TFLOAT][TDOUBLE] == TDOUBLE), so "float op double" always
+ *    worked and only this direction was wrong, which is how it survived.
+ *
+ *    musl's asin(1.0) returns "x*pio2_hi + 0x1p-120f" -- a double plus a
+ *    float constant whose only job is to raise inexact -- and the answer
+ *    came back as float pi/2, 1.5707963705062866, exactly 4.371e-08
+ *    above the double value. Every mixed-precision expression in the
+ *    tree was quietly rounded to 24 bits.
+ *
+ * 2. 0/x was folded to 0 for floating point.
+ *
+ *    cc/com.c's ccom() ODIV case did "if(vconst(l) == 0 && !side(r))
+ *    *n = *l;". True for integers. In floating point 0.0/0.0 is NaN and
+ *    0.0/-1.0 is -0.0 -- and *n = *l replaced the node with the integer
+ *    constant, so the result was a positive integer zero. The divisor-is-
+ *    zero case two lines below already had a typefd guard; this one did
+ *    not.
+ *
+ *    musl's asin(2.0) reports its domain error with "return 0/(x-x);",
+ *    which folded away and returned 0.0 instead of NaN.
+ *
+ * 3. INFINITY was DBL_MAX.
+ *
+ *    <math.h> had "#define HUGE_VAL 1.79769313486231e+308" and INFINITY
+ *    on top of it -- a finite number. C99 7.12p3/p4 require infinity.
+ *    So isinf(INFINITY) was false, exp(1000) == INFINITY was false, and
+ *    cos(INFINITY) computed the cosine of a very large angle rather than
+ *    NaN. It hid well: exp(INFINITY) "passed" because exp(1.8e308)
+ *    returns 1.0+x, which compares equal to that same 1.8e308.
+ *
+ * Every case below is required by C99, so this passes on gcc, which is
+ * how it was checked.
+ */
+
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+static int failures;
+
+static void
+ok(int cond, const char *what)
+{
+	printf("%s %s\n", cond ? "PASS" : "FAIL", what);
+	if(!cond)
+		failures++;
+}
+
+/* Kept out of the expression so nothing can be folded away. */
+static double dzero(void) { return 0.0; }
+static double done(void)  { return 1.0; }
+
+int
+main(void)
+{
+	volatile double d;
+	volatile float f;
+	double r;
+
+	/*
+	 * 1. The usual arithmetic conversions. pi/2 in double and in float
+	 * differ by 4.371e-08, so a result rounded to float is unmistakable.
+	 */
+	{
+		double pio2 = 1.57079632679489655800e+00;
+		double got;
+
+		got = pio2 + 0x1p-120f;
+		ok(got == pio2, "double + float constant stays double");
+
+		f = 1.0f;
+		d = pio2;
+		got = d + f;
+		ok(got == pio2 + 1.0, "double + float variable stays double");
+
+		got = d * f;
+		ok(got == pio2, "double * float variable stays double");
+
+		/*
+		 * The other order was always right; here so that a failure
+		 * says which half of the table moved.
+		 */
+		got = f + d;
+		ok(got == pio2 + 1.0, "float + double stays double");
+
+		/* sizeof through a promotion, which is the rule stated plainly. */
+		ok(sizeof(1.0 + 1.0f) == sizeof(double),
+			"sizeof(double + float) is sizeof(double)");
+	}
+
+	/*
+	 * 2. Zero numerators. Integer zero over floating zero is NaN, not
+	 * zero, and the sign of the result of 0.0/-1.0 is negative.
+	 */
+	r = 0 / (dzero() - dzero());
+	ok(isnan(r), "0/(0.0) is NaN, not 0");
+
+	r = 0.0 / dzero();
+	ok(isnan(r), "0.0/0.0 is NaN");
+
+	r = 0 / -done();
+	ok(r == 0.0 && signbit(r), "0/-1.0 is -0.0");
+
+	r = 0.0 / done();
+	ok(r == 0.0 && !signbit(r), "0.0/1.0 is +0.0");
+
+	/* Integer 0/x really is 0, and must stay that way. */
+	{
+		volatile int iz = 0, in = 7;
+		ok(iz / in == 0, "integer 0/7 is still 0");
+	}
+
+	/*
+	 * 3. Infinity. HUGE_VAL and INFINITY must be infinite, and the
+	 * library must agree with them.
+	 */
+	ok(isinf(INFINITY),   "INFINITY is infinite");
+	ok(isinf(HUGE_VAL),   "HUGE_VAL is infinite");
+	ok(INFINITY > 1.7976931348623157e308, "INFINITY exceeds DBL_MAX");
+	ok(-INFINITY < -1.7976931348623157e308, "-INFINITY is below -DBL_MAX");
+	ok(isinf(exp(1000.0)), "exp(1000) is infinite");
+	ok(exp(1000.0) == INFINITY, "exp(1000) equals INFINITY");
+	ok(isnan(cos(INFINITY)), "cos(INFINITY) is NaN");
+	ok(log(INFINITY) == INFINITY, "log(INFINITY) is INFINITY");
+	ok(isinf(1.0 / dzero()), "1.0/0.0 is infinite");
+
+	/*
+	 * The sign of zero through a call and a negation. This is not one
+	 * of the three above; it is here because it is the same family and
+	 * was still failing when they were fixed, so the next run says so
+	 * rather than leaving it to be rediscovered.
+	 */
+	{
+		double z;
+
+		z = -0.0;
+		ok(z == 0.0 && signbit(z), "the constant -0.0 is negative zero");
+		z = -dzero();
+		ok(z == 0.0 && signbit(z), "-(0.0) is negative zero");
+		z = sin(-0.0);
+		ok(z == 0.0 && signbit(z), "sin(-0.0) is -0.0");
+	}
+
+	printf("%d failure(s)\n", failures);
+	return failures;
+}

--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -1539,7 +1539,19 @@ loop:
 	case ODIV:
 	case OLDIV:
 		ccom(l);
-		if(vconst(l) == 0 && !side(r)) {
+		/*
+		 * 0/x is 0 only for integers. In floating point 0.0/0.0 is
+		 * NaN and 0.0/-1.0 is -0.0, and folding it away also
+		 * replaced the node with the integer constant, so the
+		 * result was a positive integer zero. The t == 0 case below
+		 * already had this guard; this one did not.
+		 *
+		 * asin(2.0) is what found it: musl reports a domain error
+		 * with "return 0/(x-x);", which folded to 0 and returned
+		 * 0.0 instead of NaN.
+		 */
+		if(vconst(l) == 0 && !side(r)
+		&& !(n->type != T && typefd[n->type->etype])) {
 			*n = *l;
 			break;
 		}

--- a/sys/src/cmd/cc/sub.c
+++ b/sys/src/cmd/cc/sub.c
@@ -1983,8 +1983,24 @@ char	tab[NTYPE][NTYPE] =
 /*TFLOAT*/	{ 0,	TFLOAT, TFLOAT, TFLOAT, TFLOAT, TFLOAT, TFLOAT, TFLOAT,
 			TFLOAT, TFLOAT, TFLOAT, TFLOAT, TDOUBLE, TIND,
 		},
+/*
+ * The TFLOAT column here used to say TFLOAT, so "double op float" was
+ * computed in FLOAT -- a straight violation of C99 6.3.1.8, which makes
+ * the common type the one with the greater rank. Note the TFLOAT row
+ * above has TDOUBLE in its TDOUBLE column, so "float op double" was
+ * always right; only this direction was wrong, which is how it survived.
+ *
+ * asin(1.0) is what found it. musl's returns
+ *
+ *	x*pio2_hi + 0x1p-120f
+ *
+ * -- a double plus a float constant that exists only to raise inexact --
+ * and the answer came back as float pi/2, 1.5707963705062866, exactly
+ * 4.371e-08 above the double value. Any mixed-precision arithmetic in
+ * the tree was silently rounded to 24 bits.
+ */
 /*TDOUBLE*/	{ 0,	TDOUBLE, TDOUBLE, TDOUBLE, TDOUBLE, TDOUBLE, TDOUBLE, TDOUBLE,
-			TDOUBLE, TDOUBLE, TDOUBLE, TFLOAT, TDOUBLE, TIND,
+			TDOUBLE, TDOUBLE, TDOUBLE, TDOUBLE, TDOUBLE, TIND,
 		},
 /*TIND*/	{ 0,	TIND, TIND, TIND, TIND, TIND, TIND, TIND,
 			 TIND, TIND, TIND, TIND, TIND, TIND,


### PR DESCRIPTION
All three found by musl's asin(), all silent, and all the same shape.

double op float was computed in FLOAT. cc/sub.c's promotion table had tab[TDOUBLE][TFLOAT] == TFLOAT, so the common type of a double and a float was the smaller of the two; C99 6.3.1.8 gives it to the greater rank. The TFLOAT row was right, so "float op double" always worked and only this direction was wrong, which is how it survived.

asin(1.0) returns "x*pio2_hi + 0x1p-120f", a double plus a float constant that exists only to raise inexact, and the answer came back as float pi/2 -- 1.5707963705062866, exactly 4.371e-08 above the double value, matching the reported error to the last digit. Every mixed-precision expression in the tree was quietly rounded to 24 bits, so anything built before this is suspect.

0/x was folded to 0 for floating point. cc/com.c's ccom() ODIV case did "if(vconst(l) == 0 && !side(r)) *n = *l;" -- true for integers, but 0.0/0.0 is NaN and 0.0/-1.0 is -0.0, and *n = *l also replaces the node with the integer constant so the result was a positive integer zero. The divisor-is-zero case two lines below already had a typefd guard; this one did not. asin(2.0) reports its domain error with "return 0/(x-x);", which folded away and returned 0.0 instead of NaN.

INFINITY was DBL_MAX. math.h had HUGE_VAL as 1.79769313486231e+308 with INFINITY on top of it, against C99 7.12p3/p4. isinf(INFINITY) was false, exp(1000) == INFINITY was false, and cos(INFINITY) computed the cosine of a very large angle rather than NaN. It hid unusually well: exp(INFINITY) passed, because exp(1.8e308) returns 1.0+x, which compares equal to that same 1.8e308. HUGE_VAL is Inf(1) now, as NAN was already NaN(); Inf and NaN are declared at the top of the header so the macros work from the first line of a translation unit.

sys/lib/tests/fparith-test.c covers all three and passes on gcc. It also reports the sign of -0.0 through a call, which was still failing when these were fixed -- named rather than left to be rediscovered.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs