### PR TITLE
tk/plan9: winfo pointerxy read a stub, not the pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1647,6 +1647,37 @@ synthesises the lot. Two details it depends on:
   again so the crossing events are generated. An X server does this
   unasked; nothing here will.
 
+**`winfo pointerxy` answered 0,0 whatever the pointer was doing.**
+`TkGetPointerCoords` in `tkPlan9Wm.c` was a stub assigning 0 to both,
+sitting a few hundred lines from an `XQueryPointer` that works. It is
+`tkUnixWm.c`'s now: ask about the root window and take the coordinates
+relative to it, which are the screen coordinates, and answer -1,-1 on
+failure rather than a plausible 0,0.
+
+That is the whole of `bind-34.1` and `bind-34.2`, and it is worth
+reading as a lesson in reading a symptom. Both tests warp the pointer
+and then read it back with `winfo pointerxy`, so `0 0` looks exactly
+like a warp that never happened -- and the chain behind a warp is long
+enough (`TkpWarpPointer` -> `XWarpPointer` -> `tkp9_warpmouse` -> a
+write to `/dev/mouse`) to hold a plausible suspect at every link. It is
+also silent at every link: `XWarpPointer` returns early without setting
+`gP9.lastmouse` when the write fails, so a failed warp and a failed
+readback are indistinguishable from Tcl.
+
+**The tell was one line of `tk-warp-test.tcl`**: a real `<Motion>`
+reported `%X %Y` as `397 124`, and `winfo pointerxy` on the next line
+said `0 0`. `gP9.lastmouse` was demonstrably right, so nothing upstream
+of the readback could be at fault. `$TKP9DEBUG` then confirmed the warp
+end to end -- `/dev/mouse fd=7 writable=1`, `-> screen 120,120`,
+`wrote "m120 120" ok` -- which is the evidence that the warp was never
+the bug. **Two rounds were spent on the write before that**, on the
+strength of a deduction that was sound except for assuming the readback
+worked.
+
+`Tk_GetPointerCoords` sat beside it, an identical stub, declared and
+called nowhere in the tree -- dead code wearing the name of an API that
+does not exist. Removed.
+
 `Tk_MeasureChars` was rewritten at the same time to honour
 `TK_WHOLE_WORDS` and `TK_AT_LEAST_ONE`, which it ignored:
 `Tk_ComputeTextLayout` wraps with both set and expects a break at the

--- a/sys/lib/tests/tk-warp-test.tcl
+++ b/sys/lib/tests/tk-warp-test.tcl
@@ -43,6 +43,26 @@
 # Run it both ways. Section 1 decides whether the warp is the bug or
 # merely downstream of a mouse poll that delivers nothing, and it needs
 # you to move the mouse.
+#
+# WHAT THIS ACTUALLY FOUND, and why the script is kept: the warp was
+# never the bug. The trace reads
+#
+#	tkp9: /dev/mouse fd=7 writable=1
+#	XWarpPointer: dw=11 dx=20 dy=20 -> screen 120,120
+#	tkp9_warpmouse: wrote "m120 120" ok
+#	  FAIL to a window (bind-34.1): pointerxy unchanged at 0 0
+#
+# -- written, and acknowledged, and still 0 0. The answer is in section
+# 1 of the same run: a real <Motion> reported 397 124 and "winfo
+# pointerxy" said 0 0 on the very next line, so gP9.lastmouse was right
+# and only the READBACK was wrong. TkGetPointerCoords in tkPlan9Wm.c
+# was a stub assigning 0 to both, next door to an XQueryPointer that
+# works.
+#
+# The moral for the next one of these: a value that is read back wrong
+# looks identical to a value that was never written. Prove the readback
+# before chasing the write -- one line comparing %X against winfo
+# pointerxy would have saved two rounds here.
 
 set fail 0
 

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -1104,20 +1104,35 @@ Tk_ResetUserInactiveTime(Display *dpy)
 /* Pointer coords (return last known mouse position)                  */
 /* ------------------------------------------------------------------ */
 
-void
-Tk_GetPointerCoords(Tk_Window tkwin, int *xPtr, int *yPtr)
-{
-    (void)tkwin;
-    *xPtr = 0;
-    *yPtr = 0;
-}
-
+/*
+ * Where is the pointer? This is what "winfo pointerxy" answers, and it
+ * was a stub returning 0,0 sitting next to an XQueryPointer that works
+ * -- so the position was always 0,0 however the pointer got there.
+ *
+ * That is the whole of bind-34.1 and bind-34.2. Both warp the pointer
+ * and then read it back with "winfo pointerxy", and it looked exactly
+ * like a warp that had not happened: the warp is fine, the readback was
+ * not. The tell was a real <Motion> reporting %X %Y as 397 124 while
+ * winfo pointerxy said 0 0 in the next line.
+ *
+ * Structured as tkUnixWm.c's: ask about the root, and take the
+ * coordinates relative to it, which are the screen coordinates.
+ * A failed query answers -1,-1 rather than a plausible 0,0.
+ */
 void
 TkGetPointerCoords(Tk_Window tkwin, int *xPtr, int *yPtr)
 {
-    (void)tkwin;
-    *xPtr = 0;
-    *yPtr = 0;
+    TkWindow *winPtr = (TkWindow *) tkwin;
+    Window root, child;
+    int rootX, rootY;
+    unsigned mask;
+
+    if (XQueryPointer(winPtr->display,
+	    RootWindow(winPtr->display, winPtr->screenNum),
+	    &root, &child, &rootX, &rootY, xPtr, yPtr, &mask) != True) {
+	*xPtr = -1;
+	*yPtr = -1;
+    }
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
TkGetPointerCoords assigned 0 to both coordinates, a few hundred lines from an XQueryPointer that works. So "winfo pointerxy" answered 0 0 whatever the pointer was doing, which is the whole of bind-34.1 and bind-34.2.

It is tkUnixWm.c's now: ask about the root window and take the coordinates relative to it, which are the screen coordinates, and answer -1,-1 on failure rather than a plausible 0,0.

The warp was never the bug, and this is worth recording as a lesson in reading a symptom. Both tests warp and then read back with winfo pointerxy, so 0 0 looks exactly like a warp that never happened, and the chain behind a warp -- TkpWarpPointer, XWarpPointer, tkp9_warpmouse, a write to /dev/mouse -- holds a plausible suspect at every link, each of them silent. Two rounds went on the write. The $TKP9DEBUG trace then showed it working end to end:

  tkp9: /dev/mouse fd=7 writable=1
  XWarpPointer: dw=11 dx=20 dy=20 -> screen 120,120
  tkp9_warpmouse: wrote "m120 120" ok
    FAIL to a window (bind-34.1): pointerxy unchanged at 0 0

and the answer was already in section 1 of the same run: a real <Motion> reported 397 124 while winfo pointerxy said 0 0 on the next line. gP9.lastmouse was right; only the readback was wrong.

A value read back wrong is indistinguishable from a value never written. Prove the readback first.

Tk_GetPointerCoords sat beside it, an identical stub, declared and called nowhere in the tree -- dead code wearing the name of an API that does not exist. Removed. Deleting it stranded its "void" above the next function's comment, which is the return-type mistake CLAUDE.md names; the host gcc syntax check caught it before shipping, as intended.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs