### PR TITLE
*l/obj.c: ieeedtof must still flush a subnormal double to zero

### DIFF
--- a/sys/src/cmd/1l/obj.c
+++ b/sys/src/cmd/1l/obj.c
@@ -1333,11 +1333,17 @@ ieeedtof(Ieee *e)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((e->h & ~0x80000000L) == 0 && e->l == 0)
+	if((e->h & ~0x80000000L) == 0)
 		return e->h & 0x80000000L;
 	exp = (e->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/2l/obj.c
+++ b/sys/src/cmd/2l/obj.c
@@ -1355,11 +1355,17 @@ ieeedtof(Ieee *e)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((e->h & ~0x80000000L) == 0 && e->l == 0)
+	if((e->h & ~0x80000000L) == 0)
 		return e->h & 0x80000000L;
 	exp = (e->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/5l/obj.c
+++ b/sys/src/cmd/5l/obj.c
@@ -1412,11 +1412,17 @@ ieeedtof(Ieee *ieeep)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+	if((ieeep->h & ~0x80000000L) == 0)
 		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/6l/obj.c
+++ b/sys/src/cmd/6l/obj.c
@@ -1470,11 +1470,17 @@ ieeedtof(Ieee *e)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((e->h & ~0x80000000L) == 0 && e->l == 0)
+	if((e->h & ~0x80000000L) == 0)
 		return e->h & 0x80000000L;
 	exp = (e->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/7l/obj.c
+++ b/sys/src/cmd/7l/obj.c
@@ -1416,11 +1416,17 @@ ieeedtof(Ieee *ieeep)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+	if((ieeep->h & ~0x80000000L) == 0)
 		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/8l/obj.c
+++ b/sys/src/cmd/8l/obj.c
@@ -1421,11 +1421,17 @@ ieeedtof(Ieee *e)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((e->h & ~0x80000000L) == 0 && e->l == 0)
+	if((e->h & ~0x80000000L) == 0)
 		return e->h & 0x80000000L;
 	exp = (e->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/9l/obj.c
+++ b/sys/src/cmd/9l/obj.c
@@ -1312,11 +1312,17 @@ ieeedtof(Ieee *ieeep)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+	if((ieeep->h & ~0x80000000L) == 0)
 		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/kl/obj.c
+++ b/sys/src/cmd/kl/obj.c
@@ -1230,11 +1230,17 @@ ieeedtof(Ieee *ieeep)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+	if((ieeep->h & ~0x80000000L) == 0)
 		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/ql/obj.c
+++ b/sys/src/cmd/ql/obj.c
@@ -1363,11 +1363,17 @@ ieeedtof(Ieee *ieeep)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+	if((ieeep->h & ~0x80000000L) == 0)
 		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;

--- a/sys/src/cmd/vl/obj.c
+++ b/sys/src/cmd/vl/obj.c
@@ -1308,11 +1308,17 @@ ieeedtof(Ieee *ieeep)
 	long v;
 
 	/*
-	 * Zero, of either sign.  Testing only h == 0 missed -0.0, whose
-	 * h is 0x80000000: it went on to compute an exponent of -1022
-	 * and reported "double fp to single fp overflow".
+	 * Zero, and anything the old test called zero.  Testing h == 0
+	 * alone missed -0.0, whose h is 0x80000000: it went on to
+	 * compute an exponent of -1022 and reported "double fp to
+	 * single fp overflow".
+	 *
+	 * Mask the sign and nothing else.  Adding "&& l == 0" here is
+	 * wrong and was a regression: a double with h == 0 and l != 0
+	 * is a subnormal, far below the least float, and this has
+	 * always flushed it to zero rather than diagnosed it.
 	 */
-	if((ieeep->h & ~0x80000000L) == 0 && ieeep->l == 0)
+	if((ieeep->h & ~0x80000000L) == 0)
 		return ieeep->h & 0x80000000L;
 	exp = (ieeep->h>>20) & ((1L<<11)-1L);
 	exp -= (1L<<10) - 2L;


### PR DESCRIPTION
My negative-zero fix added "&& l == 0" to the early return, which the old test did not have. A double with h == 0 and l != 0 is a subnormal, far below the least float; ieeedtof has always flushed it to zero, and with that clause it fell through to compute an exponent of -1022 and diagnosed instead:

	farith: double fp to single fp overflow
	ctime: double fp to single fp overflow

Mask the sign and nothing else, so the set of values treated as zero is exactly what it was, plus -0.0.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs