### PR TITLE
tk/plan9: trace XPutImage on entry, not only on success

### DIFF
--- a/sys/src/external/tk/plan9/tkPlan9Draw.c
+++ b/sys/src/external/tk/plan9/tkPlan9Draw.c
@@ -405,20 +405,49 @@ XPutImage(Display *display, Drawable d, GC gc, XImage *image,
     int ox, oy;
     (void)display; (void)gc;
 
-    if (image == NULL || image->data == NULL || width == 0 || height == 0)
+    /*
+     * Trace on ENTRY and at every refusal, not just on the way out. An
+     * exit-only trace cannot tell "never called" from "called and bailed",
+     * which is exactly the question when a photo does not appear.
+     */
+    if (tkp9_debug())
+        fprintf(stderr, "XPutImage: image %p %dx%d bpp %d bpl %d,"
+                " src %d,%d %ux%u -> drawable %lu at %d,%d\n",
+                (void *) image,
+                image? image->width: 0, image? image->height: 0,
+                image? image->bits_per_pixel: 0,
+                image? image->bytes_per_line: 0,
+                src_x, src_y, width, height, (unsigned long) d,
+                dest_x, dest_y);
+
+    if (image == NULL || image->data == NULL || width == 0 || height == 0) {
+        if (tkp9_debug())
+            fprintf(stderr, "XPutImage: refused, no image or empty\n");
         return 0;
-    if (image->bits_per_pixel != 32)
-        return 0;			/* nothing here makes any other depth */
+    }
+    if (image->bits_per_pixel != 32) {
+        /* nothing here makes any other depth */
+        if (tkp9_debug())
+            fprintf(stderr, "XPutImage: refused, %d bits per pixel\n",
+                    image->bits_per_pixel);
+        return 0;
+    }
 
     /* Clip the source rectangle to the image rather than reading past it. */
-    if (src_x < 0 || src_y < 0)
+    if (src_x < 0 || src_y < 0) {
+        if (tkp9_debug())
+            fprintf(stderr, "XPutImage: refused, negative source\n");
         return 0;
+    }
     if (src_x + (int)width > image->width)
         width = (unsigned)(image->width - src_x);
     if (src_y + (int)height > image->height)
         height = (unsigned)(image->height - src_y);
-    if ((int)width <= 0 || (int)height <= 0)
+    if ((int)width <= 0 || (int)height <= 0) {
+        if (tkp9_debug())
+            fprintf(stderr, "XPutImage: refused, clipped to nothing\n");
         return 0;
+    }
 
     buf = (unsigned char *)ckalloc((size_t)width * height * 4);
     for (y = 0; y < height; y++) {
@@ -434,10 +463,10 @@ XPutImage(Display *display, Drawable d, GC gc, XImage *image,
 
     DrawableTarget(d, &img, &ox, &oy);
     if (tkp9_debug())
-        fprintf(stderr, "XPutImage: %ux%u from (%d,%d) to drawable %lu"
-                " (%s) at %d,%d + offset %d,%d\n",
-                width, height, src_x, src_y, (unsigned long) d,
-                img? "pixmap": "screen", dest_x, dest_y, ox, oy);
+        fprintf(stderr, "XPutImage: drawing %ux%u into %s at %d,%d"
+                " + offset %d,%d\n",
+                width, height, img? "pixmap": "screen",
+                dest_x, dest_y, ox, oy);
     tkp9_putpixels(img, dest_x + ox, dest_y + oy,
                    (int)width, (int)height, buf);
     ckfree(buf);
@@ -868,8 +897,15 @@ XGetImage(
     unsigned int ix, iy;
     (void)plane_mask;
 
-    if (format != ZPixmap || width == 0 || height == 0)
+    if (tkp9_debug())
+        fprintf(stderr, "XGetImage: %ux%u at %d,%d from drawable %lu\n",
+                width, height, x, y, (unsigned long) d);
+    if (format != ZPixmap || width == 0 || height == 0) {
+        if (tkp9_debug())
+            fprintf(stderr, "XGetImage: refused, format %d %ux%u\n",
+                    format, width, height);
         return NULL;
+    }
 
     buf = (unsigned char *)ckalloc((size_t)width * height * 4);
     DrawableTarget(d, &img, &ox, &oy);


### PR DESCRIPTION
The outline fix works -- section 2 reads #000080 now, so canvas-23.1 and canvas-23.3 should be clear.

Section 3 still fails and the trace narrows it a long way. The photo's instance pixmap IS copied into the canvas pixmap, at the right place:

  XCopyArea: 4x4 from 30 (pixmap) 0,0+0,0 to 32 (pixmap) 32,32+0,0

32,32 is OVERDRAW_PIXELS, i.e. canvas origin, and 30 is the instance pixmap. So the blit is right and the pixmap is simply empty. Line 1984 of tkImgPhInstance.c is the only place anything writes pixels into it, and that is TkPutImage, which is XPutImage on this platform.

But no XPutImage line appears -- and that proves nothing, because I put the trace after all the early returns. "Never called" and "called and refused" look identical, which is the same flaw as the weak assertions earlier in this file: reporting only the success path.

So trace on entry and at every refusal, naming which one fired -- no image, wrong bits per pixel, negative source, clipped to nothing -- and give XGetImage the same treatment. One run now distinguishes DitherInstance never running from XPutImage turning the image away, and if it is the latter it says which guard and with what geometry.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs