### PR TITLE
tk/plan9: gridding, wm title, window-id parsing, unnamed keysyms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1724,10 +1724,10 @@ character put line breaks mid-word and in the wrong place for tabs
 
 ### Tk on Plan 9: what the remaining test failures are, and which are ours
 
-The suite is at **36 failing tests** (`wish all.tcl`; note `grep -c
-FAILED` counts two lines each, so 72 lines). Nine of those are known
-not to be the Plan 9 backend's, and are worth recording so they are not
-chased again:
+The suite is at **32 failing tests** (`wish all.tcl`; note `grep -c
+FAILED` counts two lines each, so 64 lines). **20 of the 32 are known
+not to be the Plan 9 backend's**, and are worth recording so they are
+not chased again:
 
 **The five remaining `event-9.*` are generic Tk.** The port's side is
 proved correct by `tk-enter-test.tcl`: the hit test agrees with the warp
@@ -1814,13 +1814,37 @@ was actually resolved is the contract (see the font section above), and
 `tk-font-test.tcl` asserts the real requirement -- that an unknown
 family does *not* come back as itself.
 
-**`imgListFormat-3.1/3.2/3.3` need `tktest`, not `wish`**:
-`invalid command name "testphotostringmatch"`, which `generic/tkTest.c`
-registers only in Tk's own test binary. A harness limitation, not a
-port bug.
+**`imgListFormat-3.1/3.2/3.3` and `image-6.2` need `tktest`, not
+`wish`**: `invalid command name "testphotostringmatch"`, and `image
+types` must list `test`, which `generic/tkTest.c` registers only in Tk's
+own test binary. A harness limitation, not a port bug.
 
-That is 16 of the 36 accounted for. `canvas-23.*` **is** ours and was
-the useful find in that sweep -- see the image section below.
+**`focus-1.19` needs two applications.** `focusClear` in `focus.test` is
+`childTkProcess eval {focus -force .}` -- it takes the focus away by
+giving it to *another* wish. rio owns the keyboard here and Tk is the
+only authority on focus within a process (see `TkP9FocusWindow` above),
+so a second wish cannot take this one's focus and `focus` stays `.t.b1`
+where the test wants `{}`. Not fixable without a cross-application focus
+protocol that Plan 9 does not have.
+
+**`imgPhoto-4.75` and `filebox-7.1-0` are the environment**, not Tk:
+the first needs `file copy` to a name beginning with `-` and reports
+ENOENT, the second needs a directory that cannot be read.
+
+`pkgconfig-1.1` wants the twelve `CFG_INSTALL_*`/`CFG_RUNTIME_*` keys,
+which the unix Makefile passes as `-D`s and `sys/src/ape/lib/tk/mkfile`
+does not. **Left undefined deliberately**: APExp has no install prefix
+to name -- it builds into the repo tree and overlays it with a union
+mount -- so every one of those paths would be a fabrication, and
+`tcl_findLibrary` is what actually locates the scripts at runtime.
+
+That is 20 of the 32 accounted for. The rest that are ours and still
+open: `frame-14.1` (a label 4 pixels too wide, so font measurement),
+`geometry-4.7` (one `<Configure>` too many from `Tk_MaintainGeometry`)
+and `event-9.11..13` alongside the two documented above.
+
+`canvas-23.*` **was** ours and is fixed -- see the image and rectangle
+sections below.
 
 ### Tk on Plan 9: the image path was a stub in both directions
 
@@ -1967,6 +1991,55 @@ after the early returns and proved nothing.
 `XSubtractRegion` in that file is still deliberately approximate (it
 returns `sra`), which with a bbox region means a re-put with
 transparency does not shrink the valid area.
+
+### Tk on Plan 9: four wm and keysym stubs that answered plausibly
+
+Four small ones, all of the same family as `XLoadFont` above -- a stub
+that returns a *plausible* answer rather than admitting it did nothing,
+so nothing upstream can tell.
+
+**`XKeysymToString` returned `""` for a keysym it could not name.**
+Xlib returns NULL, and every caller here tells the two apart:
+`tkBind.c`'s `%K` keeps its `"??"` default only while the name is NULL.
+So `event generate <Key> -keycode -1` substituted the empty string
+(`bind-13.14`). An empty *name* is not the same as *no name*.
+
+**`TkpScanWindowId` used `strtoul` and could not fail.** `toplevel .t
+-use xyz` therefore reached the container lookup with id 0 and reported
+`couldn't create child of window "xyz"` -- a believable message for the
+wrong reason, and one that equally describes a real id naming a window
+that has gone. It is `Tcl_GetWideIntFromObj` now, so a non-number gives
+the ordinary Tcl integer error (`embed-1.1`).
+
+**`wm title` was write-only.** rio owns the frame, so nothing displays a
+title -- but `wm title` is a *query* as well, and answering the empty
+string to a title the caller has just set is simply wrong.
+`fontchooser-2.0/2.1` identify the dialog they raised by reading it
+back. Stored in `WmInfo` now, defaulting to the toplevel's `nameUid` as
+Tk does on X.
+
+**`Tk_SetGrid`/`Tk_UnsetGrid` were empty, so `-setgrid 1` did nothing.**
+Gridding is not decoration: with it in force `wm geometry` speaks in
+**characters** rather than pixels, in both directions --
+
+```tcl
+listbox .l2 -font $fixed -width 30 -height 20 -setgrid 1
+wm geometry .           ;# must say 30x20, and said 190x308
+wm geometry . 26x15     ;# 26 characters, not 26 pixels
+```
+
+The convention is `tkUnixWm.c`'s and is the thing to remember: while
+`wmPtr->gridWin` is non-NULL, **`wmPtr->width`/`height` hold grid units,
+not pixels**. The conversion is confined to the three places a size
+crosses that boundary -- `WmUpdateGeometry` on the way out, and the `wm
+geometry` query and setter -- plus `Tk_SetGrid` itself, which must
+reinterpret a size that was set in pixels *before* gridding, or a
+`wm geometry` from earlier silently becomes a character count a few
+hundred times too large. `Tk_UnsetGrid` converts back.
+
+Note `wm minsize`/`maxsize` are also in grid units on X and are still
+clamped as pixels here; inert today, since the defaults are 1 and
+unlimited.
 
 ### Syntax-check Tk's Plan 9 backend on the host before shipping it
 

--- a/sys/src/external/tk/plan9/tkPlan9Event.c
+++ b/sys/src/external/tk/plan9/tkPlan9Event.c
@@ -520,7 +520,19 @@ XKeysymToString(KeySym keysym)
         buf[1] = '\0';
         return buf;
     }
-    return (char *)"";
+    /*
+     * NULL, not "". Xlib returns NULL for a keysym it cannot name, and
+     * every caller here tells the two apart: tkBind.c's %K substitution
+     * keeps its "??" default only while the name is NULL, and
+     * TkKeysymToString / Tk_GetUid pass the answer straight through.
+     * Returning an empty string says "this keysym is called nothing",
+     * which is not the same as "there is no such keysym" -- the same
+     * distinction XLoadFont got wrong in the other direction.
+     *
+     * bind-13.14 is the case: "event generate <Key> -keycode -1" must
+     * report %K as "??", and reported the empty string instead.
+     */
+    return NULL;
 }
 
 XModifierKeymap *

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -55,6 +55,16 @@ typedef struct TkWmInfo {
     int maxWidth, maxHeight;	/* 0 means unlimited. */
     int withdrawn;
     int flags;
+    char *title;		/* "wm title", or NULL for the default. */
+    /*
+     * Gridding, as tkUnixWm.c keeps it. When gridWin is non-NULL the
+     * width/height above are in GRID UNITS rather than pixels, and a
+     * grid unit is widthInc/heightInc pixels; reqGridWidth/Height is the
+     * grid size corresponding to the toplevel's own requested size.
+     */
+    TkWindow *gridWin;
+    int reqGridWidth, reqGridHeight;
+    int widthInc, heightInc;
     struct TkWmInfo *nextPtr;
 } WmInfo;
 
@@ -62,6 +72,10 @@ typedef struct TkWmInfo {
 #define WM_NEVER_MAPPED		2
 
 static void WmUpdateGeometry(void *clientData);
+static void WmGridToPixels(WmInfo *wmPtr, int gw, int gh,
+			   int *widthPtr, int *heightPtr);
+static void WmPixelsToGrid(WmInfo *wmPtr, int w, int h,
+			   int *gwPtr, int *ghPtr);
 MODULE_SCOPE void   TkP9EmbedGeometryRequest(TkWindow *winPtr, int w, int h);
 MODULE_SCOPE Window TkP9EmbedParent(TkWindow *winPtr);
 
@@ -116,10 +130,19 @@ WmUpdateGeometry(void *clientData)
 	return;
     }
 
-    width  = (wmPtr->width  >= 0) ? wmPtr->width
-				  : Tk_ReqWidth((Tk_Window) winPtr);
-    height = (wmPtr->height >= 0) ? wmPtr->height
-				  : Tk_ReqHeight((Tk_Window) winPtr);
+    /*
+     * An explicit size is in grid units while the toplevel is gridded
+     * ("-setgrid 1" on a listbox or a text widget), so convert here --
+     * this is the one place a size leaves wmPtr for the screen.
+     */
+    if (wmPtr->width >= 0 && wmPtr->height >= 0) {
+	WmGridToPixels(wmPtr, wmPtr->width, wmPtr->height, &width, &height);
+    } else {
+	width  = (wmPtr->width  >= 0) ? wmPtr->width
+				      : Tk_ReqWidth((Tk_Window) winPtr);
+	height = (wmPtr->height >= 0) ? wmPtr->height
+				      : Tk_ReqHeight((Tk_Window) winPtr);
+    }
 
     if (width  < wmPtr->minWidth)  width  = wmPtr->minWidth;
     if (height < wmPtr->minHeight) height = wmPtr->minHeight;
@@ -583,11 +606,29 @@ TkpUseWindow(Tcl_Interp *interp, Tk_Window tkwin, const char *string)
     return Tk_UseWindow(interp, tkwin, string);
 }
 
+/*
+ * Parse a window id, and *fail* on one that is not a number.
+ *
+ * strtoul answers 0 for "xyz" without complaint, so "toplevel .t -use
+ * xyz" reached the lookup below and came back "couldn't create child of
+ * window \"xyz\"" -- a plausible message for the wrong reason, and one
+ * that would equally describe a real id naming a window that has gone.
+ * tkUnixEmbed.c's version reports the ordinary Tcl integer error, which
+ * is what embed-1.1 asks for.
+ */
 int
 TkpScanWindowId(Tcl_Interp *interp, const char *string, Window *idPtr)
 {
-    (void)interp;
-    *idPtr = (Window)strtoul(string, NULL, 0);
+    Tcl_Obj *obj = Tcl_NewStringObj(string, TCL_INDEX_NONE);
+    Tcl_WideInt value;
+    int code;
+
+    Tcl_IncrRefCount(obj);
+    code = Tcl_GetWideIntFromObj(interp, obj, &value);
+    Tcl_DecrRefCount(obj);
+    if (code != TCL_OK)
+	return TCL_ERROR;
+    *idPtr = (Window) value;
     return TCL_OK;
 }
 
@@ -814,6 +855,8 @@ TkWmNewWindow(TkWindow *winPtr)
     wmPtr->height    = -1;
     wmPtr->minWidth  = 1;
     wmPtr->minHeight = 1;
+    wmPtr->widthInc  = 1;
+    wmPtr->heightInc = 1;
     wmPtr->flags     = WM_NEVER_MAPPED;
     wmPtr->nextPtr   = NULL;
     /*
@@ -894,6 +937,8 @@ TkWmDeadWindow(TkWindow *winPtr)
     WmUnlink(winPtr->dispPtr, wmPtr);
     if (wmPtr->flags & WM_UPDATE_PENDING)
 	Tcl_CancelIdleCall(WmUpdateGeometry, winPtr);
+    if (wmPtr->title != NULL)
+	ckfree(wmPtr->title);
     winPtr->wmInfoPtr = NULL;
     ckfree(wmPtr);
 }
@@ -982,18 +1027,159 @@ TkWmProtocolEventProc(TkWindow *winPtr, XEvent *eventPtr)
 /* Grid geometry hint (wm-level resize grid)                         */
 /* ------------------------------------------------------------------ */
 
+/*
+ * Both of these were empty stubs, so "-setgrid 1" on a listbox or a text
+ * widget did nothing at all. Gridding is not decoration: with it set,
+ * "wm geometry" speaks in CHARACTERS rather than pixels, in both
+ * directions, which is what listbox-4.7 checks --
+ *
+ *	listbox .l2 -font $fixed -width 30 -height 20 -setgrid 1
+ *	wm geometry .			;# must say 30x20, not 190x308
+ *	wm geometry . 26x15		;# 26 characters, not 26 pixels
+ *
+ * The convention is tkUnixWm.c's and is worth stating once: while
+ * gridWin is non-NULL, wmPtr->width and wmPtr->height hold GRID UNITS,
+ * and everything that touches them converts. Nothing else in this file
+ * needs to know, because the conversion is confined to the three places
+ * a size crosses that boundary -- WmUpdateGeometry on the way out to
+ * pixels, and the "wm geometry" query and setter.
+ */
+
+/*
+ * The pixel size may have moved even with an explicit "wm geometry" in
+ * force, since that size is now read in different units -- so ask for an
+ * update directly rather than through WmReqProc, which deliberately does
+ * nothing when the size is explicit.
+ */
+static void
+WmGridChanged(TkWindow *winPtr)
+{
+    WmInfo *wmPtr = winPtr->wmInfoPtr;
+
+    if (!(wmPtr->flags & (WM_UPDATE_PENDING|WM_NEVER_MAPPED))) {
+	Tcl_DoWhenIdle(WmUpdateGeometry, winPtr);
+	wmPtr->flags |= WM_UPDATE_PENDING;
+    }
+}
+
+/* Which toplevel does this window belong to? */
+static TkWindow *
+WmToplevelOf(TkWindow *winPtr)
+{
+    while (winPtr != NULL && !(winPtr->flags & TK_TOP_LEVEL))
+	winPtr = winPtr->parentPtr;
+    return winPtr;
+}
+
+/* Grid units -> pixels, for a size held in wmPtr->width/height. */
+static void
+WmGridToPixels(WmInfo *wmPtr, int gw, int gh, int *widthPtr, int *heightPtr)
+{
+    TkWindow *winPtr = wmPtr->winPtr;
+
+    if (wmPtr->gridWin == NULL) {
+	*widthPtr = gw;
+	*heightPtr = gh;
+	return;
+    }
+    *widthPtr  = Tk_ReqWidth((Tk_Window) winPtr)
+	    + (gw - wmPtr->reqGridWidth) * wmPtr->widthInc;
+    *heightPtr = Tk_ReqHeight((Tk_Window) winPtr)
+	    + (gh - wmPtr->reqGridHeight) * wmPtr->heightInc;
+}
+
+/* Pixels -> grid units. */
+static void
+WmPixelsToGrid(WmInfo *wmPtr, int w, int h, int *gwPtr, int *ghPtr)
+{
+    TkWindow *winPtr = wmPtr->winPtr;
+
+    if (wmPtr->gridWin == NULL) {
+	*gwPtr = w;
+	*ghPtr = h;
+	return;
+    }
+    *gwPtr = wmPtr->reqGridWidth
+	    + (w - Tk_ReqWidth((Tk_Window) winPtr)) / wmPtr->widthInc;
+    *ghPtr = wmPtr->reqGridHeight
+	    + (h - Tk_ReqHeight((Tk_Window) winPtr)) / wmPtr->heightInc;
+}
+
 void
 Tk_SetGrid(Tk_Window tkwin, int reqWidth, int reqHeight,
            int gridWidth, int gridHeight)
 {
-    (void)tkwin; (void)reqWidth; (void)reqHeight;
-    (void)gridWidth; (void)gridHeight;
+    TkWindow *winPtr = WmToplevelOf((TkWindow *) tkwin);
+    WmInfo *wmPtr;
+
+    if (winPtr == NULL || (wmPtr = winPtr->wmInfoPtr) == NULL)
+	return;
+    if (gridWidth <= 0 || gridHeight <= 0)
+	return;
+    /*
+     * Only one window may grid a toplevel. tkUnixWm.c takes the first and
+     * ignores the rest rather than reporting an error -- two gridded
+     * widgets in one toplevel is a layout mistake, not a Tcl one.
+     */
+    if (wmPtr->gridWin != NULL && wmPtr->gridWin != (TkWindow *) tkwin)
+	return;
+
+    if (wmPtr->gridWin != NULL
+	    && wmPtr->reqGridWidth == reqWidth
+	    && wmPtr->reqGridHeight == reqHeight
+	    && wmPtr->widthInc == gridWidth
+	    && wmPtr->heightInc == gridHeight)
+	return;
+
+    /*
+     * An explicit "wm geometry" set BEFORE gridding is in pixels and has
+     * to be reinterpreted, or it would silently become a character count
+     * a few hundred times too large.
+     */
+    if (wmPtr->gridWin == NULL && wmPtr->width >= 0) {
+	int gw, gh;
+
+	wmPtr->gridWin = (TkWindow *) tkwin;
+	wmPtr->reqGridWidth = reqWidth;
+	wmPtr->reqGridHeight = reqHeight;
+	wmPtr->widthInc = gridWidth;
+	wmPtr->heightInc = gridHeight;
+	WmPixelsToGrid(wmPtr, wmPtr->width, wmPtr->height, &gw, &gh);
+	wmPtr->width = gw;
+	wmPtr->height = gh;
+    } else {
+	wmPtr->gridWin = (TkWindow *) tkwin;
+	wmPtr->reqGridWidth = reqWidth;
+	wmPtr->reqGridHeight = reqHeight;
+	wmPtr->widthInc = gridWidth;
+	wmPtr->heightInc = gridHeight;
+    }
+    WmGridChanged(winPtr);
 }
 
 void
 Tk_UnsetGrid(Tk_Window tkwin)
 {
-    (void)tkwin;
+    TkWindow *winPtr = WmToplevelOf((TkWindow *) tkwin);
+    WmInfo *wmPtr;
+    int w, h;
+
+    if (winPtr == NULL || (wmPtr = winPtr->wmInfoPtr) == NULL)
+	return;
+    if (wmPtr->gridWin != (TkWindow *) tkwin)
+	return;
+
+    if (wmPtr->width >= 0) {
+	WmGridToPixels(wmPtr, wmPtr->width, wmPtr->height, &w, &h);
+	wmPtr->width = w;
+	wmPtr->height = h;
+    }
+    wmPtr->gridWin = NULL;
+    wmPtr->widthInc = 1;
+    wmPtr->heightInc = 1;
+    wmPtr->reqGridWidth = 0;
+    wmPtr->reqGridHeight = 0;
+    WmGridChanged(winPtr);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1338,8 +1524,16 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
     case OPT_GEOMETRY:
         if (objc == 3) {
             char buf[TCL_INTEGER_SPACE * 4 + 4];
-            snprintf(buf, sizeof buf, "%dx%d+%d+%d",
-                    winPtr->changes.width, winPtr->changes.height,
+            int w = winPtr->changes.width, h = winPtr->changes.height;
+
+            /*
+             * A gridded toplevel reports its size in characters, not
+             * pixels -- that is the whole point of "-setgrid 1", and the
+             * setter above already reads WxH in the same units.
+             */
+            if (wmPtr != NULL)
+                WmPixelsToGrid(wmPtr, w, h, &w, &h);
+            snprintf(buf, sizeof buf, "%dx%d+%d+%d", w, h,
                     winPtr->changes.x, winPtr->changes.y);
             Tcl_SetObjResult(interp, Tcl_NewStringObj(buf, -1));
             return TCL_OK;
@@ -1440,10 +1634,36 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
 
     case OPT_ICONNAME:
     case OPT_TITLE:
-        /* query returns empty string; set is silently accepted */
-        if (objc == 3)
-            Tcl_SetObjResult(interp, Tcl_NewStringObj("", -1));
-        return TCL_OK;
+        /*
+         * rio owns the window frame, so nothing here displays a title.
+         * That is no reason to forget it: "wm title" is a query as well
+         * as a set, and answering the empty string to a title the caller
+         * has just set is simply wrong. fontchooser-2.0/2.1 read the
+         * title back to identify the dialog they raised.
+         *
+         * The default is the toplevel's own name, as Tk uses on X.
+         */
+        if (wmPtr == NULL)
+            return TCL_OK;
+        if (objc == 3) {
+            Tcl_SetObjResult(interp, Tcl_NewStringObj(
+                    wmPtr->title != NULL ? wmPtr->title
+                                         : winPtr->nameUid, -1));
+            return TCL_OK;
+        }
+        if (objc == 4) {
+            const char *s = Tcl_GetString(objv[3]);
+            size_t n = strlen(s) + 1;
+
+            if (wmPtr->title != NULL)
+                ckfree(wmPtr->title);
+            wmPtr->title = (char *) ckalloc(n);
+            memcpy(wmPtr->title, s, n);
+            TkpWmSetTitle(winPtr, wmPtr->title);
+            return TCL_OK;
+        }
+        Tcl_WrongNumArgs(interp, 2, objv, "window ?newTitle?");
+        return TCL_ERROR;
 
     case OPT_RESIZABLE:
         /* query returns "1 1" */


### PR DESCRIPTION
Four stubs that answered plausibly rather than admitting they did nothing, so nothing upstream could tell.

Tk_SetGrid/Tk_UnsetGrid were empty, so "-setgrid 1" on a listbox or text widget did nothing. With gridding in force "wm geometry" speaks in characters rather than pixels, in both directions, and listbox-4.7 reads back 190x308 where it wants 30x20. Implemented on tkUnixWm.c's convention: while wmPtr->gridWin is set, wmPtr->width/height hold grid units, converted at the three places a size crosses that boundary -- WmUpdateGeometry, and the wm geometry query and setter. Tk_SetGrid reinterprets a size set in pixels before gridding began, or it would silently become a character count hundreds of times too large.

XKeysymToString returned "" for a keysym it could not name. Xlib returns NULL and every caller distinguishes them: tkBind.c's %K keeps its "??" only while the name is NULL, so "event generate <Key> -keycode -1" substituted an empty string (bind-13.14).

TkpScanWindowId used strtoul and could not fail, so "toplevel .t -use xyz" reached the container lookup with id 0 and blamed a missing window (embed-1.1). It reports the ordinary Tcl integer error now.

wm title was write-only: nothing here displays a title, but the query must still return what was set, which is how fontchooser-2.0/2.1 identify the dialog they raised.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs