### PR TITLE
tk/plan9: a rectangle of zero width still has an outline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1874,9 +1874,57 @@ allocated in the *screen's* channel (`tkp9_allocimage`), which varies by
 machine, and `draw()` does that conversion for us.
 
 **A round-trip test cannot check this.** The absolute colour is what
-matters, which is exactly what `canvas-23.1` does -- it fills with
-`#000080` and reads the pixels back -- so a red/blue swap shows up
-there as `#800000`.
+matters, so `sys/lib/tests/tk-image-test.tcl` only *reads*: it draws
+each of red, green, blue, navy, maroon and grey with the ordinary
+drawing path and asks what comes back.
+
+**The calibration works, and the first diagnosis from these tests was
+wrong.** With the path implemented, `canvas-23.2` passed and `23.1` and
+`23.3` did not, and the three differ only in colour -- blue, green, red
+-- with green the middle byte and `#c0c0c0` grey, both invariant under
+exchanging red and blue. That is a very convincing red/blue swap, and it
+is not what was happening: every colour makes the trip exactly, and
+`$TKP9DEBUG` reports
+
+```
+tkp9: RGBA32 memory order R=3 G=2 B=1 A=0
+```
+
+which is A,B,G,R, the documented order, measured correctly.
+
+### Tk on Plan 9: a rectangle of zero width still has an outline
+
+What actually separated those three canvas tests was not their colour
+but their **shape**:
+
+```
+23.1  .c create rectangle 0 0 0 9    zero width     FAIL
+23.2  .c create rectangle 0 0 1 9    width 1        pass
+23.3  .c create rectangle 0 0 9 0    zero height    FAIL
+```
+
+**A rectangle with zero width or height is not empty to X.** The outline
+is a closed path through the four corners, so it degenerates to a
+*line*, and that is how the canvas asks for a one-pixel column or row.
+`tkp9_drawrect` handed it to Plan 9's `border()`, which draws nothing
+for the empty rectangle `dstrect()` makes of it, so those columns came
+back as bare background -- which reads exactly like a colour bug when
+the three tests you are comparing use three different colours.
+
+Note X's outline runs corner to corner **inclusive**, covering `w+1` by
+`h+1` pixels: `canvas-23.3` asks for a rectangle nine wide and expects
+its row to span all ten columns. The degenerate case therefore draws one
+pixel longer than the width or height it was given.
+
+The non-degenerate case keeps `border()`, which draws *inside* a `w` by
+`h` box and so is one pixel short of X in both directions. That is a
+real difference and it is deliberately left alone: no failing test shows
+it, and it is the path every widget border in the toolkit draws through.
+
+**Still open:** a photo drawn onto a canvas reads back as the canvas
+background, so nothing of it renders, even though a photo now draws on
+screen. That is `XPutImage` or the path from the photo instance to it,
+and section 3 of `tk-image-test.tcl` is the case.
 
 ### Syntax-check Tk's Plan 9 backend on the host before shipping it
 

--- a/sys/lib/tests/tk-image-test.tcl
+++ b/sys/lib/tests/tk-image-test.tcl
@@ -8,37 +8,43 @@
 # with "failed to copy Pixmap to XImage") and no photo image drew at
 # all, since TkPutImage is how Tk paints one.
 #
-# With them implemented, canvas-23.2 passes and 23.1 and 23.3 do not --
-# and the three differ only in colour:
+# With them implemented, canvas-23.2 passes and 23.1 and 23.3 do not.
+# The first guess was a red/blue swap, because the three differ only in
+# colour -- 23.1 blue, 23.2 green, 23.3 red -- and green is the middle
+# byte, invariant under exchanging the other two.
 #
-#	23.1  #000080   blue    FAIL
-#	23.2  #008000   green   pass
-#	23.3  #800000   red     FAIL
+# THAT WAS WRONG, and section 1 is what refuted it: every colour makes
+# the trip exactly, red and blue included, and under $TKP9DEBUG the
+# port reports
 #
-# Green is the middle byte and #c0c0c0 is grey, so both are invariant
-# under exchanging red and blue. That is the whole diagnosis: something
-# on the way out swaps them.
+#	tkp9: RGBA32 memory order R=3 G=2 B=1 A=0
 #
-# The chain is short and only one link is uncertain:
+# which is A,B,G,R -- the documented order, measured correctly by
+# rgbacalibrate(). The byte order was never wrong.
 #
-#   .c create rectangle -fill  ->  GCForegroundRGBA -> tkp9_fillrect
-#       every widget in the toolkit has drawn through this for months,
-#       so it is not the suspect
-#   .c image                   ->  XGetImage -> tkp9_getpixels
-#       draws the source into an RGBA32 image and unloadimages it,
-#       permuting bytes by rgbaidx[], which rgbacalibrate() measures
-#   testimage data             ->  tkCanvas.c, which reads a host-order
-#       32-bit word and decomposes it with the visual's masks. Neither
-#       _WIN32 nor TK_XGETIMAGE_USES_ABGR32 is defined here, so this
-#       end is unconditional and matches what XGetImage packs.
+# Section 2 has the real answer, and it is not a colour at all: the
+# filled column reads back as the BACKGROUND. The rectangle is not
+# drawn. What separates the three tests is not their colour but their
+# shape:
 #
-# So this script prints the colours that come back, and under
-# $TKP9DEBUG the port prints the RGBA32 memory order it measured:
+#	23.1  rectangle 0 0 0 9   zero width    FAIL
+#	23.2  rectangle 0 0 1 9   width 1       pass
+#	23.3  rectangle 0 0 9 0   zero height   FAIL
+#
+# A rectangle with zero width or height is not empty to X: the outline
+# is a closed path through the four corners, so it degenerates to a
+# line, and that is how the canvas asks for a one-pixel column or row.
+# tkp9_drawrect handed it to Plan 9's border(), which draws nothing for
+# an empty rectangle.
+#
+# Section 3 is still open: a photo drawn onto the canvas reads back as
+# the canvas background, so nothing of it rendered, even though a photo
+# does now draw on screen. That is XPutImage or the path from the photo
+# instance to it, and it is a separate question from the rectangle.
+#
+# Run with $TKP9DEBUG to see the measured order:
 #
 #	tkp9: RGBA32 memory order R=? G=? B=? A=?
-#
-# Between the two, one run says whether rgbacalibrate() is wrong, never
-# ran, or is right and the fault is elsewhere. Run it BOTH ways.
 
 set fail 0
 
@@ -107,9 +113,10 @@ note "  put #123456 as a photo, read back $got"
 ok {$got eq "#123456"} "a photo round-trips through put and get"
 
 note ""
-note "If section 1 shows red and blue exchanged while green is right,"
-note "rgbacalibrate() has the RGBA32 memory order wrong. Run again with"
-note "TKP9DEBUG=1 to see the order it measured."
+note "Section 1 passing means the byte order is right -- that was the"
+note "first guess and it was wrong. Section 2 is the one that matters:"
+note "a rectangle of zero width or height must still draw its outline,"
+note "because X draws the outline as a path through the corners."
 
 puts "$fail failure(s)"
 flush stdout

--- a/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
+++ b/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
@@ -292,10 +292,34 @@ tkp9_drawrect(void *dst, int x, int y, int w, int h, int bw,
               unsigned long rgba)
 {
     Image *d = dstimage(dst), *src;
+
     if(!d || bw < 1) return;
     src = colorimage(rgba);
     if(!src) return;
-    border(d, dstrect(d, x, y, w, h), bw, src, ZP);
+    /*
+     * A rectangle with zero width or height is NOT empty to X. The
+     * outline is a closed path through the four corners, so it
+     * degenerates to a line -- and Tk's canvas relies on that:
+     *
+     *	.c create rectangle 0 0 0 9	a one-pixel column
+     *	.c create rectangle 0 0 9 0	a one-pixel row
+     *
+     * are canvas-23.1 and canvas-23.3. Plan 9's border() takes the
+     * empty rectangle dstrect() makes of those and draws nothing, so
+     * they came out as bare background. canvas-23.2 is the same test
+     * with width 1 and it passed throughout, which is what pinned this
+     * to the degenerate case rather than to colour or to the image path.
+     *
+     * X's outline runs corner to corner inclusive, covering w+1 by h+1
+     * pixels, so the line is one longer than the width or height asked
+     * for -- which is what makes canvas-23.3's row span all ten columns
+     * of a rectangle nine wide.
+     */
+    if(w <= 0 || h <= 0)
+        draw(d, dstrect(d, x, y, w > 0? w + 1: bw, h > 0? h + 1: bw),
+             src, nil, ZP);
+    else
+        border(d, dstrect(d, x, y, w, h), bw, src, ZP);
     freeimage(src);
 }
 


### PR DESCRIPTION
My red/blue diagnosis was wrong, and the test written to check it is what refuted it. Every colour makes the trip exactly -- red, green, blue, navy, maroon, grey -- and $TKP9DEBUG reports

  tkp9: RGBA32 memory order R=3 G=2 B=1 A=0

which is A,B,G,R, the documented order, measured correctly by rgbacalibrate(). The byte order was never wrong.

What separated canvas-23.1/23.3 from 23.2 was not colour but shape:

  23.1  create rectangle 0 0 0 9   zero width    FAIL
  23.2  create rectangle 0 0 1 9   width 1       pass
  23.3  create rectangle 0 0 9 0   zero height   FAIL

A rectangle with zero width or height is not empty to X: the outline is a closed path through the four corners, so it degenerates to a line, and that is how a canvas asks for a one-pixel column or row. tkp9_drawrect handed it to Plan 9's border(), which draws nothing for the empty rectangle dstrect() makes of it, so the column came back as bare background -- which reads exactly like a colour bug when the three tests being compared use three different colours. That is the whole reason the wrong guess was so plausible.

X's outline runs corner to corner inclusive, covering w+1 by h+1 pixels, so the degenerate line is one longer than the extent asked for: canvas-23.3 wants a rectangle nine wide to span all ten columns.

The non-degenerate case keeps border(), which draws inside a w by h box and is therefore one pixel short of X in both directions. Left alone deliberately: no failing test shows it, and it is the path every widget border in the toolkit draws through.

Still open, and now stated as such: a photo drawn onto a canvas reads back as the canvas background, so nothing of it renders, even though a photo does draw on screen. Section 3 of tk-image-test.tcl is the case.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs