### PR TITLE
tests: split the MouseWheel delivery that scrollbar-10.1 hangs in

### DIFF
--- a/sys/lib/tests/tk-mousewheel-test.tcl
+++ b/sys/lib/tests/tk-mousewheel-test.tcl
@@ -1,0 +1,170 @@
+# What spins when a <MouseWheel> reaches a scrollbar?
+#
+#	wish tk-mousewheel-test.tcl
+#
+# tk-scrollbar-hang-test.tcl narrowed the suite's hang to one statement
+# of scrollbar-10.1. Everything before it returns:
+#
+#	1d. update after 99 lines -- text layout alone     ok
+#	2d. update -- both widgets now feed each other     ok
+#	3.  focus -force .s                                ok
+#	4.  event generate .s <Enter>                      ok
+#	5.  event generate .s <MouseWheel> -delta -120     ok (queued)
+#	6.  after 200 + vwait                              HANGS
+#
+# So text layout is exonerated, and so is the -yscrollcommand/-command
+# wiring at rest: both were exercised and both returned. Generating the
+# event is fine too -- "event generate" only queues. What has never
+# happened until step 6 is the queued wheel event being DELIVERED, which
+# runs the Scrollbar class binding, which scrolls the text widget.
+#
+# Note "after 200 + vwait" by itself is known to work: tk-enter-test.tcl
+# uses exactly that idiom in its settle proc and passes. So the event
+# loop is not broken in general -- something about this delivery is.
+#
+# Three things happen inside step 6 and they want different fixes, so
+# this asks them separately and in order of sharpness. The early ones
+# bypass the event machinery completely: if the text widget spins when
+# scrolled by a direct command, no amount of looking at the notifier
+# will help, and vice versa.
+#
+# ORDER MATTERS. A hang has to be killed by hand, so the probe that
+# distinguishes the most comes first and the whole-event-loop case comes
+# last. Whatever the last STEP line says is the one that did not return.
+
+proc step {msg} { puts "STEP: $msg"; flush stdout }
+proc done {msg} { puts "   ok: $msg"; flush stdout }
+
+# The suite's setup, minus the wheel.
+proc build {} {
+    destroy .t .s
+    pack [text .t -yscrollcommand {.s set}] -side left
+    for {set i 1} {$i < 100} {incr i} {.t insert end "Line $i\n"}
+    pack [scrollbar .s -command {.t yview}] -fill y -expand 1 -side left
+    update
+}
+
+puts "--- what the binding actually is on this build ---"
+puts "Scrollbar <MouseWheel>: [bind Scrollbar <MouseWheel>]"
+puts "Text <MouseWheel>:      [bind Text <MouseWheel>]"
+flush stdout
+puts ""
+
+# ------------------------------------------------------------------
+build
+step "1. after+vwait with the widgets built but NOTHING queued\
+ -- does the plain event loop return here at all?"
+after 200 {set ::v1 1}
+vwait ::v1
+done "vwait returned, so the event loop and after are fine in this setup"
+
+# ------------------------------------------------------------------
+# The binding is
+#	tk::ScrollByUnits %W vh %D -40.0
+# and ScrollByUnits (library/scrlbar.tcl:391) ends in
+#	uplevel #0 $cmd scroll [expr {$amount/$factor}] units
+# so with %D = -120 and factor -40.0 the text widget is asked for
+#	.t yview scroll 3.0 units
+# -- a DOUBLE, not an integer, and positive. Both of those matter:
+# tkTextDisp.c's GetScrollInfo does
+#	*intPtr = (d > 0) ? ceil(d) : floor(d);
+# and YScrollByLines takes a different branch for each sign. So ask for
+# the exact form first, then the variants. (ceil and floor are both
+# declared in sys/include/ape/math.h -- checked -- so the implicit-int
+# trap that has bitten this tree before is not in play here.)
+#
+# What to watch for in the negative branch, because it is the one shape
+# here that spins rather than misbehaves -- YScrollByLines has
+#
+#	do {
+#	    dlPtr = LayoutDLine(textPtr, &index);
+#	    ...
+#	    bytesToCount -= dlPtr->byteCount;
+#	} while ((bytesToCount > 0)
+#	         && (index.linePtr == dlPtr->index.linePtr));
+#
+# which never ends if LayoutDLine yields a display line of ZERO bytes:
+# bytesToCount stops falling and index stops moving. LayoutDLine reaches
+# Tk_MeasureChars through TkTextCharLayoutProc, and Tk_MeasureChars is
+# this port's rewrite -- so a measure that reports no progress lands
+# exactly here. Section 1d of tk-scrollbar-hang-test.tcl does NOT cover
+# it: laying lines out for display and laying them out to count a scroll
+# are different calls.
+
+step "2. .t yview scroll 3.0 units  -- exactly what the binding asks\
+ for: a positive DOUBLE, no events involved"
+.t yview scroll 3.0 units
+done "returned; index is now [.t index @0,0]"
+
+step "2b. .t yview scroll 3 units  -- the same as an integer"
+.t yview scroll 3 units
+done "returned; index is now [.t index @0,0]"
+
+step "2c. .t yview scroll -3.0 units  -- the negative branch, which is\
+ the one with the do/while above"
+.t yview scroll -3.0 units
+done "returned; index is now [.t index @0,0]"
+
+step "2d. .t yview scroll 0.5 units  -- a fraction that ceil must round\
+ to 1; if ceil is broken this is where it shows"
+.t yview scroll 0.5 units
+done "returned; index is now [.t index @0,0]"
+
+step "3. .t yview moveto 0.5  -- the other scroll entry point"
+.t yview moveto 0.5
+done "yview moveto returned; index is now [.t index @0,0]"
+
+step "4. .s set 0.1 0.2  -- driving the scrollbar directly"
+.s set 0.1 0.2
+done "set returned"
+
+step "5. update after all that scrolling"
+update
+done "update returned"
+
+# ------------------------------------------------------------------
+step "6. tk::ScrollByUnits .s v -4  -- the class binding's BODY,\
+ called directly, so delivery is not involved"
+if {[catch {tk::ScrollByUnits .s v -4} err]} {
+    done "raised an error rather than hanging: $err"
+} else {
+    done "ScrollByUnits returned"
+}
+
+# ------------------------------------------------------------------
+# Delivery, with the class binding taken out of the way. If this returns
+# and the next section does not, the binding is the thing; if THIS hangs,
+# it is event delivery itself and the binding is innocent.
+step "7. deliver a <MouseWheel> to a scrollbar whose class binding is\
+ removed -- delivery without the binding"
+build
+set saved [bind Scrollbar <MouseWheel>]
+bind Scrollbar <MouseWheel> {}
+event generate .s <MouseWheel> -delta -120
+update
+done "delivered with no binding; update returned"
+bind Scrollbar <MouseWheel> $saved
+
+# ------------------------------------------------------------------
+step "8. the same delivery WITH the binding, through update rather\
+ than vwait"
+build
+event generate .s <MouseWheel> -delta -120
+update
+done "update returned; index is [.t index @0,0]"
+
+# ------------------------------------------------------------------
+step "9. scrollbar-10.1 exactly: generate, then after+vwait"
+build
+focus -force .s
+event generate .s <Enter>
+event generate .s <MouseWheel> -delta -120
+after 200 {set ::v9 1}
+vwait ::v9
+done "vwait returned; index is [.t index @0,0] (the test wants 4.0)"
+
+puts ""
+puts "reached the end -- nothing hung this time"
+flush stdout
+destroy .t .s
+exit 0


### PR DESCRIPTION
tk-scrollbar-hang-test.tcl localised the suite's hang to one statement: steps 1-5 all return -- text layout alone, both widgets wired, focus, <Enter>, and generating the wheel event -- and step 6, "after 200 + vwait", never does. So layout and the yscrollcommand wiring at rest are exonerated, and what has never happened before that point is the queued wheel event being DELIVERED.

tk-mousewheel-test.tcl asks the pieces separately, sharpest first, since a hang has to be killed by hand: a bare after+vwait in the same setup; the scroll commands with no events at all; the binding's body called directly; delivery with the class binding removed; delivery through update rather than vwait; then the test's own sequence.

The scroll probes are chosen from the binding rather than invented. It is "tk::ScrollByUnits %W vh %D -40.0", and ScrollByUnits ends in "$cmd scroll [expr {$amount/$factor}] units", so with %D = -120 the text widget is asked for ".t yview scroll 3.0 units" -- a positive double. Both properties matter: GetScrollInfo rounds it with ceil/floor, and YScrollByLines branches on the sign.

The negative branch is the one that can spin rather than misbehave: its do/while loops until bytesToCount falls or the line changes, and a LayoutDLine yielding a zero-byte display line stops both. LayoutDLine reaches Tk_MeasureChars through TkTextCharLayoutProc, and that is this port's rewrite -- so a measure reporting no progress lands exactly there. Laying lines out for display, which section 1d already showed works, is a different call.

ceil and floor are declared in math.h (checked), so the implicit-int trap is not in play.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs