### PR TITLE
tk/plan9: build the photo validRegion, or no photo is ever dithered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1930,10 +1930,43 @@ the third mattered.
 genuinely one wide, so the *fill* covers column 0 and nothing depends on
 the outline.
 
-**Still open:** a photo drawn onto a canvas reads back as the canvas
-background, so nothing of it renders, even though a photo now draws on
-screen. That is `XPutImage` or the path from the photo instance to it,
-and section 3 of `tk-image-test.tcl` is the case.
+### Tk on Plan 9: an empty validRegion means no photo is ever dithered
+
+A photo drawn onto a canvas read back as the canvas background --
+section 3 of `tk-image-test.tcl` -- and it was **not** `XPutImage`.
+Under `$TKP9DEBUG` the trace shows `XCopyArea: 4x4 from 30 (pixmap)` and
+**no `XPutImage` line at all**: the instance pixmap was copied
+faithfully and was empty.
+
+`TkPutImage` is reached from exactly one place, `TkImgDitherInstance`
+(`tkImgPhInstance.c:1983`), and that is gated on
+
+```c
+TkClipBox(modelPtr->validRegion, &validBox);
+if ((validBox.width > 0) && (validBox.height > 0))
+	TkImgDitherInstance(...);
+```
+
+`TkpBuildRegionFromAlphaData` is what fills that region, and it was an
+empty stub in `plan9/tkPlan9Stubs.c`. `Tk_PhotoPutBlock` calls it for any
+block with alpha, which is **every** photo -- `pix32` always carries an
+alpha byte -- so `validRegion` was empty for every photo ever created,
+the dither never ran, and the pixmap stayed blank. The same empty region
+is then set as the gc's clip mask for the `XCopyArea` that paints it, so
+it fails twice over.
+
+It is upstream's run-by-run loop now rather than a single bounding box:
+the region here is a bbox (`struct _XRegion`, same file), so the two
+agree today, but a real region implementation later needs no change.
+
+**The trace had to be on the entry of `XPutImage`.** An exit-side trace
+cannot tell *never called* from *called and turned the image away*, and
+those two want opposite fixes -- the first round of tracing here sat
+after the early returns and proved nothing.
+
+`XSubtractRegion` in that file is still deliberately approximate (it
+returns `sra`), which with a bbox region means a re-put with
+transparency does not shrink the valid area.
 
 ### Syntax-check Tk's Plan 9 backend on the host before shipping it
 

--- a/sys/lib/tests/tk-image-test.tcl
+++ b/sys/lib/tests/tk-image-test.tcl
@@ -45,10 +45,17 @@
 # Three differences between these tests (colour, width, height) and only
 # the third mattered. Both wrong guesses fitted the evidence.
 #
-# Section 3 is still open: a photo drawn onto the canvas reads back as
-# the canvas background, so nothing of it rendered, even though a photo
-# does now draw on screen. That is XPutImage or the path from the photo
-# instance to it, and it is a separate question from the rectangle.
+# Section 3 was a photo drawn onto the canvas reading back as the canvas
+# background, and it was NOT XPutImage: under $TKP9DEBUG, XPutImage was
+# never called at all. TkPutImage is reached from exactly one place --
+# TkImgDitherInstance -- and that is gated on the photo's validRegion
+# being non-empty. TkpBuildRegionFromAlphaData, which is what builds that
+# region, was an empty stub, so the region stayed empty, the dither never
+# ran, and the instance pixmap that XCopyArea then copied held nothing.
+#
+# Note the trace is what settled it, and it had to be on the ENTRY of
+# XPutImage: an exit-side trace cannot tell "never called" from "called
+# and turned the image away", and those want opposite fixes.
 #
 # Run with $TKP9DEBUG to see the measured order:
 #

--- a/sys/src/external/tk/plan9/tkPlan9Stubs.c
+++ b/sys/src/external/tk/plan9/tkPlan9Stubs.c
@@ -143,17 +143,70 @@ TkpCopyRegion(TkRegion dst, TkRegion src)
     if (dst && src) *(Region)dst = *(Region)src;
 }
 
+/*
+ * Mark the non-transparent pixels of a photo block as valid.
+ *
+ * This is not decorative and it must not be a stub. modelPtr->validRegion
+ * is how the photo code records which pixels it has, and Tk_PhotoPutBlock
+ * builds it HERE for any block with alpha -- which is every photo, since
+ * pix32 always carries an alpha byte. Leave the region empty and
+ * TkImgPhotoConfigureInstance's
+ *
+ *	TkClipBox(modelPtr->validRegion, &validBox);
+ *	if ((validBox.width > 0) && (validBox.height > 0))
+ *	    TkImgDitherInstance(...);
+ *
+ * never fires, so the instance pixmap is never written -- TkPutImage is
+ * reached from nowhere else -- and every photo drew as whatever was
+ * behind it. The same empty region is then set as the gc's clip mask for
+ * the XCopyArea that paints it, so it fails twice over.
+ *
+ * Silent, and it looks like a drawing bug: XPutImage was simply never
+ * called, which is what section 3 of sys/lib/tests/tk-image-test.tcl
+ * reports and what a $TKP9DEBUG trace on XPutImage's entry proves.
+ *
+ * Upstream's loop, kept run by run rather than collapsed to one bounding
+ * box: the region here is a bbox, so the two agree today, but a real
+ * region implementation later would need no change.
+ */
 void
 TkpBuildRegionFromAlphaData(Region region,
     unsigned x, unsigned y,
     unsigned width, unsigned height,
-    unsigned char *dataPtr,
+    unsigned char *dataPtr,	/* points at the alpha byte of (x, y) */
     unsigned pixelStride,
     unsigned lineStride)
 {
-    (void)region; (void)x; (void)y;
-    (void)width; (void)height; (void)dataPtr;
-    (void)pixelStride; (void)lineStride;
+    unsigned char *lineDataPtr;
+    unsigned x1, y1, end;
+    XRectangle rect;
+
+    if (region == NULL || dataPtr == NULL)
+	return;
+
+    for (y1 = 0; y1 < height; y1++) {
+	lineDataPtr = dataPtr;
+	for (x1 = 0; x1 < width; x1 = end) {
+	    /* Skip to the first non-transparent pixel of this run. */
+	    while (x1 < width && *lineDataPtr == 0) {
+		x1++;
+		lineDataPtr += pixelStride;
+	    }
+	    end = x1;
+	    while (end < width && *lineDataPtr != 0) {
+		end++;
+		lineDataPtr += pixelStride;
+	    }
+	    if (end > x1) {
+		rect.x      = (short)(x + x1);
+		rect.y      = (short)(y + y1);
+		rect.width  = (unsigned short)(end - x1);
+		rect.height = 1;
+		XUnionRectWithRegion(&rect, region, region);
+	    }
+	}
+	dataPtr += lineStride;
+    }
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
TkpBuildRegionFromAlphaData was an empty stub. Tk_PhotoPutBlock calls it for any block with alpha -- which is every photo, since pix32 always carries an alpha byte -- so modelPtr->validRegion stayed empty for every photo ever created.

TkImgPhotoConfigureInstance gates the dither on that region being non-empty, and TkImgDitherInstance is the only thing that ever calls TkPutImage, so the instance pixmap was never written: XCopyArea copied it faithfully and it held nothing. The same empty region is then used as the gc clip mask for that copy, so it fails twice over.

Under $TKP9DEBUG this shows as an XCopyArea from the instance pixmap with no XPutImage line anywhere -- which is why the trace had to be on XPutImage's entry: an exit-side trace cannot tell "never called" from "called and turned the image away".

Kept as upstream's run-by-run loop rather than one bounding box. The region here is a bbox, so the two agree today, but a real region implementation later needs no change.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs