### PR TITLE
tests: float overflow to Inf, and whether free() gives memory back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,8 @@ itself are `bool-test.c`, `bitfield-test.c`, `compound-assign-test.c`,
 `rol64-test.c` and `u64float-test.c`, and for libap `locale-test.c`,
 `sigset-test.c`, `posix-spawn-test.c`, `limits-test.c`,
 `format-arg-test.c`, `unget-pipe-test.c`, `isatty-test.c`,
-`sincos-test.c`, `explog-test.c`, `fparith-test.c` and
+`sincos-test.c`, `explog-test.c`, `fparith-test.c`,
+`float-overflow-test.c`, `malloc-reuse-test.c` and
 `stdio-test.c`. The three `tk-*.tcl` scripts there are Tcl, run with
 `wish`; see the Tk section below. `sys/src/ape/lib/libressl/test/` is separate: it is
 upstream's own ML-KEM and SHA-3 vectors, run by `mk test` there.
@@ -2173,6 +2174,97 @@ covers A-Z and the accented capitals and is what makes
 `bind .e <Shift-Key-A>` fire. Which *punctuation* needs Shift is a
 property of the physical layout and is not knowable here, so those are
 reported unshifted.
+
+### Tcl's own test suite, and the two things it has found so far
+
+Run from `sys/src/ape/cmd/tclsh`:
+
+```
+./tcltest $home/APExp/sys/src/external/tcl/tests/all.tcl >/tmp/tcl-all.out 2>&1
+```
+
+**It does not finish**, and that is the most important result in it. Of
+167 test files it reaches six -- `binary.test` is killed and the run
+stops during `chanio.test`, with no summary line:
+
+```
+Test file error: tcltest 69507: Killed: Insufficient physical memory
+```
+
+That note is the 9front kernel refusing to grow the process, and the
+same wall is expected to stop bash on a configure script. **Do not read
+the failure list as a survey**: it covers the first 4% of the suite in
+alphabetical order, so everything after `chanio` is simply unmeasured.
+
+Two findings, both worth a test of their own.
+
+**1. A double just past the float range may not round to infinity.**
+`binary-53.25` and `binary-53.26`:
+
+```tcl
+binary scan [binary format H* 47effffff0000001] Q round_to_inf
+binary scan [binary format R $round_to_inf] R inf1
+expr {$inf1 eq Inf}		;# answers 0, wants 1
+```
+
+`binary format R` is a 32-bit float, so this is a double -> float
+conversion and a read back. The constant is not arbitrary: FLT_MAX is
+`2**128 - 2**104`, the next float is infinity, and the midpoint is
+`2**128 - 2**103`, exactly `0x47EFFFFFF0000000`. The test value is that
+**plus one ulp of a double**, so round-to-nearest must give infinity
+with no tie to break, and `0x47EFFFFFEFFFFFFF` must give FLT_MAX.
+
+Three different things produce a `0` there and they want different
+fixes, which is why `sys/lib/tests/float-overflow-test.c` asks them
+separately: the conversion itself (6c's `CVTSD2SS`, or the folded path
+in `cc/scon.c` -- and note the sign-of-zero work found `ieeedtof` in
+every `*l/obj.c` mishandling this boundary); `isinf` and the
+`INFINITY`/`HUGE_VAL` macros, which `<math.h>` got wrong once already;
+and **printing**, because `eq Inf` is a *string* comparison -- it is
+asking whether Tcl's double-to-string gives exactly `"Inf"`, which Tcl
+reaches through `TclIsInfinite()` -> `isinf()`.
+
+**2. free() does not give memory back, except to a request of exactly
+the same size.** `ap/malloc/malloc.c` is Plan 9's: one free list per
+power-of-two class, and `free()` pushes a block onto the list for its
+own class and nowhere else. So
+
+- every request is rounded **up to a power of two** -- a 33 MB string
+  costs 64 MB;
+- **nothing splits or coalesces**, so 64 MB on the `2**26` list does not
+  satisfy a 32 MB request; the heap grows instead;
+- `realloc` is malloc-copy-free, so growing one buffer to N bytes walks
+  the classes and strands a dead block in each, leaving about 2N of
+  garbage that only an identically-sized request can reuse, on top of
+  the up-to-2N rounding.
+
+Growth by realloc is how every interpreter builds a big string, so this
+is the shape behind the OOM.
+
+**Splitting is the obvious fix and does not work as written.** A block
+of class k occupies `16 + 2**k` bytes -- the header is padded to 16 for
+`max_align_t` -- so two class-k blocks need `32 + 2**(k+1)`, which is
+sixteen bytes **more** than the class-(k+1) block they would be carved
+from. The layout has no room for it, which is presumably why Plan 9
+never did it. Making this allocator return memory means changing the
+block layout or replacing the allocator.
+
+`sys/lib/tests/malloc-reuse-test.c` measures it through `sbrk(0)` --
+what the process took from the kernel, which is the quantity the note is
+about, rather than what malloc believes it handed out. Its sizes are
+under glibc's 128 KB mmap threshold on purpose, so both assertions hold
+on glibc, which is how it was checked.
+
+**The rest of the list is not new work.** `chan-16.9` wants
+`socket -server`, which libap answers `ENOTSUP`; the seven
+`chan-io-6.4x`/`8.1` failures are one cluster, all `-buffersize 16` with
+`testchannel inputbuffered` reporting 0 where a partial buffer should
+remain, on a pipe and on a file alike. Tcl channels use `read`/`write`
+directly, not stdio, so the stdio work above is not implicated.
+
+**Getting a full run is the first job here**, not fixing the ten. Skip
+the files that cannot fit in the VM (`bigdata.test`, and `binary.test`
+until the allocator is dealt with) so the other 161 are measured at all.
 
 ### Build order for compiler changes
 ```

--- a/sys/lib/tests/float-overflow-test.c
+++ b/sys/lib/tests/float-overflow-test.c
@@ -1,0 +1,165 @@
+/*
+ * Does a double just past the float range round to infinity?
+ *
+ *	pcc -o float-overflow-test float-overflow-test.c && ./float-overflow-test
+ *
+ * From Tcl's own suite, binary-53.25 and binary-53.26:
+ *
+ *	binary scan [binary format H* 47effffff0000001] Q round_to_inf
+ *	binary scan [binary format R $round_to_inf] R inf1
+ *	expr {$inf1 eq Inf}		;# answered 0, wants 1
+ *
+ * "binary format R" is a 32-bit float, so that is a double -> float
+ * conversion and a read back. The constant is not arbitrary: FLT_MAX is
+ * 2**128 - 2**104, the next float up is infinity, and the midpoint
+ * between them is 2**128 - 2**103, which is exactly 0x47EFFFFFF0000000.
+ * The test value is that **plus one ulp of a double**, so it is strictly
+ * above the midpoint and round-to-nearest must give infinity with no tie
+ * to break. 0x47EFFFFFEFFFFFFF, one ulp below, must give FLT_MAX.
+ *
+ * Three separate things could produce "0" there and they want different
+ * fixes, so ask them separately:
+ *
+ *   1. the double -> float conversion itself (6c's CVTSD2SS, or the
+ *      constant-folded path in cc/scon.c -- note the sign-of-zero work
+ *      found ieeedtof in every *l/obj.c mishandling the boundary);
+ *   2. isinf() and the INFINITY/HUGE_VAL macros, which <math.h> got
+ *      wrong once already -- INFINITY used to be DBL_MAX, so
+ *      isinf(INFINITY) was false;
+ *   3. printing, since Tcl's "eq Inf" is a STRING comparison: it is
+ *      really asking whether Tcl's double-to-string gives exactly "Inf",
+ *      and Tcl reaches that spelling through TclIsInfinite() -> isinf().
+ *
+ * Every case here is required of any conforming C implementation, so it
+ * passes on gcc -- which is how it was checked.
+ */
+
+#include <stdio.h>
+#include <math.h>
+#include <float.h>
+#include <string.h>
+
+static int fail = 0;
+
+static void
+ok(int cond, const char *what)
+{
+	if(cond)
+		printf("  PASS %s\n", what);
+	else {
+		printf("  FAIL %s\n", what);
+		fail++;
+	}
+}
+
+/* Read a double out of its bit pattern, and a float's bits back out. */
+static double
+d_from_bits(unsigned long long b)
+{
+	union { unsigned long long u; double d; } x;
+
+	x.u = b;
+	return x.d;
+}
+
+static unsigned long
+f_bits(float f)
+{
+	union { unsigned long u; float f; } x;
+
+	x.f = f;
+	return x.u;
+}
+
+int
+main(void)
+{
+	double above, below, big;
+	float f;
+	volatile double vd;
+	char buf[64];
+
+	printf("--- 1. double -> float at the overflow boundary ---\n");
+	printf("  (FLT_MAX = %.17g, 2**128 = %.17g)\n",
+		(double)FLT_MAX, d_from_bits(0x47F0000000000000ULL));
+
+	/* Strictly above the midpoint: must become +Inf. */
+	above = d_from_bits(0x47EFFFFFF0000001ULL);
+	f = (float)above;
+	printf("  (float)%.17g -> bits %08lx\n", above, f_bits(f));
+	ok(f_bits(f) == 0x7F800000UL, "just past the midpoint gives +Inf");
+
+	/* And the negative of it. */
+	above = d_from_bits(0xC7EFFFFFF0000001ULL);
+	f = (float)above;
+	printf("  (float)%.17g -> bits %08lx\n", above, f_bits(f));
+	ok(f_bits(f) == 0xFF800000UL, "and the negative gives -Inf");
+
+	/*
+	 * One ulp the other side of the midpoint must NOT overflow. This is
+	 * the case that tells "the conversion rounds correctly" apart from
+	 * "the conversion saturates to infinity too eagerly", which would
+	 * pass the two above for the wrong reason.
+	 */
+	below = d_from_bits(0x47EFFFFFEFFFFFFFULL);
+	f = (float)below;
+	printf("  (float)%.17g -> bits %08lx\n", below, f_bits(f));
+	ok(f_bits(f) == 0x7F7FFFFFUL, "just below the midpoint gives FLT_MAX");
+
+	/* Something plainly out of range. */
+	big = 1e300;
+	f = (float)big;
+	ok(f_bits(f) == 0x7F800000UL, "1e300 gives +Inf");
+
+	/* And a value that fits, so the whole conversion is not just Inf. */
+	f = (float)0.5;
+	ok(f_bits(f) == 0x3F000000UL, "0.5 survives the conversion");
+
+	printf("\n--- 2. isinf, INFINITY and HUGE_VAL ---\n");
+	/*
+	 * <math.h> defined INFINITY as DBL_MAX once. isinf(INFINITY) was
+	 * false, and exp(1000) == INFINITY was false too -- see the
+	 * fparith-test.c notes. Kept here because Tcl's Inf spelling goes
+	 * through isinf().
+	 */
+	ok(isinf(INFINITY), "isinf(INFINITY)");
+	ok(isinf(HUGE_VAL), "isinf(HUGE_VAL)");
+	ok(INFINITY > DBL_MAX, "INFINITY exceeds DBL_MAX");
+	ok(!isinf(DBL_MAX), "isinf(DBL_MAX) is false");
+
+	vd = (double)d_from_bits(0x7FF0000000000000ULL);
+	ok(isinf(vd), "isinf of a hand-built +Inf");
+	ok(vd > 0, "and it is positive");
+
+	vd = (double)d_from_bits(0xFFF0000000000000ULL);
+	ok(isinf(vd), "isinf of a hand-built -Inf");
+	ok(vd < 0, "and it is negative");
+
+	/*
+	 * The float that came out of the conversion above, widened back to
+	 * double, is what Tcl's "binary scan R" produces and then prints.
+	 */
+	f = (float)d_from_bits(0x47EFFFFFF0000001ULL);
+	vd = (double)f;
+	ok(isinf(vd), "the converted float widens back to an infinite double");
+
+	printf("\n--- 3. what printf makes of it ---\n");
+	/*
+	 * Reported, not asserted: C leaves the spelling to the
+	 * implementation ("inf" and "INF" are both seen), and Tcl does not
+	 * use printf for this. It is here because a printf that produces a
+	 * FINITE-looking string is evidence the value is not really
+	 * infinite, which is the thing under test.
+	 */
+	snprintf(buf, sizeof buf, "%g", (double)INFINITY);
+	printf("  printf %%g of INFINITY: \"%s\"\n", buf);
+	ok(strstr(buf, "inf") != NULL || strstr(buf, "INF") != NULL
+		|| strstr(buf, "Inf") != NULL,
+		"printf spells INFINITY as some form of \"inf\"");
+
+	snprintf(buf, sizeof buf, "%g", (double)-INFINITY);
+	printf("  printf %%g of -INFINITY: \"%s\"\n", buf);
+
+	printf("\n%d failure(s)\n", fail);
+	return fail;
+}

--- a/sys/lib/tests/malloc-reuse-test.c
+++ b/sys/lib/tests/malloc-reuse-test.c
@@ -1,0 +1,157 @@
+/*
+ * Does free() give memory back to malloc()?
+ *
+ *	pcc -o malloc-reuse-test malloc-reuse-test.c && ./malloc-reuse-test
+ *
+ * tcltest dies partway through Tcl's own test suite with
+ *
+ *	Test file error: tcltest 69507: Killed: Insufficient physical memory
+ *
+ * which is the 9front kernel refusing to grow the process, and the same
+ * thing is expected to stop bash on a configure script. So the question
+ * is whether APE's allocator hands memory back.
+ *
+ * ap/malloc/malloc.c is Plan 9's: one free list per power-of-two size
+ * class, and free() pushes the block onto the list for ITS OWN class and
+ * nowhere else. Two consequences, both measured below:
+ *
+ *   - every request is rounded UP to a power of two, so a 3 MB string
+ *     costs 4 MB and a 33 MB one costs 64 MB;
+ *   - a freed block can only ever be reused by a request in the SAME
+ *     class. Nothing splits a large free block for a smaller request and
+ *     nothing coalesces, so 64 MB sitting on the 2**26 list does not
+ *     satisfy a 32 MB request -- the heap grows instead.
+ *
+ * The second one is what makes growth by realloc expensive, and growth
+ * by realloc is how every interpreter builds a big string. realloc()
+ * here is malloc-copy-free, so growing one buffer to N bytes walks the
+ * classes and strands one dead block in each: the heap ends up holding
+ * about 2N of garbage that only an identically-sized request can ever
+ * use again, on top of the up-to-2N rounding.
+ *
+ * A note on splitting, since it is the obvious fix and does not work as
+ * written: a block of class k occupies 16 + 2**k bytes (the header is
+ * padded to 16 for max_align_t), so two class-k blocks need 32 + 2**(k+1)
+ * -- sixteen bytes MORE than the one class-(k+1) block they would come
+ * from. The layout has no room for the split, which is presumably why
+ * Plan 9 never did it. Making this allocator return memory means
+ * changing the block layout or replacing it.
+ *
+ * Sizes here are deliberately small (64 KB and below) so the test costs
+ * nothing to run, and so that it is meaningful on glibc too: they are
+ * under the 128 KB mmap threshold, so glibc serves them from the same
+ * heap and its own splitting is what makes section 2 pass there. Every
+ * assertion below holds on glibc, which is how this was checked.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int fail = 0;
+
+static void
+ok(int cond, const char *what)
+{
+	if(cond)
+		printf("  PASS %s\n", what);
+	else {
+		printf("  FAIL %s\n", what);
+		fail++;
+	}
+}
+
+/*
+ * How far has the break moved? sbrk(0) is the current break on both
+ * systems. This measures what the process took from the kernel, which is
+ * the quantity the "Insufficient physical memory" note is about --
+ * not what malloc thinks it has handed out.
+ */
+static unsigned long
+brknow(void)
+{
+	return (unsigned long)(char *)sbrk(0);
+}
+
+int
+main(void)
+{
+	unsigned long base, mark, grew;
+	char *p, *q;
+	int i;
+
+	/*
+	 * Warm up first: the first malloc in a program sets up whatever the
+	 * allocator needs, and charging that to the measurement below would
+	 * report a growth that has nothing to do with reuse.
+	 */
+	p = malloc(1024);
+	if(p == NULL) { printf("malloc failed\n"); return 1; }
+	free(p);
+
+	printf("--- 1. free then ask for the SAME size again ---\n");
+	base = brknow();
+	p = malloc(64 * 1024);
+	if(p == NULL) { printf("malloc failed\n"); return 1; }
+	memset(p, 1, 64 * 1024);
+	free(p);
+	mark = brknow();
+	q = malloc(64 * 1024);
+	if(q == NULL) { printf("malloc failed\n"); return 1; }
+	grew = brknow() - mark;
+	printf("  first 64K grew the heap by %lu bytes\n", mark - base);
+	printf("  second 64K grew it by a further %lu\n", grew);
+	ok(grew == 0, "the same size is served from the freed block");
+	free(q);
+
+	printf("\n--- 2. free then ask for a SMALLER size ---\n");
+	/*
+	 * This is the one that separates a real allocator from a set of
+	 * per-size free lists. 64 KB is free and 32 KB is wanted; there is
+	 * no reason to touch the kernel.
+	 */
+	p = malloc(64 * 1024);
+	if(p == NULL) { printf("malloc failed\n"); return 1; }
+	free(p);
+	mark = brknow();
+	q = malloc(32 * 1024);
+	if(q == NULL) { printf("malloc failed\n"); return 1; }
+	grew = brknow() - mark;
+	printf("  32K after freeing 64K grew the heap by %lu bytes\n", grew);
+	ok(grew == 0, "a smaller request reuses the larger free block");
+	free(q);
+
+	printf("\n--- 3. growing one buffer with realloc ---\n");
+	/*
+	 * The interpreter pattern. Reported rather than asserted, because
+	 * how much a conforming allocator needs here is its own business --
+	 * but the number says what a Tcl or bash script that builds a big
+	 * string will cost, and it is the number behind the OOM.
+	 */
+	mark = brknow();
+	p = malloc(1024);
+	if(p == NULL) { printf("malloc failed\n"); return 1; }
+	for(i = 11; i <= 20; i++) {		/* 2K up to 1M */
+		q = realloc(p, 1UL << i);
+		if(q == NULL) { printf("realloc failed at 2**%d\n", i); return 1; }
+		p = q;
+		memset(p, i, 1UL << i);
+	}
+	grew = brknow() - mark;
+	printf("  growing 1K -> 1M by realloc took %lu bytes from the kernel\n",
+		grew);
+	printf("  (1M is 1048576; anything near 2M means each intermediate\n");
+	printf("   block was stranded on its own size-class free list)\n");
+	free(p);
+
+	/* And is any of that reusable? Ask for the final size again. */
+	mark = brknow();
+	q = malloc(1024 * 1024);
+	if(q == NULL) { printf("malloc failed\n"); return 1; }
+	printf("  asking for 1M again grew it by %lu\n", brknow() - mark);
+	free(q);
+
+	printf("\n%d failure(s)\n", fail);
+	return fail;
+}


### PR DESCRIPTION
Two reproducers for what Tcl's own suite found, both checked against gcc first.

float-overflow-test.c is binary-53.25/53.26. FLT_MAX is 2**128 - 2**104 and the midpoint to infinity is 0x47EFFFFFF0000000; the test value is one double-ulp above it, so round-to-nearest must give Inf with no tie, and one ulp below must give FLT_MAX. Three things produce the observed 0 and want different fixes -- the conversion, isinf/INFINITY, and printing, since Tcl's "eq Inf" is a string comparison that reaches TclIsInfinite() -> isinf() -- so it asks them separately.

malloc-reuse-test.c is the memory wall that kills tcltest and is expected to kill bash on configure. ap/malloc/malloc.c keeps one free list per power-of-two class and free() pushes a block onto its own class and nowhere else, so nothing splits or coalesces: 64MB on the 2**26 list does not satisfy a 32MB request. With realloc being malloc-copy-free, growing one buffer to N strands a dead block in every class on the way, about 2N of garbage on top of the up-to-2N rounding.

Splitting is the obvious fix and does not work as written: a class-k block occupies 16 + 2**k bytes, so two of them need sixteen bytes more than the class-(k+1) block they would come from. Returning memory means changing the layout or replacing the allocator.

CLAUDE.md also records that the run reaches six of 167 files, so the failure list is the first 4% in alphabetical order and not a survey.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs