### PR TITLE
cc/dcl.c: a static -0.0 initialiser is not a zero initialiser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1780,11 +1780,11 @@ Covered by `sys/lib/tests/fparith-test.c`.
 
 ### The sign of zero was dropped everywhere (FIXED)
 
-The fourth of that family, and the widest: **six** separate places, each
-one a test of the form `x == 0` or `x < 0` written by someone who did
-not have two zeros in mind. `-0.0` compares equal to `0.0` and is not
-less than it, so every ordinary test misses it and every one of these
-was silent.
+The fourth of that family, and the widest: **seven** separate places,
+each one a test of the form `x == 0` or `x < 0` written by someone who
+did not have two zeros in mind. `-0.0` compares equal to `0.0` and is
+not less than it, so every ordinary test misses it and every one of
+these was silent.
 
 **Negation was `0 - x`.** x86-64 has no scalar floating-point negate, and
 `cc/com.c` rewrites `-x` as `0 - x` whenever the back end says it cannot
@@ -1803,15 +1803,23 @@ aligned and the memory form of those instructions wants sixteen.
 `AXORPD` (`gmove` uses it to make a zero); `reg.c`'s default arm is
 `diag("reg: unknown op")`, so a missing entry is at least loud.
 
-Four more places lost the sign on the way out, and they are the reason
+Five more places lost the sign on the way out, and they are the reason
 fixing the negation alone was not enough:
 
 | | |
 |---|---|
 | `cc/scon.c` | `evconst` folded `-x` with a runtime negation, so it inherited the bug from the compiler compiling it |
 | `cc/pswt.c`, `1c`+`2c` `swt.c` | `ieeedtod` tested `native < 0` before `native == 0` |
+| `cc/dcl.c` | `init1` skips a **zero** static initialiser, since BSS is already zero -- and `vconst()` answers 0 for `-0.0`, because it truncates to an `int` |
 | `6c/txt.c` | `gmove` made any zero constant with `XORPD` of a register against itself, which is `+0.0` |
 | every `*l/obj.c` | `ieeedtof` took `-0.0` for a denormal and said `double fp to single fp overflow` |
+
+The `dcl.c` one is the one to remember, because it is the shape that
+survives every fix upstream of it: the value was folded correctly, and
+then **discarded as a zero** rather than written wrongly. `static double
+negzero = -0.0;` was the last case still failing after the other six
+were fixed, and it fails on its own -- a file-scope initialiser never
+goes through `com.c` or `cgen.c` at all.
 
 **`fpnegzero()` and `fpnegzeroval()` are in `cc/sub.c`**, so they are in
 `cc.a` and every back end has them -- `1c` and `2c` do not build

--- a/sys/lib/tests/fparith-test.c
+++ b/sys/lib/tests/fparith-test.c
@@ -60,11 +60,20 @@
  *	            inherited the bug from the compiler compiling it;
  *	cc/pswt.c   ieeedtod tested "native < 0" before "native == 0",
  *	            and -0.0 is not less than 0;
+ *	cc/dcl.c    init1 skips a zero static initialiser, since BSS is
+ *	            already zero -- and vconst() answers 0 for -0.0,
+ *	            because it truncates to an int;
  *	6c/txt.c    gmove materialised any zero constant with XORPD of a
  *	            register against itself, which gives +0.0.
  *
  *    and 6l's ieeedtof took -0.0 for a denormal and diagnosed "double
  *    fp to single fp overflow".
+ *
+ *    The dcl.c one is the shape that survives every fix upstream of it:
+ *    the value was folded correctly and then DISCARDED AS A ZERO rather
+ *    than written wrongly. It was the last case still failing when the
+ *    others were fixed. A file-scope initialiser never goes through
+ *    com.c or cgen.c, so it fails on its own.
  *
  *    The sign of zero is not decorative: it is what makes 1/x tell the
  *    two infinities apart, and it is the sign of the result of every

--- a/sys/src/cmd/cc/dcl.c
+++ b/sys/src/cmd/cc/dcl.c
@@ -604,7 +604,15 @@ init1(Sym *s, Type *t, long o, int exflag)
 					s->name);
 				return Z;
 			}
-			if(vconst(a) == 0)
+			/*
+			 * A zero initialiser needs no DATA record: the
+			 * object goes in BSS, which is already zero. That
+			 * is the fifth place the sign of zero was lost --
+			 * -0.0 is not all-zero bits, and vconst() answers 0
+			 * for it because it truncates to an int. Emit it.
+			 */
+			if(vconst(a) == 0
+			&& !(typefd[a->type->etype] && fpnegzero(a->fconst)))
 				return Z;
 
 			if(t->nbits) {


### PR DESCRIPTION
init1() skips emitting a DATA record when the initialiser is zero: the object is in BSS, which is already zero. vconst() answers 0 for -0.0, because it truncates the value to an int -- so a static -0.0 was discarded and read back as +0.0.

The seventh place the sign of zero was lost, and the one that survived the other six: the value was folded correctly and then thrown away as a zero rather than written wrongly. A file-scope initialiser never goes through com.c or cgen.c, so it fails on its own, and it was the last case still failing in fparith-test after the negation fix.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs