### PR TITLE
tests: log background errors instead of letting a modal dialog wedge

### DIFF
--- a/sys/lib/tests/tk-mousewheel-test.tcl
+++ b/sys/lib/tests/tk-mousewheel-test.tcl
@@ -35,6 +35,15 @@
 proc step {msg} { puts "STEP: $msg"; flush stdout }
 proc done {msg} { puts "   ok: $msg"; flush stdout }
 
+# A background error inside a binding otherwise reaches Tk's bgerror
+# dialog, which is MODAL and waits for a click that no test will ever
+# give it -- so an error turns into a hang and the message is only
+# visible on screen. Log it instead.
+proc ::bgerror {msg} {
+    puts "BGERROR: $msg"
+    flush stdout
+}
+
 # The suite's setup, minus the wheel.
 proc build {} {
     destroy .t .s
@@ -49,6 +58,42 @@ puts "Scrollbar <MouseWheel>: [bind Scrollbar <MouseWheel>]"
 puts "Text <MouseWheel>:      [bind Text <MouseWheel>]"
 flush stdout
 puts ""
+
+# ------------------------------------------------------------------
+# Section 0, and it is the one that matters now.
+#
+# tk::ScrollByUnits reads $Priv(xEvents) and $Priv(yEvents) on every
+# wheel event, and the ONLY place in the whole library that ever sets
+# them is scrlbar.tcl:132
+#
+#	bind Scrollbar <Enter> {+
+#	    set tk::Priv(xEvents) 0; set tk::Priv(yEvents) 0
+#	}
+#
+# So a wheel event delivered to a scrollbar that has never seen an
+# <Enter> raises
+#
+#	can't read "Priv(xEvents)": no such element in array
+#
+# That is upstream's design, not a port bug: any Tk would do the same.
+# scrollbar-10.1 knows it, which is why it sends <Enter> first.
+#
+# The question this section asks is therefore whether the <Enter> is
+# actually DELIVERED here -- because if it is not, the wheel event
+# raises that error, the error reaches bgerror, and on a suite run the
+# modal dialog is the hang.
+build
+catch {unset ::tk::Priv(xEvents)}
+catch {unset ::tk::Priv(yEvents)}
+step "0. deliver <Enter> to the scrollbar and ask whether the class\
+ binding ran"
+event generate .s <Enter>
+update
+puts "   Priv(xEvents) exists: [info exists ::tk::Priv(xEvents)]\
+ (1 means the <Enter> class binding ran)"
+puts "   Priv(yEvents) exists: [info exists ::tk::Priv(yEvents)]"
+flush stdout
+done "probe complete"
 
 # ------------------------------------------------------------------
 build
@@ -146,9 +191,15 @@ done "delivered with no binding; update returned"
 bind Scrollbar <MouseWheel> $saved
 
 # ------------------------------------------------------------------
-step "8. the same delivery WITH the binding, through update rather\
- than vwait"
+# NOTE: this used to omit the <Enter>, which made it an invalid
+# sequence on ANY Tk -- ScrollByUnits would raise "can't read
+# Priv(xEvents)" upstream too. The hang that produced was Tk's modal
+# bgerror dialog waiting for a click, not a loop. Send the <Enter>, as
+# scrollbar-10.1 does.
+step "8. the same delivery WITH the binding and a preceding <Enter>,\
+ through update rather than vwait"
 build
+event generate .s <Enter>
 event generate .s <MouseWheel> -delta -120
 update
 done "update returned; index is [.t index @0,0]"

--- a/sys/lib/tests/tk-runall.tcl
+++ b/sys/lib/tests/tk-runall.tcl
@@ -65,7 +65,29 @@ fconfigure stderr -buffering line
 catch {fconfigure $::tcltest::outputChannel -buffering line}
 catch {fconfigure $::tcltest::errorChannel -buffering line}
 
-puts "tk-runall: starting, line buffered"
+# A background error inside a binding reaches bgerror, and Tk's default
+# bgerror puts up a MODAL dialog and waits for a click. Nothing in a
+# test run will ever click it, so an unhandled error inside any binding
+# stops the whole suite dead -- with the message only on screen, never
+# in the log, and the CPU pinned by the dialog's own event loop. That is
+# a hang whose cause is invisible from the log alone, which is exactly
+# the trap this file spent several rounds inside.
+#
+# Log it instead. This is a deliberate change to how the suite behaves,
+# so note the one place it could matter: bgerror.test tests bgerror
+# itself, but each of its cases defines its own bgerror, which overrides
+# this one for the duration -- so it is unaffected. Any BGERROR line
+# below is a real background error that would otherwise have wedged the
+# run.
+proc ::bgerror {msg} {
+    puts "BGERROR: $msg"
+    if {[info exists ::errorInfo]} {
+	puts "BGERROR-INFO: $::errorInfo"
+    }
+    flush stdout
+}
+
+puts "tk-runall: starting, line buffered, bgerror logged not dialogged"
 
 # all.tcl reads $argv itself, so options given here reach tcltest.
 source [file join [pwd] all.tcl]


### PR DESCRIPTION
tk-mousewheel-test.tcl froze at step 8 and put an error dialog on screen:

  can't read "Priv(xEvents)": no such element in array

Two separate things, and the first is mine. Step 8 delivered a <MouseWheel> without a preceding <Enter>, and tk::ScrollByUnits reads Priv(xEvents) on every wheel event while the ONLY place the library ever sets it is scrlbar.tcl:132, "bind Scrollbar <Enter> {+ set tk::Priv(xEvents) 0 ...}". So any Tk raises that error for that sequence; it was an invalid test, not a port bug. Step 8 now sends the <Enter>, as scrollbar-10.1 does.

The second thing is general and worth having. An unhandled background error inside a binding reaches Tk's default bgerror, which puts up a MODAL dialog and waits for a click no test will ever give it -- so any such error stops a suite run dead, with the message only on screen, never in the log, and the CPU pinned by the dialog's own event loop. A hang whose cause is invisible from the log is exactly the trap the last several rounds were spent in, so tk-runall.tcl and the mousewheel test both define a bgerror that logs and returns. bgerror.test is unaffected: each of its cases defines its own bgerror, which overrides this.

Whether that is also the suite's hang is still open -- scrollbar-10.1 does send <Enter> before the wheel. The new section 0 of tk-mousewheel-test.tcl answers it directly by unsetting both variables, delivering an <Enter>, and printing whether the class binding ran.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs