### PR TITLE
tk/plan9: trace XPutImage and XCopyArea; split section 3 three ways

### DIFF
--- a/sys/lib/tests/tk-image-test.tcl
+++ b/sys/lib/tests/tk-image-test.tcl
@@ -106,19 +106,34 @@ ok {$right eq "#c0c0c0"} "the background reads back #c0c0c0"
 
 note ""
 note "--- 3. a photo drawn INTO the canvas, i.e. XPutImage ---"
-# The other direction: put a known photo on the canvas and read it back.
-# This is a round trip through both halves, so it passes even if both
-# are wrong by the same permutation -- which is exactly why section 1
-# and 2 above, which only read, are the ones that decide.
+# The other direction. Three things have to be true and they fail
+# differently, so ask them separately rather than only looking at the
+# canvas at the end.
 image create photo src -width 4 -height 4
 src put #123456 -to 0 0 4 4
+
+# (a) does the photo itself hold the colour? If not, nothing below is
+# about drawing at all.
+note "  the photo's own data: [lindex [lindex [src data] 1] 1]"
+ok {[lindex [lindex [src data] 1] 1] eq "#123456"} "the photo holds #123456"
+
+# (b) can one photo be copied to another? That is pure Tk, no platform
+# drawing, and separates the photo machinery from this port.
+image create photo copyof -width 4 -height 4
+copyof copy src
+note "  after 'copyof copy src': [lindex [lindex [copyof data] 1] 1]"
+ok {[lindex [lindex [copyof data] 1] 1] eq "#123456"} "photo-to-photo copy works"
+
+# (c) the real question: onto a canvas, and back out again. This is
+# XPutImage into the instance pixmap, then XCopyArea from it into the
+# canvas, then XGetImage out of the canvas.
 .c delete all
-.c configure -background #ffffff
+.c configure -background #ffffff -scrollregion {0 0 9 9}
 .c create image 0 0 -anchor nw -image src
 update
 set got [pixelat 1 1]
-note "  put #123456 as a photo, read back $got"
-ok {$got eq "#123456"} "a photo round-trips through put and get"
+note "  drawn on a canvas and read back: $got"
+ok {$got eq "#123456"} "a photo drawn on a canvas reads back"
 
 note ""
 note "Section 1 passing means the byte order is right -- that was the"

--- a/sys/src/external/tk/plan9/tkPlan9Draw.c
+++ b/sys/src/external/tk/plan9/tkPlan9Draw.c
@@ -193,6 +193,14 @@ XCopyArea(Display *display, Drawable src, Drawable dst, GC gc,
 
     DrawableTarget(src, &simg, &sox, &soy);
     DrawableTarget(dst, &dimg, &dox, &doy);
+    if (tkp9_debug())
+        fprintf(stderr, "XCopyArea: %ux%u from %lu (%s) %d,%d+%d,%d"
+                " to %lu (%s) %d,%d+%d,%d\n",
+                w, h,
+                (unsigned long) src, simg? "pixmap": "screen",
+                src_x, src_y, sox, soy,
+                (unsigned long) dst, dimg? "pixmap": "screen",
+                dst_x, dst_y, dox, doy);
     tkp9_copyarea(simg, src_x + sox, src_y + soy,
                   (int)w, (int)h,
                   dimg, dst_x + dox, dst_y + doy);
@@ -425,6 +433,11 @@ XPutImage(Display *display, Drawable d, GC gc, XImage *image,
     }
 
     DrawableTarget(d, &img, &ox, &oy);
+    if (tkp9_debug())
+        fprintf(stderr, "XPutImage: %ux%u from (%d,%d) to drawable %lu"
+                " (%s) at %d,%d + offset %d,%d\n",
+                width, height, src_x, src_y, (unsigned long) d,
+                img? "pixmap": "screen", dest_x, dest_y, ox, oy);
     tkp9_putpixels(img, dest_x + ox, dest_y + oy,
                    (int)width, (int)height, buf);
     ckfree(buf);


### PR DESCRIPTION
The w+1/h+1 outline fix works: section 2 now reads #000080 in column 0, so canvas-23.1 and canvas-23.3 should go with it and canvas is clear. event-9.1 flipping between runs with nothing touching crossings confirms it as flaky rather than a regression, so the count is stable at 35 rather than 36.

Section 3 is the one left -- a photo drawn onto a canvas renders nothing -- and reading did not settle it. Everything on the Tk side checks out: TK_CAN_RENDER_RGBA is Mac-only so the path really is DitherInstance -> TkPutImage -> XPutImage into the instance pixmap and then XCopyArea out of it; Tk sets width, height and bytes_per_line on the XImage before calling, so the clipping in XPutImage is not eating it; and XCopyArea ignores the GC, so the clip region TkSetRegion installs cannot be losing it either.

So instrument instead of guessing further, which is what worked for the warp. Both entry points now report under $TKP9DEBUG, naming the drawable and whether it resolved to a pixmap or the screen -- the destination in this test is a pixmap, since ".c image" renders the canvas off-screen, and that is the one difference from the on-screen case that demonstrably works.

Section 3 also asks its three questions separately, because they fail differently: whether the photo holds the colour at all, whether photo-to-photo copy works (pure Tk, no platform drawing), and only then whether it survives a canvas. If the first two pass and the third does not, it is this port; if the first fails it was never about drawing.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs