### PR TITLE
tk/plan9: Tk_GetRootCoords must stop at a toplevel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1647,6 +1647,43 @@ synthesises the lot. Two details it depends on:
   again so the crossing events are generated. An X server does this
   unasked; nothing here will.
 
+**`Tk_GetRootCoords` walked past the toplevel, so every toplevel but
+`.` was in the wrong place.** The walk up `parentPtr` must **stop at a
+window with `TK_TOP_LEVEL`**: a toplevel's `parentPtr` is its logical
+Tk parent -- `.one`'s is `.` -- and its `changes.x/y` are already screen
+coordinates, so continuing past it adds the parent's position to a
+window that is not inside it. `tkUnixWm.c` breaks there; this walked the
+whole chain.
+
+Invisible while `.` sits at 0,0, which is why `tk-warp-test.tcl` never
+caught it -- `.` is the one toplevel with no `parentPtr`. `event.test`'s
+`setup_win_mousepointer` opens with
+
+```tcl
+wm geometry . +700+400; # root window out of our way
+```
+
+and that is what made it fatal rather than merely wrong: `.one` at
++100+100 was reported at **800,500**.
+
+**Everything that asks where a window is went wrong with it** --
+`winfo rootx`/`rooty` for any toplevel, `winfo containing`, and through
+`Tk_CoordsToWindow` the entire pointer machinery, because a hit test
+that finds nothing hands NULL to `Tk_UpdatePointer` and no crossing is
+ever generated. That is the ten `event-9.*` failures, every one of them
+stuck in that single setup line waiting for an `<Enter>` that could not
+come, never reaching the behaviour it was written to test.
+
+An **embedded** toplevel is the exception and must keep walking, through
+its container rather than its parent. `tkUnixWm.c` consults the X server
+when the container belongs to another application; here
+`Tk_GetOtherWindow` can always answer, since the two share this process.
+
+Covered by `sys/lib/tests/tk-enter-test.tcl`, which prints
+`winfo rootx`/`width`/`ismapped` for each window before using it. One
+line of that would have found this immediately; the round trip went on
+the crossing machinery instead, which was correct all along.
+
 **`winfo pointerxy` answered 0,0 whatever the pointer was doing.**
 `TkGetPointerCoords` in `tkPlan9Wm.c` was a stub assigning 0 to both,
 sitting a few hundred lines from an `XQueryPointer` that works. It is

--- a/sys/lib/tests/tk-enter-test.tcl
+++ b/sys/lib/tests/tk-enter-test.tcl
@@ -36,20 +36,49 @@
 # So this reports which window each Enter actually names, and asks
 # "winfo containing" separately, rather than only whether one arrived.
 #
+# WHAT IT FOUND, first run:
+#
+#	pointer now at 350 350  (want 350 350)
+#	winfo containing -> ''  (want .one)
+#	crossings:
+#
+# The warp is exact and the hit test finds nothing at a point plainly
+# inside .one -- so Tk_CoordsToWindow returned NULL, TkP9UpdatePointer
+# handed NULL to Tk_UpdatePointer, and no crossing could be generated.
+# Behind that: Tk_GetRootCoords walked the parent chain past the
+# toplevel, and a toplevel's parentPtr is its logical Tk parent, so
+# .one's position had .'s added to it. setup_win_mousepointer moves .
+# to +700+400 first, which is what made it fatal rather than merely
+# wrong. Hence the "where" proc below -- one line of geometry would
+# have pinned this without the round trip that found it.
+#
 # DO NOT TOUCH THE MOUSE while this runs.
 
 set fail 0
 
 proc note {m} { puts $m; flush stdout }
 
+# The condition is a braced expression, evaluated in the caller's scope:
+# "if {$cond}" on a braced argument gets the string, not a boolean, and
+# fails with "expected boolean value but got a list".
 proc ok {cond what} {
     global fail
-    if {$cond} {
+    if {[uplevel 1 [list expr $cond]]} {
 	note "  PASS $what"
     } else {
 	note "  FAIL $what"
 	incr fail
     }
+}
+
+# Where does Tk think a window is, and how big? Tk_GetRootCoords is the
+# thing behind "winfo rootx", and getting it wrong takes winfo
+# containing and the whole pointer machinery with it, so print it for
+# anything whose position matters.
+proc where {w} {
+    note "  $w: rootx,rooty [winfo rootx $w],[winfo rooty $w]\
+ size [winfo width $w]x[winfo height $w]\
+ mapped [winfo ismapped $w]"
 }
 
 # Collect every crossing, with the window and the detail field, the way
@@ -83,6 +112,8 @@ tkwait visibility .one
 update
 crossings
 
+where .
+where .one
 event generate .one <Motion> -warp 1 -x 250 -y 250
 settle
 set c [crossings]

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -1000,14 +1000,53 @@ Tk_UnsetGrid(Tk_Window tkwin)
 /* Root coordinates                                                   */
 /* ------------------------------------------------------------------ */
 
+/*
+ * The walk up the parents STOPS AT A TOPLEVEL. A toplevel's parentPtr
+ * is its logical Tk parent -- ".one"'s is "." -- and its changes.x/y
+ * are already screen coordinates, so continuing past it adds the
+ * parent's position to a window that is not inside it.
+ *
+ * This walked the whole chain, so every toplevel but "." was reported
+ * at its own position plus "."'s. Invisible while "." sits at 0,0, and
+ * event.test's setup_win_mousepointer opens with
+ *
+ *	wm geometry . +700+400; # root window out of our way
+ *
+ * which is what made it maximal: ".one" at +100+100 was reported at
+ * 800,500. Everything that asks where a window is went wrong with it --
+ * "winfo rootx/rooty" for any toplevel, "winfo containing", and through
+ * Tk_CoordsToWindow the entire pointer machinery, since a hit test that
+ * finds nothing hands NULL to Tk_UpdatePointer and no crossing is ever
+ * generated. That is the ten event-9.* failures, all of them stuck in
+ * that one setup line waiting for an <Enter> that could not come.
+ *
+ * An EMBEDDED toplevel is the exception and must keep walking, through
+ * its container rather than its parent -- the container is where it
+ * actually sits. tkUnixWm.c has to consult the X server when the
+ * container belongs to another application; here Tk_GetOtherWindow can
+ * always answer, because an embedded window and its container share
+ * this process.
+ */
 void
 Tk_GetRootCoords(Tk_Window tkwin, int *xPtr, int *yPtr)
 {
     TkWindow *winPtr = (TkWindow *)tkwin;
     int x = 0, y = 0;
-    while (winPtr) {
+
+    while (winPtr != NULL) {
         x += winPtr->changes.x + winPtr->changes.border_width;
         y += winPtr->changes.y + winPtr->changes.border_width;
+        if (winPtr->flags & TK_TOP_LEVEL) {
+            Tk_Window otherPtr;
+
+            if (!(winPtr->flags & TK_EMBEDDED))
+                break;
+            otherPtr = Tk_GetOtherWindow((Tk_Window) winPtr);
+            if (otherPtr == NULL)
+                break;
+            winPtr = (TkWindow *) otherPtr;
+            continue;
+        }
         winPtr = winPtr->parentPtr;
     }
     *xPtr = x;


### PR DESCRIPTION
The walk up parentPtr ran the whole chain. A toplevel's parentPtr is its logical Tk parent -- .one's is . -- and its changes.x/y are already screen coordinates, so continuing past it adds the parent's position to a window that is not inside it. tkUnixWm.c breaks at TK_TOP_LEVEL; an embedded toplevel is the exception and keeps walking through its container, which Tk_GetOtherWindow can always answer here because the two share this process.

Invisible while . sits at 0,0, which is why tk-warp-test.tcl never caught it: . is the one toplevel with no parentPtr. event.test's setup_win_mousepointer opens with

  wm geometry . +700+400; # root window out of our way

and that is what made it fatal rather than merely wrong -- .one at +100+100 was reported at 800,500.

Everything that asks where a window is went wrong with it: winfo rootx/rooty for any toplevel, winfo containing, and through Tk_CoordsToWindow the whole pointer machinery, since a hit test that finds nothing hands NULL to Tk_UpdatePointer and no crossing can be generated. That is the ten event-9.* failures, every one stuck in that single setup line waiting for an <Enter> that could not come.

tk-enter-test.tcl found it in one run by asking winfo containing separately from the crossings:

  pointer now at 350 350  (want 350 350)
  winfo containing -> ''  (want .one)
  crossings:

an exact warp and a hit test that finds nothing. It now also prints rootx/width/ismapped for each window before using them -- one line of that would have found this without the round trip that went on the crossing machinery, which was correct all along.

Also fixes the script's own ok proc: it took a braced expression and tested it with "if {$cond}", which gets the string and fails with "expected boolean value but got a list". It evaluates it with uplevel now.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs