### PR TITLE
cc, 6c, *l: keep the sign of zero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1776,9 +1776,62 @@ compares equal to that same 1.8e308. `HUGE_VAL` is `Inf(1)` now, as
 `NAN` was already `NaN()` -- neither is the constant expression the
 standard asks for, and there is no way to write one here.
 
-Covered by `sys/lib/tests/fparith-test.c`, which also reports the sign
-of `-0.0` through a call: that was still failing when these three were
-fixed, and is left named rather than rediscovered.
+Covered by `sys/lib/tests/fparith-test.c`.
+
+### The sign of zero was dropped everywhere (FIXED)
+
+The fourth of that family, and the widest: **six** separate places, each
+one a test of the form `x == 0` or `x < 0` written by someone who did
+not have two zeros in mind. `-0.0` compares equal to `0.0` and is not
+less than it, so every ordinary test misses it and every one of these
+was silent.
+
+**Negation was `0 - x`.** x86-64 has no scalar floating-point negate, and
+`cc/com.c` rewrites `-x` as `0 - x` whenever the back end says it cannot
+do the operation itself -- `machcap()`. 6c's `machcap()` answered for the
+integer types only (`typechlv`), so **every** floating-point negation in
+the tree went through the rewrite, and `0.0 - 0.0` is `+0.0`. Unary plus
+is the same shape one line above, `0 + x`, so `+(-0.0)` was `+0.0` too;
+that one is now simply the operand, since floating point has no
+promotions to apply.
+
+Negation is a sign-bit flip and `6c/cgen.c` generates one: `XORPS` or
+`XORPD` against a mask of `-0.0`. The mask is loaded into a register
+first -- the linker lays an `FCONST` literal out four or eight bytes
+aligned and the memory form of those instructions wants sixteen.
+`AXORPS` had to be added to `reg.c` and `peep.c`, which knew only
+`AXORPD` (`gmove` uses it to make a zero); `reg.c`'s default arm is
+`diag("reg: unknown op")`, so a missing entry is at least loud.
+
+Four more places lost the sign on the way out, and they are the reason
+fixing the negation alone was not enough:
+
+| | |
+|---|---|
+| `cc/scon.c` | `evconst` folded `-x` with a runtime negation, so it inherited the bug from the compiler compiling it |
+| `cc/pswt.c`, `1c`+`2c` `swt.c` | `ieeedtod` tested `native < 0` before `native == 0` |
+| `6c/txt.c` | `gmove` made any zero constant with `XORPD` of a register against itself, which is `+0.0` |
+| every `*l/obj.c` | `ieeedtof` took `-0.0` for a denormal and said `double fp to single fp overflow` |
+
+**`fpnegzero()` and `fpnegzeroval()` are in `cc/sub.c`**, so they are in
+`cc.a` and every back end has them -- `1c` and `2c` do not build
+`pswt.c`, which is where they were first put. Both read or write the
+sign bit through a `union { double; uvlong; }` rather than writing
+`-0.0`: **kencc compiles kencc**, so a `-0.0` in the compiler's own
+source would have folded to `+0.0` and the fix would only have taken
+effect on the second rebuild. `evconst` is written the same way for the
+same reason.
+
+The sign of zero is not decorative. It is what makes `1/x` tell the two
+infinities apart, it is the sign of every underflowing product and
+quotient, and `atan2`, `copysign` and `log` all branch on it -- so
+**anything doing floating-point arithmetic near zero and built before
+this is suspect**, the same warning as the 6c spill and the `bool` fix.
+
+Covered by `sys/lib/tests/fparith-test.c`, which reaches a `-0.0` by
+each of the routes above separately -- a constant, a static initialiser,
+a runtime negation, unary plus and the library -- because they fail
+independently.
 
 ### Hex floating constants were silently zero (FIXED)
 

--- a/sys/lib/tests/fparith-test.c
+++ b/sys/lib/tests/fparith-test.c
@@ -42,6 +42,34 @@
  *    NaN. It hid well: exp(INFINITY) "passed" because exp(1.8e308)
  *    returns 1.0+x, which compares equal to that same 1.8e308.
  *
+ * 4. Negation was 0 - x, so -(+0.0) was +0.0.
+ *
+ *    x86-64 has no scalar floating-point negate, and cc/com.c rewrites
+ *    -x as 0 - x whenever the back end says it cannot do the operation
+ *    itself (machcap()). 6c's machcap() answered for the integer types
+ *    only, so every floating-point negation went through the rewrite --
+ *    and 0.0 - 0.0 is +0.0. Unary plus had the same shape, 0 + x, so
+ *    +(-0.0) was +0.0 as well.
+ *
+ *    Negation is a sign-bit flip and is now generated as one, an XORPS
+ *    or XORPD against a mask of -0.0. Three more places dropped the
+ *    sign of zero on the way to the object file, each of them a test of
+ *    the form "if(x == 0)" where the two zeros differ:
+ *
+ *	cc/scon.c   evconst folded -0.0 with a runtime negation, so it
+ *	            inherited the bug from the compiler compiling it;
+ *	cc/pswt.c   ieeedtod tested "native < 0" before "native == 0",
+ *	            and -0.0 is not less than 0;
+ *	6c/txt.c    gmove materialised any zero constant with XORPD of a
+ *	            register against itself, which gives +0.0.
+ *
+ *    and 6l's ieeedtof took -0.0 for a denormal and diagnosed "double
+ *    fp to single fp overflow".
+ *
+ *    The sign of zero is not decorative: it is what makes 1/x tell the
+ *    two infinities apart, and it is the sign of the result of every
+ *    multiplication and division that underflows.
+ *
  * Every case below is required by C99, so this passes on gcc, which is
  * how it was checked.
  */
@@ -63,6 +91,15 @@ ok(int cond, const char *what)
 /* Kept out of the expression so nothing can be folded away. */
 static double dzero(void) { return 0.0; }
 static double done(void)  { return 1.0; }
+static float  fzero(void) { return 0.0f; }
+static float  fone(void)  { return 1.0f; }
+
+/*
+ * A static initialiser is folded in dcl.c and written straight to the
+ * object file, so it never goes through com.c or cgen.c -- a separate
+ * path, and it was separately wrong.
+ */
+static double negzero = -0.0;
 
 int
 main(void)
@@ -139,18 +176,41 @@ main(void)
 	ok(isinf(1.0 / dzero()), "1.0/0.0 is infinite");
 
 	/*
-	 * The sign of zero through a call and a negation. This is not one
-	 * of the three above; it is here because it is the same family and
-	 * was still failing when they were fixed, so the next run says so
-	 * rather than leaving it to be rediscovered.
+	 * 4. The sign of zero, through every route to one: a constant, a
+	 * runtime negation, a static initialiser, unary plus, and the
+	 * library. Each went through a different piece of the compiler and
+	 * each failed separately, so they are listed separately.
 	 */
 	{
 		double z;
+		float g;
 
 		z = -0.0;
 		ok(z == 0.0 && signbit(z), "the constant -0.0 is negative zero");
+		ok(negzero == 0.0 && signbit(negzero),
+			"a static -0.0 initialiser is negative zero");
 		z = -dzero();
 		ok(z == 0.0 && signbit(z), "-(0.0) is negative zero");
+		z = -(-dzero());
+		ok(z == 0.0 && !signbit(z), "-(-(0.0)) is back to +0.0");
+
+		/* Unary plus is the value of its operand, sign and all. */
+		z = +(-0.0);
+		ok(z == 0.0 && signbit(z), "+(-0.0) is negative zero");
+
+		/* Ordinary negation must still work. */
+		ok(-done() == -1.0, "-(1.0) is -1.0");
+		ok(-(-done()) == 1.0, "-(-(1.0)) is 1.0");
+
+		/* float has its own sign bit, in its own place. */
+		g = fzero();
+		ok(-g == 0.0f && signbit(-g), "float -(0.0f) is negative zero");
+		ok(-fone() == -1.0f, "float -(1.0f) is -1.0f");
+
+		/* 1/x is how a program notices. */
+		ok(1.0 / -dzero() < 0.0, "1/-0.0 is -inf");
+		ok(1.0 / dzero() > 0.0, "1/+0.0 is +inf");
+
 		z = sin(-0.0);
 		ok(z == 0.0 && signbit(z), "sin(-0.0) is -0.0");
 	}

--- a/sys/src/cmd/1c/swt.c
+++ b/sys/src/cmd/1c/swt.c
@@ -702,14 +702,19 @@ ieeedtod(Ieee *ieee, double native)
 	double fr, ho, f;
 	int exp;
 
+	/*
+	 * Zero must be tested before the sign, not after: -0.0 is not
+	 * < 0, so it used to fall into the "native == 0" arm and come
+	 * out as +0.0, losing the sign of a -0.0 constant.
+	 */
+	if(native == 0) {
+		ieee->l = 0;
+		ieee->h = fpnegzero(native)? 0x80000000L: 0;
+		return;
+	}
 	if(native < 0) {
 		ieeedtod(ieee, -native);
 		ieee->h |= 0x80000000L;
-		return;
-	}
-	if(native == 0) {
-		ieee->l = 0;
-		ieee->h = 0;
 		return;
 	}
 	fr = frexp(native, &exp);

--- a/sys/src/cmd/1l/obj.c
+++ b/sys/src/cmd/1l/obj.c
@@ -1332,8 +1332,13 @@ ieeedtof(Ieee *e)
 	int exp;
 	long v;
 
-	if(e->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((e->h & ~0x80000000L) == 0 && e->l == 0)
+		return e->h & 0x80000000L;
 	exp = (e->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (e->h & 0xfffffL) << 3;

--- a/sys/src/cmd/2c/swt.c
+++ b/sys/src/cmd/2c/swt.c
@@ -784,14 +784,19 @@ ieeedtod(Ieee *ieee, double native)
 	double fr, ho, f;
 	int exp;
 
+	/*
+	 * Zero must be tested before the sign, not after: -0.0 is not
+	 * < 0, so it used to fall into the "native == 0" arm and come
+	 * out as +0.0, losing the sign of a -0.0 constant.
+	 */
+	if(native == 0) {
+		ieee->l = 0;
+		ieee->h = fpnegzero(native)? 0x80000000L: 0;
+		return;
+	}
 	if(native < 0) {
 		ieeedtod(ieee, -native);
 		ieee->h |= 0x80000000L;
-		return;
-	}
-	if(native == 0) {
-		ieee->l = 0;
-		ieee->h = 0;
 		return;
 	}
 	fr = frexp(native, &exp);

--- a/sys/src/cmd/2l/obj.c
+++ b/sys/src/cmd/2l/obj.c
@@ -1354,8 +1354,13 @@ ieeedtof(Ieee *e)
 	int exp;
 	long v;
 
-	if(e->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((e->h & ~0x80000000L) == 0 && e->l == 0)
+		return e->h & 0x80000000L;
 	exp = (e->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (e->h & 0xfffffL) << 3;

--- a/sys/src/cmd/5l/obj.c
+++ b/sys/src/cmd/5l/obj.c
@@ -1411,8 +1411,13 @@ ieeedtof(Ieee *ieeep)
 	int exp;
 	long v;
 
-	if(ieeep->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (ieeep->h & 0xfffffL) << 3;

--- a/sys/src/cmd/6c/cgen.c
+++ b/sys/src/cmd/6c/cgen.c
@@ -162,6 +162,38 @@ cgen(Node *n, Node *nn)
 			nullwarn(l, Z);
 			break;
 		}
+		/*
+		 * Floating-point negation flips the sign bit; it is not
+		 * 0 - x, which gives +0.0 for an argument of +0.0 and so
+		 * loses the sign of zero. com.c did that rewrite because
+		 * machcap() used to answer 0 for ONEG on a float or double.
+		 *
+		 * There is no scalar negate instruction, so this is XOR
+		 * with a mask holding nothing but the sign bit -- which is
+		 * the constant -0.0, of the same type as the operand, so
+		 * the same code covers float and double. The mask is loaded
+		 * into a register rather than used from memory: the linker
+		 * lays an FCONST literal out four or eight bytes aligned,
+		 * and the memory form of XORPS/XORPD requires sixteen.
+		 *
+		 * fpnegzeroval() assembles the mask from its bits instead
+		 * of writing -0.0, because kencc builds kencc: until the
+		 * fix has propagated through a rebuild, a -0.0 written here
+		 * would be folded to +0.0 by the compiler compiling it.
+		 */
+		if(o == ONEG && typefd[n->type->etype]) {
+			regalloc(&nod, n, nn);
+			cgen(l, &nod);
+			nod1 = *nodfconst(fpnegzeroval());
+			nod1.type = n->type;
+			regalloc(&nod2, n, Z);
+			gmove(&nod1, &nod2);
+			gins(n->type->etype == TFLOAT? AXORPS: AXORPD, &nod2, &nod);
+			regfree(&nod2);
+			gmove(&nod, nn);
+			regfree(&nod);
+			break;
+		}
 		regalloc(&nod, l, nn);
 		cgen(l, &nod);
 		gopcode(o, n->type, Z, &nod);

--- a/sys/src/cmd/6c/machcap.c
+++ b/sys/src/cmd/6c/machcap.c
@@ -19,8 +19,17 @@ machcap(Node *n)
 		}
 		break;
 
-	case OCOM:
 	case ONEG:
+		/*
+		 * Floating-point negation is a sign-bit flip, generated in
+		 * cgen.c.  Answering 0 here made com.c rewrite -x as 0 - x,
+		 * which is right for integers and wrong for floating point:
+		 * 0.0 - 0.0 is +0.0, so -(+0.0) came out positive.
+		 */
+		if(typefd[n->left->type->etype])
+			return 1;
+		/* fall through */
+	case OCOM:
 	case OADD:
 	case OAND:
 	case OOR:

--- a/sys/src/cmd/6c/peep.c
+++ b/sys/src/cmd/6c/peep.c
@@ -798,6 +798,7 @@ copyu(Prog *p, Adr *v, Adr *s)
 	case ASUBSD:
 	case ASUBSS:
 	case AXORPD:
+	case AXORPS:
 		if(copyas(&p->to, v))
 			return 2;
 		goto caseread;

--- a/sys/src/cmd/6c/reg.c
+++ b/sys/src/cmd/6c/reg.c
@@ -286,6 +286,7 @@ regopt(Prog *p)
 		case ASUBSD:
 		case ASUBSS:
 		case AXORPD:
+		case AXORPS:
 			for(z=0; z<BITS; z++) {
 				r->set.b[z] |= bit.b[z];
 				r->use2.b[z] |= bit.b[z];

--- a/sys/src/cmd/6c/txt.c
+++ b/sys/src/cmd/6c/txt.c
@@ -596,7 +596,12 @@ gmove(Node *f, Node *t)
 			f->op, tnames[ft], t->op, tnames[tt]);
 	if(typefd[ft] && f->op == OCONST) {
 		/* TO DO: pick up special constants, possibly preloaded */
-		if(f->fconst == 0.0){
+		/*
+		 * XORPD of a register with itself gives +0.0, so -0.0 must
+		 * not take this path -- it compares equal to 0.0 and used
+		 * to lose its sign here.
+		 */
+		if(f->fconst == 0.0 && !fpnegzero(f->fconst)){
 			regalloc(&nod, t, t);
 			gins(AXORPD, &nod, &nod);
 			gmove(&nod, t);

--- a/sys/src/cmd/6l/obj.c
+++ b/sys/src/cmd/6l/obj.c
@@ -1469,8 +1469,13 @@ ieeedtof(Ieee *e)
 	int exp;
 	long v;
 
-	if(e->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((e->h & ~0x80000000L) == 0 && e->l == 0)
+		return e->h & 0x80000000L;
 	exp = (e->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (e->h & 0xfffffL) << 3;

--- a/sys/src/cmd/7l/obj.c
+++ b/sys/src/cmd/7l/obj.c
@@ -1415,8 +1415,13 @@ ieeedtof(Ieee *ieeep)
 	int exp;
 	long v;
 
-	if(ieeep->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (ieeep->h & 0xfffffL) << 3;

--- a/sys/src/cmd/8l/obj.c
+++ b/sys/src/cmd/8l/obj.c
@@ -1420,8 +1420,13 @@ ieeedtof(Ieee *e)
 	int exp;
 	long v;
 
-	if(e->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((e->h & ~0x80000000L) == 0 && e->l == 0)
+		return e->h & 0x80000000L;
 	exp = (e->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (e->h & 0xfffffL) << 3;

--- a/sys/src/cmd/9l/obj.c
+++ b/sys/src/cmd/9l/obj.c
@@ -1311,8 +1311,13 @@ ieeedtof(Ieee *ieeep)
 	int exp;
 	long v;
 
-	if(ieeep->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (ieeep->h & 0xfffffL) << 3;

--- a/sys/src/cmd/cc/cc.h
+++ b/sys/src/cmd/cc/cc.h
@@ -716,6 +716,8 @@ int	vconst(Node*);
 int	log2(uvlong);
 int	vlog(Node*);
 int	topbit(ulong);
+int	fpnegzero(double);
+double	fpnegzeroval(void);
 void	simplifyshift(Node*);
 void	rolor(Node*);
 long	typebitor(long, long);

--- a/sys/src/cmd/cc/com.c
+++ b/sys/src/cmd/cc/com.c
@@ -616,6 +616,17 @@ tcomo(Node *n, int f)
 			goto bad;
 		if(isfunct(n))
 			break;
+		/*
+		 * Unary + is the value of its operand (C99 6.5.3.3p2).
+		 * Rewriting it as 0 + x below is a way of applying the
+		 * integer promotions; floating point has none to apply,
+		 * and the rewrite is wrong there -- 0.0 + -0.0 is +0.0,
+		 * so +(-0.0) lost its sign.
+		 */
+		if(typefd[l->type->etype]) {
+			*n = *l;
+			break;
+		}
 
 		r = l;
 		l = new(OCONST, Z, Z);

--- a/sys/src/cmd/cc/pswt.c
+++ b/sys/src/cmd/cc/pswt.c
@@ -174,14 +174,20 @@ ieeedtod(Ieee *ieee, double native)
 	double fr, ho, f;
 	int exp;
 
+	/*
+	 * Zero must be tested before the sign, not after: -0.0 is not
+	 * < 0, so it used to fall into the "native == 0" arm below and
+	 * come out as +0.0.  A constant -0.0 in the source was
+	 * therefore emitted with its sign lost.
+	 */
+	if(native == 0) {
+		ieee->l = 0;
+		ieee->h = fpnegzero(native)? 0x80000000L: 0;
+		return;
+	}
 	if(native < 0) {
 		ieeedtod(ieee, -native);
 		ieee->h |= 0x80000000L;
-		return;
-	}
-	if(native == 0) {
-		ieee->l = 0;
-		ieee->h = 0;
 		return;
 	}
 	fr = frexp(native, &exp);

--- a/sys/src/cmd/cc/scon.c
+++ b/sys/src/cmd/cc/scon.c
@@ -38,9 +38,20 @@ evconst(Node *n)
 		return;
 
 	case ONEG:
-		if(isf)
-			d = -l->fconst;
-		else
+		if(isf) {
+			/*
+			 * Negating +0.0 has to give -0.0. The plain "-x"
+			 * here would be right in a compiler that generates
+			 * negation correctly, but this one compiles itself:
+			 * writing it as an exclusive-or with the sign bit
+			 * makes the fold correct on the first rebuild
+			 * rather than the second.
+			 */
+			if(l->fconst == 0)
+				d = fpnegzero(l->fconst)? 0.0: fpnegzeroval();
+			else
+				d = -l->fconst;
+		} else
 			v = -l->vconst;
 		break;
 

--- a/sys/src/cmd/cc/sub.c
+++ b/sys/src/cmd/cc/sub.c
@@ -1231,6 +1231,43 @@ topbit(ulong v)
 }
 
 /*
+ * Is this negative zero?  -0.0 compares equal to 0.0 and is not less
+ * than it, so every ordinary test misses it; the sign bit is the only
+ * thing that distinguishes the two, and it has to be read directly.
+ * Both members are eight bytes, so the byte order does not matter.
+ */
+int
+fpnegzero(double d)
+{
+	union {
+		double	d;
+		uvlong	v;
+	} u;
+
+	if(d != 0)
+		return 0;
+	u.d = d;
+	return (int)(u.v >> 63);
+}
+
+/*
+ * -0.0, assembled from its bits.  Writing the constant would not do:
+ * this compiler is compiled by itself, so before the fix has been
+ * through a rebuild the -0.0 in the source folds to +0.0.
+ */
+double
+fpnegzeroval(void)
+{
+	union {
+		double	d;
+		uvlong	v;
+	} u;
+
+	u.v = (uvlong)1 << 63;
+	return u.d;
+}
+
+/*
  * try to cast a constant down
  * rather than cast a variable up
  * example:

--- a/sys/src/cmd/kl/obj.c
+++ b/sys/src/cmd/kl/obj.c
@@ -1229,8 +1229,13 @@ ieeedtof(Ieee *ieeep)
 	int exp;
 	long v;
 
-	if(ieeep->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (ieeep->h & 0xfffffL) << 3;

--- a/sys/src/cmd/ql/obj.c
+++ b/sys/src/cmd/ql/obj.c
@@ -1362,8 +1362,13 @@ ieeedtof(Ieee *ieeep)
 	int exp;
 	long v;
 
-	if(ieeep->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (ieeep->h & 0xfffffL) << 3;

--- a/sys/src/cmd/vl/obj.c
+++ b/sys/src/cmd/vl/obj.c
@@ -1307,8 +1307,13 @@ ieeedtof(Ieee *ieeep)
 	int exp;
 	long v;
 
-	if(ieeep->h == 0)
-		return 0;
+	/*
+	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
+	 * h is 0x80000000: it went on to compute an exponent of -1022
+	 * and reported "double fp to single fp overflow".
+	 */
+	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;
 	v = (ieeep->h & 0xfffffL) << 3;


### PR DESCRIPTION
Floating-point negation was generated as 0 - x, because 6c's machcap() answered only for the integer types and cc/com.c rewrites -x that way when the back end says it cannot do the operation itself. 0.0 - 0.0 is +0.0, so -(+0.0) came out positive -- and every floating-point negation in the tree went through that rewrite. Unary plus was 0 + x, with the same effect on +(-0.0); it is now simply the operand, floating point having no promotions to apply.

6c/cgen.c generates the sign-bit flip instead: XORPS or XORPD against a mask of -0.0, loaded into a register because the linker aligns an FCONST literal to its own width and the memory form of those instructions wants sixteen bytes. AXORPS added to reg.c and peep.c, which knew only AXORPD.

Four more places dropped the sign on the way to the object file, each a test of the form "x == 0" or "x < 0" that cannot tell the two zeros apart:

  cc/scon.c        evconst folded -x with a runtime negation, so it
                   inherited the bug from the compiler compiling it
  cc/pswt.c,       ieeedtod tested "native < 0" before "native == 0"
  1c/2c swt.c
  6c/txt.c         gmove made any zero constant with XORPD of a register
                   against itself, which gives +0.0
  every *l/obj.c   ieeedtof took -0.0 for a denormal and diagnosed
                   "double fp to single fp overflow"

fpnegzero() and fpnegzeroval() go in cc/sub.c so they are in cc.a and reach every back end; 1c and 2c do not build pswt.c. Both work on the bits through a union rather than writing -0.0, because kencc compiles kencc: the constant in the compiler's own source would fold to +0.0 and the fix would only take effect on the second rebuild.

fparith-test.c reaches a -0.0 by each route separately -- a constant, a static initialiser, a runtime negation, unary plus and the library -- since they fail independently. Verified against gcc.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs