### PR TITLE
tests: fix tk-runall's bgerror override, split the mousewheel hang fu…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1755,6 +1755,32 @@ wrong order, so keep them apart:
 written and prints `tk-runall: runAllTests returned, N failed` when the
 suite completes. With both in place the answer is settled:
 
+**A background error is a hang, and neutralising it means replacing the
+default handler, not `::bgerror`.** Tk's default background-error
+handler puts up a **modal** dialog and waits for a click, so any
+unhandled error inside any binding stops the suite dead -- with the
+message only on screen, never in the log, and the CPU pinned by the
+dialog's own event loop. That is indistinguishable from a real spin.
+
+The obvious cure makes it worse. `::bgerror` is a `namespace import` of
+`::tk::dialog::error::bgerror` (`library/bgerror.tcl:281`), and the
+**`tkerror` compatibility delegation lives inside that handler**
+(`bgerror.tcl:107`), not in the dispatcher. Overriding `::bgerror`
+therefore threw the delegation away along with the dialog, and
+`bgerror-1.1..1.3` -- which each install a `::tkerror` and then
+`vwait errRes` for it to fire -- waited forever. The suite stopped
+three files in with a 632-byte log: the file that tests bgerror is
+exactly the one a careless bgerror override breaks, and it is early in
+the alphabet.
+
+`tk-runall.tcl` replaces `::tk::dialog::error::bgerror` instead,
+keeping the `::tkerror` call (and its return code, which `bgerror-1.3`
+relies on) and dropping only the dialog. A test's own `::bgerror` still
+wins, being consulted first. Note the override has to come **after**
+`bgerror.tcl` is sourced -- it is autoloaded on first use, so an
+override written first is silently undone the first time a background
+error arrives; `catch {::bgerror}` forces the load.
+
 **The hang is in `scrollbar.test`.** The marker is absent, so
 `runAllTests` never returned, and with line buffering the last name in
 the log is now genuinely where it stopped rather than wherever the 4 KB

--- a/sys/lib/tests/tk-mousewheel-test.tcl
+++ b/sys/lib/tests/tk-mousewheel-test.tcl
@@ -191,6 +191,85 @@ done "delivered with no binding; update returned"
 bind Scrollbar <MouseWheel> $saved
 
 # ------------------------------------------------------------------
+# Between step 6 (returned) and step 8 (hangs) there are THREE
+# differences, not one, and each wants a different fix. Step 6 called
+#
+#	tk::ScrollByUnits .s v -4
+#
+# and the real binding is
+#
+#	tk::ScrollByUnits %W vh %D -40.0		-> .s vh -120 -40.0
+#
+# so step 6 skipped, all at once:
+#
+#   a. the counting branch. It is guarded by
+#	  [string length $orient] == 2 && $factor != 1.0
+#      (scrlbar.tcl:375), and "v" with the default 1.0 fails BOTH halves
+#      -- so Priv(xEvents)/Priv(yEvents) were never read, and the
+#      "> 10 and non-dominant" early return was never reachable;
+#   b. the division. -4/1.0 is -4.0; -120/-40.0 is 3.0. Opposite signs,
+#      and sign picks the branch in YScrollByLines;
+#   c. delivery. Step 6 ran at the top level, step 8 runs inside the
+#      event loop with a redisplay pending.
+#
+# These sections take them one at a time, and they are placed BEFORE
+# step 8 on purpose: a hang has to be killed by hand, so everything
+# cheaper than the hang must have already printed.
+
+step "7b. what does .s get return, and how long is it? (ScrollByUnits\
+ branches on llength: 2 picks 'yview scroll N units', anything else\
+ picks 'yview <fraction>', a different command entirely)"
+build
+event generate .s <Enter>
+update
+puts "   .s get -> [.s get]  (llength [llength [.s get]])"
+flush stdout
+done "probe complete"
+
+step "7c. tk::ScrollByUnits .s vh -120 -40.0 -- the binding's exact\
+ arguments, called directly, so delivery is NOT involved"
+if {[catch {tk::ScrollByUnits .s vh -120 -40.0} err]} {
+    done "raised an error rather than hanging: $err"
+} else {
+    done "returned; index is [.t index @0,0]"
+}
+
+step "7d. the same call twelve times -- the counting branch's early\
+ return needs xEvents+yEvents > 10 to fire at all, so it is unreachable\
+ in one call"
+if {[catch {
+    for {set i 0} {$i < 12} {incr i} {tk::ScrollByUnits .s vh -120 -40.0}
+} err]} {
+    done "raised an error rather than hanging: $err"
+} else {
+    done "returned; index is [.t index @0,0], xEvents\
+ $::tk::Priv(xEvents) yEvents $::tk::Priv(yEvents)"
+}
+
+step "7e. delivery of a <MouseWheel> whose class binding SCROLLS but\
+ does not go through ScrollByUnits -- delivery plus a scroll, with the\
+ library proc taken out"
+build
+set saved [bind Scrollbar <MouseWheel>]
+bind Scrollbar <MouseWheel> {.t yview scroll 3.0 units}
+event generate .s <Enter>
+event generate .s <MouseWheel> -delta -120
+update
+bind Scrollbar <MouseWheel> $saved
+done "returned; index is [.t index @0,0].  If THIS hangs it is scrolling\
+ from inside event delivery, and ScrollByUnits is innocent; if it\
+ returns and step 8 does not, it is the proc."
+
+step "7f. the real binding body, but run from 'after idle' rather than\
+ from an event -- inside the event loop, without the wheel event"
+build
+event generate .s <Enter>
+update
+after idle {tk::ScrollByUnits .s vh -120 -40.0}
+update
+done "returned; index is [.t index @0,0]"
+
+# ------------------------------------------------------------------
 # NOTE: this used to omit the <Enter>, which made it an invalid
 # sequence on ANY Tk -- ScrollByUnits would raise "can't read
 # Priv(xEvents)" upstream too. The hang that produced was Tk's modal

--- a/sys/lib/tests/tk-runall.tcl
+++ b/sys/lib/tests/tk-runall.tcl
@@ -73,21 +73,60 @@ catch {fconfigure $::tcltest::errorChannel -buffering line}
 # a hang whose cause is invisible from the log alone, which is exactly
 # the trap this file spent several rounds inside.
 #
-# Log it instead. This is a deliberate change to how the suite behaves,
-# so note the one place it could matter: bgerror.test tests bgerror
-# itself, but each of its cases defines its own bgerror, which overrides
-# this one for the duration -- so it is unaffected. Any BGERROR line
-# below is a real background error that would otherwise have wedged the
-# run.
-proc ::bgerror {msg} {
-    puts "BGERROR: $msg"
-    if {[info exists ::errorInfo]} {
-	puts "BGERROR-INFO: $::errorInfo"
+# Log it instead. WHICH COMMAND TO REPLACE IS THE WHOLE OF IT, and the
+# obvious choice is wrong: overriding ::bgerror wedged the suite at
+# bgerror.test, three test files in, and produced a 632-byte log.
+#
+# The chain is
+#
+#	background error -> ::bgerror
+#	                 -> (namespace import, bgerror.tcl:281)
+#	                 -> ::tk::dialog::error::bgerror
+#	                       -> catch {::tkerror $err}   <- delegation
+#	                       -> otherwise the modal dialog
+#
+# so the tkerror compatibility path lives INSIDE the default handler,
+# not in the dispatcher. bgerror-1.1..1.3 each install a ::tkerror and
+# then "vwait errRes" for it to fire; replacing ::bgerror threw the
+# delegation away with the dialog, so errRes was never set and the vwait
+# never returned. The test file that tests bgerror is exactly the one a
+# careless bgerror override breaks, and it is early in the alphabet.
+#
+# Replacing the default handler instead keeps both things a test may
+# rely on: a test's own ::bgerror still wins (it is consulted first),
+# and ::tkerror is still delegated to, here, before anything is logged.
+# Only the dialog goes. Any BGERROR line below is a real background
+# error that would otherwise have wedged the run.
+#
+# Force bgerror.tcl to be sourced BEFORE overriding it. It is autoloaded
+# on first use, so an override written first would be silently undone
+# the first time a background error arrived and the real file was read
+# on top of it. Calling ::bgerror with no arguments triggers the
+# autoload and then fails on the argument count, which is what the catch
+# is for.
+catch {::bgerror}
+
+proc ::tk::dialog::error::bgerror {err {flag 1}} {
+    # Save errorInfo before ::tkerror can overwrite it, as the original
+    # does -- the trace is the useful half of the report.
+    set info $::errorInfo
+
+    set ret [catch {::tkerror $err} msg]
+    if {$ret != 1} {
+	# The application handled it. Return exactly what it returned:
+	# bgerror-1.3 relies on "return -code break" stopping the rest
+	# of the queued errors.
+	return -code $ret $msg
     }
+
+    puts "BGERROR: $err"
+    puts "BGERROR-INFO: $info"
     flush stdout
+    return
 }
 
-puts "tk-runall: starting, line buffered, bgerror logged not dialogged"
+puts "tk-runall: starting, line buffered, default bgerror dialog replaced\
+ by a log line (tkerror delegation kept)"
 
 # all.tcl reads $argv itself, so options given here reach tcltest.
 source [file join [pwd] all.tcl]


### PR DESCRIPTION
…rther

tk-runall.tcl's bgerror override wedged the suite at bgerror.test, three files in, with a 632-byte log. ::bgerror is a namespace import of ::tk::dialog::error::bgerror, and the ::tkerror compatibility delegation lives inside that handler (bgerror.tcl:107) rather than in the dispatcher -- so replacing ::bgerror discarded the delegation with the dialog, and bgerror-1.1..1.3 waited forever on a vwait their tkerror was supposed to satisfy.

Replace the default handler instead: keep the ::tkerror call and its return code (bgerror-1.3 needs "return -code break" to propagate), drop only the modal dialog. Force bgerror.tcl to load first, since it is autoloaded and would otherwise overwrite the override on first use.

tk-mousewheel-test.tcl: step 6 returned and step 8 hangs, but they differ in three ways at once -- the counting branch (guarded on orient length 2 AND factor != 1.0, so "v"/1.0 skipped it), the sign of the division (-4.0 vs 3.0), and whether the call happens inside event delivery. New sections 7b-7f take them one at a time, all placed before the hang so they print.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs