### PR TITLE
tk/plan9: $TKP9DEBUG, and record whether /dev/mouse opened writable

### DIFF
--- a/sys/lib/tests/tk-warp-test.tcl
+++ b/sys/lib/tests/tk-warp-test.tcl
@@ -22,14 +22,27 @@
 #
 # so an unchanged 0 0 means the write to /dev/mouse did not happen.
 # tkp9_warpmouse fails in exactly two ways: no descriptor, or a short
-# write. This script asks rio directly, from Tcl, so the answer costs
-# no rebuild.
+# write.
 #
-# Section 2 is the one that matters. Plan 9's mouse file takes "m x y",
-# and what it does with a window's file is the question: rio may refuse
-# the write when the window is not the current one, and the coordinates
-# may be the window's or the screen's. Section 3 asks which by warping
-# to a point whose two readings differ.
+# The first attempt at this script tried to ask rio directly, by
+# opening /dev/mouse from Tcl and writing "m150 150". That cannot work,
+# and the failure is the useful part of the answer:
+#
+#	couldn't open "/dev/mouse": file in use
+#
+# /dev/mouse opens once, and this process is holding it -- which does
+# at least prove the descriptor exists, so tkp9_warpmouse is not
+# failing for want of one. Everything else about it (whether the open
+# got O_RDWR or fell back to O_RDONLY, what the write returned, what
+# rio put in the errstr) is only visible from inside the process.
+#
+# Hence $TKP9DEBUG, which traces the whole chain:
+#
+#	TKP9DEBUG=1 wish tk-warp-test.tcl
+#
+# Run it both ways. Section 1 decides whether the warp is the bug or
+# merely downstream of a mouse poll that delivers nothing, and it needs
+# you to move the mouse.
 
 set fail 0
 
@@ -54,49 +67,46 @@ note "  mouse report or a warp changes it. Move the mouse over the"
 note "  window and run again -- if it is still 0 0 then the poll is"
 note "  the bug and the warp is a red herring."
 
-# 1. Does a real mouse report reach Tk at all? Bind <Motion> and ask
-# the user to move the pointer. This separates "the poll never updates
-# lastmouse" from "the warp cannot write".
+# 1. Does a real mouse report reach Tk at all? This is the question
+# that decides whether the warp is the bug or a symptom, so it waits
+# long enough to actually be answered: MOVE THE MOUSE OVER THE wish
+# WINDOW while it counts down. Doing nothing reports "no motion seen",
+# which is not the same as a failure and is not counted as one.
 note ""
-note "--- 1. real motion (move the mouse over this window) ---"
+note "--- 1. real motion ---"
+note "  MOVE THE MOUSE OVER THE wish WINDOW now (10s)..."
 set ::sawmotion {}
 bind . <Motion> {set ::sawmotion "%X %Y"}
-set after_id [after 3000 {set ::sawmotion timeout}]
-vwait ::sawmotion
-after cancel $after_id
-if {$::sawmotion eq "timeout"} {
-    note "  FAIL no <Motion> in 3s -- the mouse poll is not delivering"
-    incr fail
+for {set i 10} {$i > 0 && $::sawmotion eq ""} {incr i -1} {
+    after 1000 {set ::tick 1}
+    vwait ::tick
+    update
+}
+bind . <Motion> {}
+if {$::sawmotion eq ""} {
+    note "  no <Motion> seen. If you did move the mouse over the window,"
+    note "  the poll is the bug and the warp is downstream of it; run"
+    note "  with TKP9DEBUG set to see what tkp9_readmouse got."
 } else {
     note "  PASS <Motion> reported screen coords $::sawmotion"
     note "  winfo pointerxy . -> [pxy]"
 }
-bind . <Motion> {}
 
-# 2. Write to /dev/mouse by hand. This is exactly what tkp9_warpmouse
-# does -- "m" then the two numbers, no newline -- so a failure here is
-# the failure, and the error message names it.
+# 2. /dev/mouse cannot be opened twice, and this process holds it, so
+# asking rio from Tcl is not possible -- "file in use" is all that can
+# come back, which at least proves Tk has the descriptor. The state
+# that matters (was it opened for writing, and what did the warp write
+# return) is only visible from inside, hence $TKP9DEBUG.
 note ""
-note "--- 2. writing \"m x y\" to /dev/mouse by hand ---"
-foreach mode {r+ w} {
-    if {[catch {open /dev/mouse $mode} f]} {
-	note "  open /dev/mouse $mode: FAILED: $f"
-	continue
-    }
-    note "  open /dev/mouse $mode: ok"
-    fconfigure $f -translation binary -buffering none
-    set target "m150 150"
-    if {[catch {puts -nonewline $f $target; flush $f} err]} {
-	note "  write '$target': FAILED: $err"
-	incr fail
-    } else {
-	note "  write '$target': ok"
-	after 100
-	update
-	note "  winfo pointerxy . -> [pxy]"
-    }
+note "--- 2. who holds /dev/mouse ---"
+if {[catch {open /dev/mouse r+} f]} {
+    note "  open /dev/mouse: $f"
+    note "  'file in use' here is the expected answer and means Tk has it."
+} else {
+    note "  open /dev/mouse SUCCEEDED -- so Tk does NOT have it, which is"
+    note "  the bug: no descriptor means no events and no warp."
     catch {close $f}
-    break
+    incr fail
 }
 
 # 3. Tk's own warp, both forms. bind-34.2 is the second of these.
@@ -125,16 +135,19 @@ foreach {what cmd} {
     }
 }
 
-# 4. Which coordinate system did the write use? Warp to a point well
-# inside the window and compare the two readings. If rio takes the
-# coordinates as window-relative it will land at rootx+150, and if as
-# screen coordinates at 150.
+# 4. If the warp DID move the pointer, which coordinate system did rio
+# take? The last warp above asked for screen 200,200.
 note ""
 note "--- 4. window-relative or screen coordinates? ---"
 note "  . is at [winfo rootx .],[winfo rooty .]"
-note "  after 'm150 150' the pointer is at [pxy]"
-note "  screen-relative would read 150 150"
-note "  window-relative would read [expr {[winfo rootx .]+150}] [expr {[winfo rooty .]+150}]"
+note "  after warping to screen 200,200 the pointer reads [pxy]"
+note "  screen-relative would read 200 200"
+note "  window-relative would read [expr {[winfo rootx .]+200}] [expr {[winfo rooty .]+200}]"
+note ""
+note "Run again with TKP9DEBUG set for the trace from inside:"
+note "    TKP9DEBUG=1 wish tk-warp-test.tcl"
+note "which reports the /dev/mouse descriptor and mode, every"
+note "TkpWarpPointer/XWarpPointer call, and the warp write with its errstr."
 
 puts "$fail failure(s)"
 flush stdout

--- a/sys/src/external/tk/plan9/tkP9Draw.h
+++ b/sys/src/external/tk/plan9/tkP9Draw.h
@@ -127,6 +127,13 @@ int    tkp9_kbdfd(void);
 /*
  * Event reading
  */
+/*
+ * Is $TKP9DEBUG set? Tracing for the paths nothing else can report --
+ * /dev/mouse opens once and this process holds it, so its state is not
+ * reachable from Tcl. See the note in tkPlan9DrawImpl.c.
+ */
+int    tkp9_debug(void);
+
 int    tkp9_readmouse(TkP9Mouse *out);	/* 0=ok, -1=eof/error */
 int    tkp9_readkey(void);		/* UTF-32 codepoint, or -1 */
 int    tkp9_checkresized(void);		/* 1 if window was resized */

--- a/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
+++ b/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
@@ -42,8 +42,32 @@
 /* ------------------------------------------------------------------ */
 
 static int  gMouseFd  = -1;	/* /dev/mouse */
+static int  gMouseRW  = 0;	/* was /dev/mouse opened for writing? */
 static int  gConsFd   = -1;	/* /dev/cons (keyboard) */
 static int  gResized  = 0;
+
+/*
+ * $TKP9DEBUG turns on tracing for the paths that have no other way to
+ * report themselves. Nothing here can be reached from Tcl -- /dev/mouse
+ * can only be opened once, and this process holds it -- so a question
+ * like "did the warp write succeed, and what did rio say" is otherwise
+ * only answerable by rebuilding with a printf in it. CLAUDE.md records
+ * that as the technique that worked for every bug found in this
+ * directory; this is the same thing left behind rather than removed.
+ *
+ * Plan 9's fprint() is used rather than fprintf(): this file includes
+ * no stdio (see the header comment), and libc.h declares fprint, so
+ * there is no variadic-call-with-no-prototype trap. %r is the errstr.
+ */
+int
+tkp9_debug(void)
+{
+    static int on = -1;
+
+    if(on < 0)
+        on = getenv("TKP9DEBUG") != nil;
+    return on;
+}
 
 /* ------------------------------------------------------------------ */
 /* Helpers                                                             */
@@ -65,10 +89,27 @@ tkp9_open(const char *label)
     if(initdraw(nil, nil, (char*)label) < 0)
         return -1;
 
-    /* Open mouse device directly (avoids libthread dependency) */
+    /*
+     * Open mouse device directly (avoids libthread dependency).
+     *
+     * It has to be O_RDWR to warp the pointer: a warp is a write of
+     * "m x y" to this same descriptor, which is what libdraw's moveto()
+     * does. The read-only fallback keeps events working on a system
+     * that will not give write permission, at the cost of warping, so
+     * remember which one we got -- silently losing the warp is how
+     * bind-34.* and event-9.* fail.
+     */
     gMouseFd = open("/dev/mouse", O_RDWR);
+    gMouseRW = gMouseFd >= 0;
     if(gMouseFd < 0)
         gMouseFd = open("/dev/mouse", O_RDONLY);
+    if(tkp9_debug()){
+        if(gMouseFd < 0)
+            fprint(2, "tkp9: /dev/mouse will not open: %r\n");
+        else
+            fprint(2, "tkp9: /dev/mouse fd=%d writable=%d\n",
+                gMouseFd, gMouseRW);
+    }
 
     /* Open console for keyboard input */
     gConsFd = open("/dev/cons", O_RDONLY);
@@ -399,16 +440,34 @@ int
 tkp9_warpmouse(int x, int y)
 {
     char buf[40];
-    int n = 0;
+    int n = 0, w;
 
-    if(gMouseFd < 0)
+    if(gMouseFd < 0){
+        if(tkp9_debug())
+            fprint(2, "tkp9_warpmouse(%d,%d): no /dev/mouse\n", x, y);
         return -1;
+    }
+    if(!gMouseRW && tkp9_debug())
+        fprint(2, "tkp9_warpmouse(%d,%d): /dev/mouse is read-only\n", x, y);
+
     buf[n++] = 'm';
     n += putnum(buf + n, x);
     buf[n++] = ' ';
     n += putnum(buf + n, y);
-    if(write(gMouseFd, buf, n) != n)
+
+    w = write(gMouseFd, buf, n);
+    if(w != n){
+        if(tkp9_debug()){
+            buf[n] = '\0';		/* n <= 24, buf is 40 */
+            fprint(2, "tkp9_warpmouse: write(%d, \"%s\", %d) = %d: %r\n",
+                gMouseFd, buf, n, w);
+        }
         return -1;
+    }
+    if(tkp9_debug()){
+        buf[n] = '\0';
+        fprint(2, "tkp9_warpmouse: wrote \"%s\" ok\n", buf);
+    }
     return 0;
 }
 
@@ -520,7 +579,16 @@ tkp9_readmouse(TkP9Mouse *out)
     if(gMouseFd < 0) return -1;
 
     n = read(gMouseFd, buf, sizeof buf);
-    if(n != 1 + 4*12) return -1;
+    if(n != 1 + 4*12){
+        /*
+         * A short record is dropped silently, so if the format is ever
+         * not 'm' plus four 12-byte fields, no mouse event is delivered
+         * at all and nothing says why.
+         */
+        if(tkp9_debug())
+            fprint(2, "tkp9_readmouse: read = %d, want %d: %r\n", n, 1 + 4*12);
+        return -1;
+    }
 
     if(buf[0] == 'r') {
         /* Resize event */

--- a/sys/src/external/tk/plan9/tkPlan9Init.c
+++ b/sys/src/external/tk/plan9/tkPlan9Init.c
@@ -1076,6 +1076,10 @@ XWarpPointer(Display *d, Window s, Window dw,
     if (x >= gP9.screenw) x = gP9.screenw - 1;
     if (y >= gP9.screenh) y = gP9.screenh - 1;
 
+    if (tkp9_debug())
+        fprintf(stderr, "XWarpPointer: dw=%lu dx=%d dy=%d -> screen %d,%d\n",
+                (unsigned long) dw, dx, dy, x, y);
+
     if (tkp9_warpmouse(x, y) < 0)
         return 0;
 

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -610,6 +610,12 @@ TkpWarpPointer(TkDisplay *dispPtr)
 	w = Tk_WindowId(dispPtr->warpWindow);
     else
 	w = TKP9_ROOT_XID;
+
+    if (tkp9_debug())
+	fprintf(stderr, "TkpWarpPointer: warpWindow=%s w=%lu warpX=%d warpY=%d\n",
+		dispPtr->warpWindow? Tk_PathName(dispPtr->warpWindow): "(screen)",
+		(unsigned long) w, (int) dispPtr->warpX, (int) dispPtr->warpY);
+
     XWarpPointer(dispPtr->display, None, w, 0, 0, 0, 0,
 	    (int) dispPtr->warpX, (int) dispPtr->warpY);
 }


### PR DESCRIPTION
Asking rio about the warp from Tcl cannot work: /dev/mouse opens once and this process holds it, so the probe only ever answers "file in use". That does prove tkp9_warpmouse is not failing for want of a descriptor -- but which of the remaining possibilities it is (the open fell back to O_RDONLY, or rio refused the write) is visible only from inside.

So trace it from inside, permanently and off by default. tkp9_debug() reads $TKP9DEBUG once; the /dev/mouse open reports its descriptor and mode, TkpWarpPointer and XWarpPointer report their arguments and the screen coordinate they computed, and tkp9_warpmouse reports the bytes it wrote with the write result and %r. tkp9_readmouse reports a short record too: it drops anything that is not 'm' plus four 12-byte fields and says nothing, so a format mismatch would deliver no mouse event at all with nothing to say why -- which is the other reading of the "no <Motion> in 3s" this run showed.

The read-only fallback in the open is now remembered rather than silently accepted. A warp is a write to that same descriptor, so falling back costs the pointer warp entirely, which is exactly how bind-34.* and the ten event-9.* cases fail.

tkPlan9DrawImpl.c uses fprint(2, ...) rather than fprintf: it includes no stdio, and <draw.h> brings <fmt.h>, which prototypes fprint -- so this is not another variadic call with no prototype in scope. %r is __errfmt, installed in this libap.

tk-warp-test.tcl updated to match: it no longer pretends it can open /dev/mouse, and section 1 waits ten seconds for a real <Motion> rather than three, since that is the question deciding whether the warp is the bug or downstream of a poll that delivers nothing.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs