### PR TITLE
tests: line-buffer tk-runall.tcl, and separate the hang from the log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1728,23 +1728,55 @@ character put line breaks mid-word and in the wrong place for tabs
 The suite is at **24 failing tests** (`grep -c FAILED` counts two lines
 each, so 48 lines).
 
-**Read that number with the caveat below.** Every `tk-all.out` collected
-so far stops after `scrollbar.test`, 62 files of 97 -- and it is not a
-hang. Tk's `all.tcl` ends with its only `exit` inside
-`if {... && [info exists env(ERROR_ON_FAILURES)]}`, so with that
-variable unset the script falls off the end, **wish enters
-`Tk_MainLoop`**, and stdout redirected to a file is block buffered: the
-tail of the run is still in a stdio buffer that never gets flushed.
-The leftover windows on screen are the same cause -- `all.tcl` sets
-`-singleproc 1`, so all 97 files share one wish and every toplevel a
-test forgets to destroy stays up for the life of a process that never
-exits. Use `sys/lib/tests/tk-runall.tcl`, which sources `all.tcl` and
-then exits (exit flushes); if the log still stops short of tcltest's
-summary after that, then it really is a hang and the last file named is
-where to look. **So 35 files -- `select`, `send`, all of `text*`,
-`unixFont`, `unixWm`, `winfo`, `wm` and the `ttk` set -- have never been
-measured**, and every count in this section has silently been about the
-same 62-file prefix.
+**Read that number with the caveat below: the suite does not finish.**
+Every `tk-all.out` collected so far stops after `scrollbar.test`, 62
+files of 97, and **`grep -c FAILED` has therefore always been counting a
+62-file prefix**. 35 files -- `select`, `send`, `spinbox`, `systray`,
+all of `text*`, `unixFont`, `unixWm`, `winfo`, `wm` and the `ttk` set --
+have never been measured at all.
+
+Three separate things were tangled here, and they were sorted out in the
+wrong order, so keep them apart:
+
+- **`wish all.tcl` never exits, even on success.** Its only `exit` is
+  inside `if {... && [info exists env(ERROR_ON_FAILURES)]}`; Github CI
+  sets that variable and nothing else does, so the script falls off the
+  end and wish enters `Tk_MainLoop`. Under `tclsh` the same file exits,
+  which is why upstream does not notice.
+- **The log lies about where the run stopped.** stdout redirected to a
+  file is block buffered, so the last file name visible is an upper
+  bound on progress, not the truth.
+- **There is also a real hang**, and this is the one that matters.
+  Adding the exit did *not* change the log: `tk-runall.tcl` produced a
+  byte-identical 535 lines, so `runAllTests` never returned. The first
+  two explanations were both true and neither was the cause.
+
+`sys/lib/tests/tk-runall.tcl` now sets line buffering before anything is
+written and prints
+
+```
+tk-runall: runAllTests returned, N failed
+```
+
+which is the discriminator. **Present**: every file ran, and whatever is
+wedged is in `exit` -- `Tcl_Exit` destroying the main window, i.e. this
+port's teardown, which the leftover windows on screen also point at.
+**Absent**: a test file hung, and with line buffering the last name in
+the log is now genuinely where it stopped.
+
+The next file after `scrollbar.test` is `select.test`, and `select.test`
+and `send.test` are the only two of the remaining 35 that spawn a child
+wish (`childTkProcess`) -- the handshake that already cost a round trip
+once, see `tk-childproc-test.tcl`. Note `send` itself is not built here:
+`unix/tkUnixSend.c` is absent from the libtk mkfile and the port
+supplies only `TkpTestsendCmd`, which errors. Bisect with
+`wish .../tk-runall.tcl -file select.test`; every option is forwarded to
+tcltest.
+
+The leftover windows are a third thing and not a mystery: `all.tcl` sets
+`-singleproc 1`, so all 97 files are sourced into one wish and every
+toplevel a test forgets to destroy stays up for the life of a process
+that never ends.
 
 **23 of the 24 are known not to be the Plan 9 backend's**, and are worth
 recording so they are not chased again:

--- a/sys/lib/tests/tk-runall.tcl
+++ b/sys/lib/tests/tk-runall.tcl
@@ -1,60 +1,79 @@
-# Run Tk's whole test suite and then EXIT.
+# Run Tk's whole test suite, say where it got to, and then EXIT.
 #
 #	cd sys/src/external/tk/tests
 #	wish $home/APExp/sys/lib/tests/tk-runall.tcl >/tmp/tk-all.out 2>&1
 #
-# WHY THIS EXISTS. "wish all.tcl" never comes back, and the log it
-# leaves is short. Both are the same one line -- the end of Tk's
-# all.tcl:
+# To run part of it -- everything here is forwarded to tcltest, so its
+# options work. This is how to bisect a hang:
+#
+#	wish .../tk-runall.tcl -file select.test
+#	wish .../tk-runall.tcl -file {s*.test t*.test}
+#
+# ------------------------------------------------------------------
+# WHY THIS EXISTS, in two parts, because they were confused once.
+#
+# 1. "wish all.tcl" never comes back even when it finishes. The end of
+#    Tk's all.tcl is
 #
 #	if {[tcltest::runAllTests] && [info exists env(ERROR_ON_FAILURES)]} {
 #	    exit 1
 #	}
 #
-# That is the ONLY exit in the file. With ERROR_ON_FAILURES unset --
-# Github CI sets it, nothing else does -- the script simply falls off
-# the end, and falling off the end of a script is not how wish stops:
-# it enters Tk_MainLoop and sits in the event loop forever. Under tclsh
-# the same file exits, which is why nobody upstream notices.
+#    and that is its ONLY exit. Github CI sets that variable; nothing
+#    else does. So the script falls off the end, and falling off the end
+#    of a script is not how wish stops -- it enters Tk_MainLoop and sits
+#    there. Under tclsh the same file exits, which is why upstream does
+#    not notice.
 #
-# The consequence that actually costs you: stdout redirected to a file
-# is BLOCK buffered, and a process that never exits never flushes. So
-# the tail of the run -- the last few file names, and the summary with
-# the totals -- is still sitting in a stdio buffer when you give up and
-# kill it. Every tk-all.out collected this way stops mid-suite at
-# whatever the last 4 KB boundary was, and "the suite got this far"
-# reads that truncation as a hang. It is not a hang.
+# 2. The log lies about where the run stopped. stdout redirected to a
+#    file is BLOCK buffered, so up to a bufferful of output is still in
+#    memory whenever the process is killed or wedged -- and the last
+#    file name you can see is therefore an upper bound on progress, not
+#    the truth. That is why this script sets line buffering below. It
+#    was NOT the reason the logs were short: with the exit in place the
+#    run still wedged at the same point, which is what proves there is a
+#    genuine hang rather than a formatting artefact.
 #
-# The leftover windows are the same thing. Tk's all.tcl sets
+#    Those two look identical from outside and want opposite next steps,
+#    so the marker line at the bottom separates them:
 #
-#	tcltest::configure -singleproc 1
+#	tk-runall: runAllTests returned, N failed
 #
-# so all 97 files are sourced into ONE wish rather than run as separate
-# processes. Any toplevel a test file forgets to destroy -- safe.test's
-# "Untrusted Tcl applet" containers are the visible ones -- stays on
-# screen for the life of that process, which is forever.
+#    Present  -> every file ran; anything wedged after it is in exit,
+#                i.e. Tcl_Exit -> destroying the main window -> this
+#                port's teardown. The leftover windows on screen point
+#                the same way.
+#    Absent   -> a test file hung, and with line buffering the LAST
+#                NAME IN THE LOG is now genuinely where it stopped
+#                rather than wherever the buffer happened to end.
 #
-# exit flushes, so with this wrapper the log ends with tcltest's own
-# summary. If the log still stops short of that, THEN it really is a
-# hang and the last file named is where to look.
-#
-# The zero-effort alternative, while the suite still has failures:
-#
-#	ERROR_ON_FAILURES=1 wish all.tcl >/tmp/tk-all.out 2>&1
-#
-# which takes the exit branch above -- but only when something failed,
-# so it stops working on the day the suite comes out clean.
+# The leftover windows are a third thing, and not a mystery: all.tcl
+# sets -singleproc 1, so all 97 files are sourced into one wish, and
+# every toplevel a test forgets to destroy -- safe.test's "Untrusted Tcl
+# applet" containers are the ones you can see -- stays up for the life
+# of a process that never exits.
 
 package require Tk
 package require tcltest 2.2
 
-# all.tcl reads $argv itself, so anything passed here is forwarded.
+# Line buffering, before anything is written. Without this the tail of
+# the log is lost on any abnormal end, and the last file named is
+# wherever the 4 KB boundary fell -- which is indistinguishable from
+# where the suite actually stopped.
+fconfigure stdout -buffering line
+fconfigure stderr -buffering line
+catch {fconfigure $::tcltest::outputChannel -buffering line}
+catch {fconfigure $::tcltest::errorChannel -buffering line}
+
+puts "tk-runall: starting, line buffered"
+
+# all.tcl reads $argv itself, so options given here reach tcltest.
 source [file join [pwd] all.tcl]
 
-# runAllTests has returned, so every file has been sourced. Exit with
-# the number of failures, as the C tests in this directory do, and let
-# exit flush stdout.
+# Reaching this line at all is the interesting part -- see above.
 set failed 0
 catch {set failed $::tcltest::numTests(Failed)}
-puts "tk-runall: $failed failed"
+puts "tk-runall: runAllTests returned, $failed failed"
+flush stdout
+
 exit [expr {$failed > 0 ? 1 : 0}]


### PR DESCRIPTION
Adding the exit did not change the log: tk-runall.tcl produced a byte-identical 535 lines with the same 62 files and the same 24 failures, so runAllTests never returned. The suite really does hang; the missing exit and the block-buffered stdout are both real and neither was the cause.

Those three look identical from outside and want opposite next steps, so the runner now sets line buffering before anything is written and prints a marker after runAllTests returns:

  present -> every file ran and the wedge is in exit, i.e. Tcl_Exit
             destroying the main window and this port's teardown, which
             is also what the leftover windows suggest;
  absent  -> a test file hung, and with line buffering the last name in
             the log is genuinely where it stopped rather than wherever
             the 4 KB boundary fell.

Records that the counts have always covered a 62-file prefix, so 35 files including select, send, all of text*, unixFont, unixWm, winfo, wm and the ttk set are unmeasured. select.test is next after scrollbar.test and is, with send.test, one of only two remaining files that spawn a child wish; send itself is not built here (unix/tkUnixSend.c is not in the libtk mkfile, and the port supplies only an erroring TkpTestsendCmd).


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs