### PR TITLE
tests: tk-enter-test.tcl -- clear the crossing log before, not after

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1722,6 +1722,76 @@ last word boundary that fits, or at least one character. Breaking at any
 character put line breaks mid-word and in the wrong place for tabs
 (font-24.*). The structure follows `tkUnixFont.c`.
 
+### Tk on Plan 9: what the remaining test failures are, and which are ours
+
+The suite is at **36 failing tests** (`wish all.tcl`; note `grep -c
+FAILED` counts two lines each, so 72 lines). Nine of those are known
+not to be the Plan 9 backend's, and are worth recording so they are not
+chased again:
+
+**The five remaining `event-9.*` are generic Tk.** The port's side is
+proved correct by `tk-enter-test.tcl`: the hit test agrees with the warp
+at every level and the crossings arrive. What is wrong is the `%d`
+detail when the window the pointer was in has just been **destroyed**:
+
+```
+event-9.14  got   |<Enter> NotifyVirtual .one|<Enter> NotifyVirtual .one.f1|<Enter> NotifyAncestor .one.f1.f2|
+            want  |<Enter> NotifyNonlinearVirtual .one|...NotifyNonlinearVirtual .one.f1|...NotifyNonlinear .one.f1.f2|
+```
+
+`TkPointerDeadWindow` (`generic/tkPointer.c`) sets `lastWinPtr =
+TkGetContainer(winPtr)`, which is NULL for anything not embedded. So
+`GenerateEnterLeave` calls `TkInOutEvents` with a **NULL sourcePtr**,
+`FindCommonAncestor(NULL, dest)` returns `upLevels == 0`, and that is
+the "dest is an inferior of source" branch -- `NotifyVirtual` down the
+chain and `NotifyAncestor` at the end, exactly what comes out. The
+non-linear details need a live source in a different branch.
+
+`event-9.16` and `event-9.17` say in their own comments that they test
+"overwriting the dead window struct in `TkPointerDeadWindow()` and
+subsequent reading in `GenerateEnterLeave()`" -- **a mechanism this
+tree's `tkPointer.c` does not have**: its `ThreadSpecificData` holds
+`grabWinPtr`, `lastState`, `lastPos`, `lastWinPtr`, `restrictWinPtr`
+and `cursorWinPtr`, and nothing else. So the test file is newer than
+the `tkPointer.c` beside it. Fixing this means patching generic Tk,
+which is shared with the Windows and Mac ports; `TkPointerDeadWindow`
+is called from exactly three places and ours (`XDestroyWindow` in
+`tkPlan9Init.c`) matches `win/tkWinWindow.c:316` and
+`macosx/tkMacOSXSubwindows.c:70`.
+
+**The four `place-8.*`/`pack-18.*` fail on X11 too.** All four have the
+shape
+
+```
+got   1 1 W H 1 1
+want  1 0 W H 0 1
+```
+
+and all four ask whether a **child** reports `winfo ismapped` as 0 after
+`wm iconify` on its toplevel. On Windows the OS sends `WM_SHOWWINDOW`
+with `SW_PARENTCLOSING` to the children and Tk turns that into
+`UnmapNotify`; X sends nothing for a child of an unmapped window, and
+neither `Tk_UnmapWindow` nor either port's `TkWmUnmapWindow` walks the
+children. The tests carry `-constraints {failsOnUbuntu failsOnXQuartz}`,
+and that constraint is
+
+```tcl
+testConstraint failsOnUbuntu [expr {![info exists ::env(CI)] || ![string match Linux $::tcl_platform(os)]}]
+```
+
+-- true (so the test *runs*) everywhere except CI on Linux. They
+therefore fail on an ordinary Linux/X11 desktop as well. **Do not
+"fix" these by unmapping descendants**: that would be inventing
+semantics X does not have, in the one direction where this port
+deliberately follows X.
+
+`clipboard-4.1/4.2/4.4/6.2` are the third such group, and were already
+known: they turn on X selection *ownership*, which `/dev/snarf` has no
+concept of.
+
+That leaves roughly 23 that may be real, the largest being `font` (4),
+`imgListFormat` (3) and `canvas` (3).
+
 ### Syntax-check Tk's Plan 9 backend on the host before shipping it
 
 A round trip to the VM costs a full rebuild, and twice now it has been

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1789,8 +1789,94 @@ deliberately follows X.
 known: they turn on X selection *ownership*, which `/dev/snarf` has no
 concept of.
 
-That leaves roughly 23 that may be real, the largest being `font` (4),
-`imgListFormat` (3) and `canvas` (3).
+**The four `font-21.19..22` are an upstream test bug**, and the block
+they sit in shows it. Sixteen tests there all ask the *same* question
+and compare it against a *different* name:
+
+```tcl
+if {[font actual {avantgarde 12 roman normal} -family] == "helvetica"} {
+    set x [psfontname avantgarde 12 roman normal]      ;# four arguments
+} else {
+    set x Helvetica
+}
+```
+
+`proc psfontname {name}` takes **one** argument, and every other call
+site in the file quotes it (`psfontname "arial 10"`). So the `then`
+branch raises `wrong # args`. It is dead code on a normal machine --
+21.7..21.10 compare against `avantgarde`, 21.11..18 against `bookman`
+and so on, and only a machine where avantgarde resolves to *helvetica*
+ever enters it. `ChooseFont` here resolves any unknown proportional
+family to helvetica, so we do.
+
+**Do not change the fallback to dodge this.** Reporting the family that
+was actually resolved is the contract (see the font section above), and
+`tk-font-test.tcl` asserts the real requirement -- that an unknown
+family does *not* come back as itself.
+
+**`imgListFormat-3.1/3.2/3.3` need `tktest`, not `wish`**:
+`invalid command name "testphotostringmatch"`, which `generic/tkTest.c`
+registers only in Tk's own test binary. A harness limitation, not a
+port bug.
+
+That is 16 of the 36 accounted for. `canvas-23.*` **is** ours and was
+the useful find in that sweep -- see the image section below.
+
+### Tk on Plan 9: the image path was a stub in both directions
+
+`canvas-23.1/23.2/23.3` fail with
+
+```
+failed to copy Pixmap to XImage
+```
+
+which is `tkCanvas.c` reporting that `XGetImage` returned NULL. It was
+a stub, and so were `XPutImage` and `TkPutImage`; `tkp9_putpixels`
+existed but **nothing called it**. So the whole pixel path was
+unimplemented in both directions, and the three canvas tests are only
+the corner of it the suite happens to poke -- `TkPutImage` is how Tk
+draws every photo image.
+
+The awkward part is the pixel format, and it has a trap in it.
+
+**The XImage side.** `XCreateImage` here declares 32 bits per pixel and
+`byte_order`, and generic Tk reads a pixel with a plain 32-bit load and
+then decomposes it with the *visual's* masks -- `tkCanvas.c`'s
+`DrawCanvas` does exactly that, and `screen->root_visual` says
+`0xFF0000`/`0x00FF00`/`0x0000FF`. So an XImage pixel is the host-order
+word `0x00RRGGBB`, and the only way to agree on both endiannesses is a
+32-bit access rather than naming bytes. `XImagePixel()` is that
+accessor. `P9GetPixel`/`P9PutPixel` used to store R,G,B,A in *memory*
+order, which contradicts the `LSBFirst` the same file declared -- on a
+little-endian machine that puts blue where the red mask looks. Nothing
+had noticed because no pixel ever made the trip. `byte_order` now
+follows the host rather than being hardcoded, since this tree builds
+big-endian architectures too.
+
+**The Plan 9 side, and the trap.** `tkp9_putpixels`/`tkp9_getpixels`
+speak R,G,B,A bytes and convert to Plan 9's `RGBA32`. Plan 9 names a
+channel from the most significant bits down and stores the pixel
+little-endian, which makes `RGBA32` A,B,G,R in memory -- but **that is
+not assumed**, because getting it wrong is *invisible in a round trip*:
+put and get would permute and unpermute by the same amount and cancel,
+and the error would surface only where these bytes meet the XImage
+layout, as red and blue exchanged in every photo, a long way from here.
+So `rgbacalibrate()` asks instead, once: fill a pixel with four
+components that are all different (`0x4080C0FF` -- the colour argument
+to `allocimage` is `0xRRGGBBAA`, documented and stable, and an alpha of
+`0xFF` makes premultiplication the identity) and see where each lands.
+The documented order is the fallback if the probe cannot run.
+`$TKP9DEBUG` prints what it found.
+
+`tkp9_getpixels` draws the source into an `RGBA32` temporary before
+unloading it rather than unloading the source directly: a pixmap is
+allocated in the *screen's* channel (`tkp9_allocimage`), which varies by
+machine, and `draw()` does that conversion for us.
+
+**A round-trip test cannot check this.** The absolute colour is what
+matters, which is exactly what `canvas-23.1` does -- it fills with
+`#000080` and reads the pixels back -- so a red/blue swap shows up
+there as `#800000`.
 
 ### Syntax-check Tk's Plan 9 backend on the host before shipping it
 

--- a/sys/lib/tests/tk-enter-test.tcl
+++ b/sys/lib/tests/tk-enter-test.tcl
@@ -52,6 +52,19 @@
 # wrong. Hence the "where" proc below -- one line of geometry would
 # have pinned this without the round trip that found it.
 #
+# With Tk_GetRootCoords fixed, all four sections pass:
+#
+#	.: rootx,rooty 700,400 size 200x200 mapped 1
+#	.one: rootx,rooty 100,100 size 300x300 mapped 1
+#	pointer now at 350 350; winfo containing -> '.one'
+#	crossings: {Enter .one NotifyAncestor}
+#	...
+#	crossings after destroying .two:
+#	    {Enter .one NotifyVirtual} {Enter .one.f1 NotifyAncestor}
+#
+# -- the hit test agrees with the warp at every level, and the detail
+# fields are the ones event-9.* expects.
+#
 # DO NOT TOUCH THE MOUSE while this runs.
 
 set fail 0
@@ -125,16 +138,26 @@ ok {[winfo containing 350 350] eq ".one"} "winfo containing says .one"
 ok {[lsearch -glob $c "Enter .one *"] >= 0} "<Enter> arrived on .one"
 
 note ""
-note "--- 2. a child under the pointer ---"
+note "--- 2. a child mapped under a stationary pointer ---"
+# The frame covers 200,200..400,400 within .one, i.e. screen 300..500
+# clipped to .one's 400 -- the pointer at 350,350 is inside it. An X
+# server generates the crossing unasked; here gP9.pointerDirty makes the
+# next poll re-report the same position so tkPointer.c can.
+#
+# Clear the log BEFORE the thing being measured. Reading it with
+# "[crossings]" after having called "crossings" to clear reports the
+# buffer that call just emptied, which is how this section first printed
+# an empty result that looked like a missing crossing.
+crossings
 frame .one.f1 -width 200 -height 200 -bg red
 place .one.f1 -x 200 -y 200
 update
 settle
-crossings
-# The frame covers 300,300..500,500 in .one, i.e. screen 300..500 --
-# the pointer at 350,350 is inside it, so mapping it must give an Enter.
+set c [crossings]
 note "  winfo containing 350 350 -> '[winfo containing 350 350]'"
-note "  crossings from mapping a frame under the pointer: [crossings]"
+note "  crossings from mapping a frame under the pointer: $c"
+ok {[lsearch -glob $c "Enter .one.f1 *"] >= 0} \
+    "a child mapped under the pointer gives an <Enter>"
 
 note ""
 note "--- 3. destroy the window under the pointer (event-9.1's shape) ---"

--- a/sys/src/external/tk/plan9/tkP9Draw.h
+++ b/sys/src/external/tk/plan9/tkP9Draw.h
@@ -119,6 +119,13 @@ void   tkp9_putpixels(void *dst, int x, int y, int w, int h,
 		      const unsigned char *rgba32);
 
 /*
+ * Read w*h pixels back out, as R,G,B,A bytes. 0 on success, -1 on
+ * failure. The inverse of tkp9_putpixels, and what XGetImage needs.
+ */
+int    tkp9_getpixels(void *src, int x, int y, int w, int h,
+		      unsigned char *rgba32);
+
+/*
  * Event file descriptors (callers select on these)
  */
 int    tkp9_mousefd(void);

--- a/sys/src/external/tk/plan9/tkPlan9Draw.c
+++ b/sys/src/external/tk/plan9/tkPlan9Draw.c
@@ -65,6 +65,36 @@ DrawableTarget(Drawable d, void **img, int *ox, int *oy)
     TkP9WindowOffset((Window)d, ox, oy);
 }
 
+/*
+ * An XImage here is 32 bits per pixel holding the visual's pixel value
+ * -- 0x00RRGGBB, per screen->root_visual's masks -- in the HOST's byte
+ * order, which is what XCreateImage below declares. Generic Tk reads a
+ * pixel with a plain 32-bit load and then decomposes it with those
+ * masks (tkCanvas.c's DrawCanvas does exactly that), so the only way to
+ * agree with it on both endiannesses is to go through a 32-bit access
+ * rather than naming bytes.
+ *
+ * These two used to store R,G,B,A in memory order, which contradicts
+ * the LSBFirst byte_order the same file declares: on a little-endian
+ * machine that puts blue where the red mask looks. Nothing had noticed
+ * because XPutImage and XGetImage were both stubs, so no pixel ever
+ * made the trip.
+ */
+static unsigned int *
+XImagePixel(XImage *image, int x, int y)
+{
+    return (unsigned int *)(image->data + (size_t)y * image->bytes_per_line
+                            + (size_t)x * 4);
+}
+
+static int
+HostByteOrder(void)
+{
+    unsigned int one = 1;
+
+    return (*(unsigned char *)&one) ? LSBFirst : MSBFirst;
+}
+
 /* ------------------------------------------------------------------ */
 /* Core drawing operations                                             */
 /* ------------------------------------------------------------------ */
@@ -361,9 +391,43 @@ XPutImage(Display *display, Drawable d, GC gc, XImage *image,
           int dest_x, int dest_y,
           unsigned int width, unsigned int height)
 {
-    (void)display; (void)d; (void)gc; (void)image;
-    (void)src_x; (void)src_y; (void)dest_x; (void)dest_y;
-    (void)width; (void)height;
+    void *img;
+    unsigned char *buf, *q;
+    unsigned int x, y, p;
+    int ox, oy;
+    (void)display; (void)gc;
+
+    if (image == NULL || image->data == NULL || width == 0 || height == 0)
+        return 0;
+    if (image->bits_per_pixel != 32)
+        return 0;			/* nothing here makes any other depth */
+
+    /* Clip the source rectangle to the image rather than reading past it. */
+    if (src_x < 0 || src_y < 0)
+        return 0;
+    if (src_x + (int)width > image->width)
+        width = (unsigned)(image->width - src_x);
+    if (src_y + (int)height > image->height)
+        height = (unsigned)(image->height - src_y);
+    if ((int)width <= 0 || (int)height <= 0)
+        return 0;
+
+    buf = (unsigned char *)ckalloc((size_t)width * height * 4);
+    for (y = 0; y < height; y++) {
+        for (x = 0; x < width; x++) {
+            p = *XImagePixel(image, src_x + (int)x, src_y + (int)y);
+            q = buf + ((size_t)y * width + x) * 4;
+            q[0] = (unsigned char)(p >> 16);	/* red_mask   0xFF0000 */
+            q[1] = (unsigned char)(p >>  8);	/* green_mask 0x00FF00 */
+            q[2] = (unsigned char)(p);		/* blue_mask  0x0000FF */
+            q[3] = 0xFF;
+        }
+    }
+
+    DrawableTarget(d, &img, &ox, &oy);
+    tkp9_putpixels(img, dest_x + ox, dest_y + oy,
+                   (int)width, (int)height, buf);
+    ckfree(buf);
     return 0;
 }
 
@@ -682,33 +746,21 @@ P9DestroyImage(XImage *image)
     return 0;
 }
 
+
 static unsigned long
 P9GetPixel(XImage *image, int x, int y)
 {
-    unsigned char *data;
-    int idx;
     if (!image || !image->data) return 0;
     if (x < 0 || y < 0 || x >= image->width || y >= image->height) return 0;
-    data = (unsigned char *)image->data;
-    idx  = y * image->bytes_per_line + x * 4;
-    return ((unsigned long)data[idx+0] << 16) |
-           ((unsigned long)data[idx+1] <<  8) |
-            (unsigned long)data[idx+2];
+    return *XImagePixel(image, x, y) & 0x00FFFFFFu;
 }
 
 static int
 P9PutPixel(XImage *image, int x, int y, unsigned long pixel)
 {
-    unsigned char *data;
-    int idx;
     if (!image || !image->data) return 0;
     if (x < 0 || y < 0 || x >= image->width || y >= image->height) return 0;
-    data = (unsigned char *)image->data;
-    idx  = y * image->bytes_per_line + x * 4;
-    data[idx+0] = (pixel >> 16) & 0xFF;
-    data[idx+1] = (pixel >>  8) & 0xFF;
-    data[idx+2] =  pixel        & 0xFF;
-    data[idx+3] = 0xFF;
+    *XImagePixel(image, x, y) = 0xFF000000u | (unsigned int)(pixel & 0x00FFFFFFu);
     return 0;
 }
 
@@ -764,14 +816,27 @@ XCreateImage(
     image->data           = data;
     image->bytes_per_line = bytes_per_line > 0 ? bytes_per_line : (int)width * 4;
     image->bits_per_pixel = 32;
-    image->byte_order     = LSBFirst;
+    /*
+     * The pixel is stored as a host-order 32-bit word (see
+     * XImagePixel), so say so rather than hardcoding LSBFirst: this
+     * tree builds for big-endian architectures too, and generic Tk
+     * byte-swaps when byte_order disagrees with the host.
+     */
+    image->byte_order     = HostByteOrder();
     image->bitmap_unit    = 32;
-    image->bitmap_bit_order = LSBFirst;
+    image->bitmap_bit_order = image->byte_order;
     image->bitmap_pad     = 32;
     _XInitImageFuncPtrs(image);
     return image;
 }
 
+/*
+ * Read a rectangle of a drawable back as an XImage. "canvas image"
+ * renders the canvas into a pixmap and then has to get the pixels out
+ * of it -- tkCanvas.c's comment calls this "the only way to get Pixmap
+ * image data out of an image" -- so a stub returning NULL is
+ * canvas-23.* failing with "failed to copy Pixmap to XImage".
+ */
 XImage *
 XGetImage(
     Display *display,
@@ -782,9 +847,44 @@ XGetImage(
     unsigned long plane_mask,
     int format)
 {
-    (void)display; (void)d; (void)x; (void)y;
-    (void)width; (void)height; (void)plane_mask; (void)format;
-    return NULL;
+    XImage *image;
+    unsigned char *buf, *q;
+    char *data;
+    void *img;
+    int ox, oy;
+    unsigned int ix, iy;
+    (void)plane_mask;
+
+    if (format != ZPixmap || width == 0 || height == 0)
+        return NULL;
+
+    buf = (unsigned char *)ckalloc((size_t)width * height * 4);
+    DrawableTarget(d, &img, &ox, &oy);
+    if (tkp9_getpixels(img, x + ox, y + oy, (int)width, (int)height, buf) < 0) {
+        ckfree(buf);
+        return NULL;
+    }
+
+    data = (char *)ckalloc((size_t)width * height * 4);
+    image = XCreateImage(display, NULL, 32, ZPixmap, 0, data,
+                         width, height, 32, (int)width * 4);
+    if (image == NULL) {
+        ckfree(buf);
+        ckfree(data);
+        return NULL;
+    }
+
+    for (iy = 0; iy < height; iy++) {
+        for (ix = 0; ix < width; ix++) {
+            q = buf + ((size_t)iy * width + ix) * 4;
+            *XImagePixel(image, (int)ix, (int)iy) =
+                0xFF000000u | ((unsigned int)q[0] << 16)
+                            | ((unsigned int)q[1] <<  8)
+                            |  (unsigned int)q[2];
+        }
+    }
+    ckfree(buf);
+    return image;
 }
 
 /* Region operations — minimal implementations */

--- a/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
+++ b/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
@@ -180,6 +180,60 @@ dstrect(Image *d, int x, int y, int w, int h)
 }
 
 /* ------------------------------------------------------------------ */
+/* Pixel byte order                                                    */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Which byte of an RGBA32 pixel holds which component, in memory order.
+ *
+ * Plan 9 names a channel from the most significant bits of the pixel
+ * downwards and stores the pixel little-endian, which makes RGBA32
+ * A,B,G,R in memory. That is the documented answer and it is used as
+ * the fallback -- but it is not assumed, because **getting it wrong is
+ * invisible in a round trip**: tkp9_putpixels and tkp9_getpixels would
+ * permute and unpermute by the same amount and cancel out. The error
+ * would surface only where these bytes meet Tk's XImage layout, as red
+ * and blue exchanged in every photo image, which is a long way from
+ * here.
+ *
+ * So ask rather than assume, once: fill a pixel with four components
+ * that are all different and see where each one lands. The colour
+ * argument to allocimage is 0xRRGGBBAA, which is documented and stable,
+ * and an alpha of 0xFF makes premultiplication the identity so the
+ * values arrive unchanged.
+ */
+static int rgbaidx[4] = { -1, -1, -1, -1 };	/* memory index of R,G,B,A */
+
+static void
+rgbacalibrate(void)
+{
+    Image *img;
+    uchar buf[4];
+    int i;
+
+    if(rgbaidx[0] >= 0)
+        return;
+    rgbaidx[0] = 3; rgbaidx[1] = 2; rgbaidx[2] = 1; rgbaidx[3] = 0;
+    if(display == nil)
+        return;
+    img = allocimage(display, Rect(0, 0, 1, 1), RGBA32, 1, 0x4080C0FF);
+    if(img == nil)
+        return;
+    if(unloadimage(img, img->r, buf, sizeof buf) == sizeof buf)
+        for(i = 0; i < 4; i++)
+            switch(buf[i]){
+            case 0x40: rgbaidx[0] = i; break;
+            case 0x80: rgbaidx[1] = i; break;
+            case 0xC0: rgbaidx[2] = i; break;
+            case 0xFF: rgbaidx[3] = i; break;
+            }
+    freeimage(img);
+    if(tkp9_debug())
+        fprint(2, "tkp9: RGBA32 memory order R=%d G=%d B=%d A=%d\n",
+            rgbaidx[0], rgbaidx[1], rgbaidx[2], rgbaidx[3]);
+}
+
+/* ------------------------------------------------------------------ */
 /* Off-screen drawables                                                */
 /* ------------------------------------------------------------------ */
 
@@ -542,12 +596,71 @@ tkp9_putpixels(void *dst, int x, int y, int w, int h,
                const unsigned char *rgba32)
 {
     Image *d = dstimage(dst), *img;
+    uchar *p;
+    int i, n;
+
     if(!d || !rgba32 || w <= 0 || h <= 0) return;
+    rgbacalibrate();
+    n = w * h;
+    if((p = malloc(n * 4)) == nil)
+        return;
+    for(i = 0; i < n; i++){
+        p[i*4 + rgbaidx[0]] = rgba32[i*4 + 0];
+        p[i*4 + rgbaidx[1]] = rgba32[i*4 + 1];
+        p[i*4 + rgbaidx[2]] = rgba32[i*4 + 2];
+        p[i*4 + rgbaidx[3]] = rgba32[i*4 + 3];
+    }
     img = allocimage(display, Rect(0, 0, w, h), RGBA32, 0, DTransparent);
-    if(!img) return;
-    loadimage(img, img->r, (uchar*)rgba32, w * h * 4);
-    draw(d, dstrect(d, x, y, w, h), img, nil, img->r.min);
+    if(img != nil){
+        loadimage(img, img->r, p, n * 4);
+        draw(d, dstrect(d, x, y, w, h), img, nil, img->r.min);
+        freeimage(img);
+    }
+    free(p);
+}
+
+/*
+ * Read w*h pixels back out of a drawable, as R,G,B,A bytes. The inverse
+ * of tkp9_putpixels, and the thing XGetImage needs: "canvas image"
+ * renders into a pixmap and then has to get the pixels out of it, which
+ * is the only way Tk can copy a drawable into a photo.
+ *
+ * The source is drawn into an RGBA32 temporary first rather than being
+ * unloaded directly, because a pixmap is allocated in the screen's own
+ * channel (tkp9_allocimage) and that varies by machine; draw() does the
+ * conversion for us and unloadimage then has one format to deal with.
+ */
+int
+tkp9_getpixels(void *src, int x, int y, int w, int h, unsigned char *rgba32)
+{
+    Image *s = dstimage(src), *img;
+    uchar *p;
+    int i, n, ok;
+
+    if(!s || !rgba32 || w <= 0 || h <= 0) return -1;
+    rgbacalibrate();
+    n = w * h;
+    img = allocimage(display, Rect(0, 0, w, h), RGBA32, 0, DTransparent);
+    if(img == nil)
+        return -1;
+    draw(img, img->r, s, nil, dstrect(s, x, y, w, h).min);
+    if((p = malloc(n * 4)) == nil){
+        freeimage(img);
+        return -1;
+    }
+    ok = unloadimage(img, img->r, p, n * 4) == n * 4;
     freeimage(img);
+    if(ok)
+        for(i = 0; i < n; i++){
+            rgba32[i*4 + 0] = p[i*4 + rgbaidx[0]];
+            rgba32[i*4 + 1] = p[i*4 + rgbaidx[1]];
+            rgba32[i*4 + 2] = p[i*4 + rgbaidx[2]];
+            rgba32[i*4 + 3] = p[i*4 + rgbaidx[3]];
+        }
+    free(p);
+    if(tkp9_debug() && !ok)
+        fprint(2, "tkp9_getpixels: unloadimage %dx%d failed: %r\n", w, h);
+    return ok ? 0 : -1;
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Section 2 called "crossings" (which clears the log) and then printed "[crossings]", so it reported the buffer it had just emptied. It came out blank, which reads exactly like a missing crossing -- the thing the script exists to detect -- when the other three sections had just shown the machinery working. Cleared before the frame is mapped now, and the result is asserted rather than only printed.

With Tk_GetRootCoords fixed the whole script passes:

  .one: rootx,rooty 100,100 size 300x300 mapped 1
  pointer now at 350 350; winfo containing -> '.one'
  crossings: {Enter .one NotifyAncestor}
  crossings after destroying .two:
      {Enter .one NotifyVirtual} {Enter .one.f1 NotifyAncestor}

so the hit test agrees with the warp at every level and the detail fields are the ones event-9.* checks. Recorded in the header, since the point of the file is the trail from symptom to cause.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs