### PR TITLE
tk/plan9: XDrawRectangle covers w+1 by h+1 pixels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1892,34 +1892,43 @@ tkp9: RGBA32 memory order R=3 G=2 B=1 A=0
 
 which is A,B,G,R, the documented order, measured correctly.
 
-### Tk on Plan 9: a rectangle of zero width still has an outline
+### Tk on Plan 9: XDrawRectangle covers w+1 by h+1 pixels
 
-What actually separated those three canvas tests was not their colour
-but their **shape**:
+**X's rectangle outline is a five-point path through the corners** --
+`(x,y) (x+w,y) (x+w,y+h) (x,y+h) (x,y)` -- so it covers **w+1 by h+1**
+pixels, one more than the width and height it is given. Plan 9's
+`border()` draws *inside* the rectangle handed to it, so `tkp9_drawrect`
+has to widen by one in each direction to mean the same thing.
+`XFillRectangle` is **not** like this: a fill really is `w` by `h`, and
+`tkp9_fillrect` is right as it stands.
 
+That extra pixel is not a rounding detail, it is load-bearing, and
+`canvas-23.1` is the proof:
+
+```tcl
+.c create rectangle 0 0 0 9 -fill #000080 -outline #000080
 ```
-23.1  .c create rectangle 0 0 0 9    zero width     FAIL
-23.2  .c create rectangle 0 0 1 9    width 1        pass
-23.3  .c create rectangle 0 0 9 0    zero height    FAIL
-```
 
-**A rectangle with zero width or height is not empty to X.** The outline
-is a closed path through the four corners, so it degenerates to a
-*line*, and that is how the canvas asks for a one-pixel column or row.
-`tkp9_drawrect` handed it to Plan 9's `border()`, which draws nothing
-for the empty rectangle `dstrect()` makes of it, so those columns came
-back as bare background -- which reads exactly like a colour bug when
-the three tests you are comparing use three different colours.
+`tkRectOval.c`'s `DisplayRectOval` **already widens a degenerate box
+itself** -- for `x2 == x1` at a coordinate of 0 it does `x1 -= 1` -- so
+what arrives at the platform is one pixel wide starting at **-1**. The
+fill covers only column -1, off the canvas; column 0 is painted by the
+outline's extra pixel and by nothing else. Drawing the outline one short
+lost the whole column.
 
-Note X's outline runs corner to corner **inclusive**, covering `w+1` by
-`h+1` pixels: `canvas-23.3` asks for a rectangle nine wide and expects
-its row to span all ten columns. The degenerate case therefore draws one
-pixel longer than the width or height it was given.
+**This was diagnosed wrong twice, and both wrong answers were
+plausible.** First as a red/blue swap, because 23.1/23.2/23.3 differ in
+colour (blue, green, red) and green is the invariant middle byte --
+refuted by `tk-image-test.tcl` section 1, where every colour makes the
+trip exactly. Then as a *zero-width* rectangle reaching X, which is
+wrong because Tk normalises that before the platform ever sees it; the
+special case written for it was dead code. The lesson both times: the
+tests differed in three ways at once (colour, width, height), and only
+the third mattered.
 
-The non-degenerate case keeps `border()`, which draws *inside* a `w` by
-`h` box and so is one pixel short of X in both directions. That is a
-real difference and it is deliberately left alone: no failing test shows
-it, and it is the path every widget border in the toolkit draws through.
+`canvas-23.2` passes throughout because its rectangle is `0 0 1 9` --
+genuinely one wide, so the *fill* covers column 0 and nothing depends on
+the outline.
 
 **Still open:** a photo drawn onto a canvas reads back as the canvas
 background, so nothing of it renders, even though a photo now draws on

--- a/sys/lib/tests/tk-image-test.tcl
+++ b/sys/lib/tests/tk-image-test.tcl
@@ -31,11 +31,19 @@
 #	23.2  rectangle 0 0 1 9   width 1       pass
 #	23.3  rectangle 0 0 9 0   zero height   FAIL
 #
-# A rectangle with zero width or height is not empty to X: the outline
-# is a closed path through the four corners, so it degenerates to a
-# line, and that is how the canvas asks for a one-pixel column or row.
-# tkp9_drawrect handed it to Plan 9's border(), which draws nothing for
-# an empty rectangle.
+# The SECOND wrong guess was that a zero-width rectangle reaches the
+# platform and has to be drawn as a line. It does not: tkRectOval.c
+# widens a degenerate box itself, "x1 -= 1" here, so what arrives is one
+# pixel wide starting at -1.
+#
+# The answer is X's outline convention. XDrawRectangle draws a
+# five-point path through the corners, so it covers w+1 by h+1 pixels --
+# and for this item the fill lands on column -1, off the canvas, while
+# column 0 is painted by that extra outline pixel and by nothing else.
+# Plan 9's border() draws inside the rectangle it is given, one short.
+#
+# Three differences between these tests (colour, width, height) and only
+# the third mattered. Both wrong guesses fitted the evidence.
 #
 # Section 3 is still open: a photo drawn onto the canvas reads back as
 # the canvas background, so nothing of it rendered, even though a photo
@@ -115,8 +123,9 @@ ok {$got eq "#123456"} "a photo round-trips through put and get"
 note ""
 note "Section 1 passing means the byte order is right -- that was the"
 note "first guess and it was wrong. Section 2 is the one that matters:"
-note "a rectangle of zero width or height must still draw its outline,"
-note "because X draws the outline as a path through the corners."
+note "XDrawRectangle covers w+1 by h+1 pixels, because X draws the"
+note "outline as a five-point path through the corners, and column 0"
+note "here is painted by that extra pixel and by nothing else."
 
 puts "$fail failure(s)"
 flush stdout

--- a/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
+++ b/sys/src/external/tk/plan9/tkPlan9DrawImpl.c
@@ -297,29 +297,29 @@ tkp9_drawrect(void *dst, int x, int y, int w, int h, int bw,
     src = colorimage(rgba);
     if(!src) return;
     /*
-     * A rectangle with zero width or height is NOT empty to X. The
-     * outline is a closed path through the four corners, so it
-     * degenerates to a line -- and Tk's canvas relies on that:
+     * X's rectangle outline is a five-point path through the corners --
+     * (x,y) (x+w,y) (x+w,y+h) (x,y+h) (x,y) -- so it covers **w+1 by
+     * h+1 pixels**, one more than the width and height it was given.
+     * Plan 9's border() draws inside the rectangle it is handed, so it
+     * has to be widened by one in each direction to mean the same
+     * thing. Note XFillRectangle is not like this: a fill really is w
+     * by h, and tkp9_fillrect is right as it stands.
      *
-     *	.c create rectangle 0 0 0 9	a one-pixel column
-     *	.c create rectangle 0 0 9 0	a one-pixel row
+     * That extra pixel is not a rounding detail, it is load-bearing.
+     * canvas-23.1 is
      *
-     * are canvas-23.1 and canvas-23.3. Plan 9's border() takes the
-     * empty rectangle dstrect() makes of those and draws nothing, so
-     * they came out as bare background. canvas-23.2 is the same test
-     * with width 1 and it passed throughout, which is what pinned this
-     * to the degenerate case rather than to colour or to the image path.
+     *	.c create rectangle 0 0 0 9 -fill #000080 -outline #000080
      *
-     * X's outline runs corner to corner inclusive, covering w+1 by h+1
-     * pixels, so the line is one longer than the width or height asked
-     * for -- which is what makes canvas-23.3's row span all ten columns
-     * of a rectangle nine wide.
+     * and tkRectOval.c's DisplayRectOval already widens a degenerate
+     * box itself -- for x2 == x1 with a coordinate of 0 it does
+     * "x1 -= 1" -- so what arrives here is one pixel wide starting at
+     * -1. The fill covers only column -1, off the canvas; column 0 is
+     * painted by the outline's extra pixel and by nothing else. Drawing
+     * the outline one short therefore lost the whole column, which read
+     * back as bare background and looked for all the world like a
+     * colour bug, since 23.1, 23.2 and 23.3 differ in colour too.
      */
-    if(w <= 0 || h <= 0)
-        draw(d, dstrect(d, x, y, w > 0? w + 1: bw, h > 0? h + 1: bw),
-             src, nil, ZP);
-    else
-        border(d, dstrect(d, x, y, w, h), bw, src, ZP);
+    border(d, dstrect(d, x, y, w + 1, h + 1), bw, src, ZP);
     freeimage(src);
 }
 


### PR DESCRIPTION
The second wrong diagnosis of canvas-23.1, and this time the fix for it was dead code. A zero-width rectangle never reaches the platform: tkRectOval.c's DisplayRectOval widens a degenerate box itself, and for x2 == x1 at coordinate 0 it does "x1 -= 1", so what arrives is one pixel wide starting at -1.

The real difference is X's outline convention. XDrawRectangle draws a five-point path through the corners -- (x,y) (x+w,y) (x+w,y+h) (x,y+h) (x,y) -- so it covers w+1 by h+1 pixels, one more than the extent it was given. Plan 9's border() draws inside the rectangle handed to it, so tkp9_drawrect has to widen by one in each direction. XFillRectangle is not like this and tkp9_fillrect is right as it stands.

That pixel is load-bearing. For

  .c create rectangle 0 0 0 9 -fill #000080 -outline #000080

the fill lands on column -1, off the canvas; column 0 is painted by the outline's extra pixel and by nothing else, so drawing the outline one short lost the whole column. canvas-23.2 passes throughout because its rectangle is genuinely one wide and its fill covers column 0 without help from the outline.

I set this exact off-by-one aside last commit on the grounds that no failing test showed it. canvas-23.1 and canvas-23.3 were showing it.

Both wrong answers fitted the evidence, which is worth recording: the three tests differ in colour AND width AND height, and only the third mattered. First guess was a red/blue swap (the colours are blue, green, red and green is the invariant middle byte), refuted by section 1 of tk-image-test.tcl where every colour makes the trip exactly. Second was a zero-width rectangle reaching X, refuted by reading DisplayRectOval.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs