### PR TITLE
tests: ScrollByUnits is innocent -- split "scroll from inside delivery"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1725,8 +1725,26 @@ character put line breaks mid-word and in the wrong place for tabs
 
 ### Tk on Plan 9: what the remaining test failures are, and which are ours
 
-The suite is at **24 failing tests** (`grep -c FAILED` counts two lines
-each, so 48 lines).
+The suite is at **25 failing tests** (`grep -c FAILED` counts two lines
+each, so 50 lines).
+
+**It was 24, and the twenty-fifth is `event-9.16` -- which passed the
+previous run, with no C change in between.** The only difference between
+the two runs was `tk-runall.tcl`'s bgerror handling, which cannot reach
+a crossing event. So **at least one `event-9.*` test is
+nondeterministic here**, and the likely reason is worth knowing before
+anything is concluded from that group again: those tests warp the
+pointer and then depend on what is under it, while this port has no
+server and **polls the real `/dev/mouse`**. `gP9.pointerDirty` makes the
+next poll re-report the true position, so a mouse that moves during the
+run -- or a rio window that takes the pointer -- can overrule the warp.
+
+The practical rule: **an `event-9.*` result is only evidence if it
+repeats.** `9.16` reports the same empty `|` as `9.11`/`9.12`/`9.17`
+did, which is the "no crossing at all" failure the
+`SendEnterLeaveForDestroy` change fixed for its siblings; it is
+therefore also possible that the fix is racy rather than that the run
+was. Run `tk-enter-test.tcl` twice before touching it.
 
 **Read that number with the caveat below: the suite does not finish.**
 Every `tk-all.out` collected so far stops after `scrollbar.test`, 62
@@ -1849,13 +1867,58 @@ Do not skip to a fix from the mechanism: this file has now recorded four
 occasions where a confident mechanism was wrong and a printed
 intermediate value settled it in one round.
 
+**`sys/lib/tests/tk-mousewheel-test.tcl` has narrowed it to one
+sentence**, and the sentence is not what either shape above predicted.
+Its steps 0-7d all return, and between them they exonerate: crossing
+delivery (the `<Enter>` class binding demonstrably runs, so
+`Priv(xEvents)` is set and the "can't read Priv(xEvents)" error is not
+in play); the plain event loop and `after`; every shape of `yview
+scroll` -- positive, negative, integer, and the 0.5 that `ceil` must
+round to 1, so `GetScrollInfo`, `YScrollByLines`' do/while and this
+port's `Tk_MeasureChars` rewrite are all clear; `yview moveto`; `.s
+set`; `update` after all of it; `tk::ScrollByUnits` called directly with
+the binding's **exact** arguments (`.s vh -120 -40.0`) and twelve times
+over so the counting branch is reached; and delivery of a `<MouseWheel>`
+with the class binding removed.
+
+**The first thing that hangs is 7e, whose binding is a bare
+`.t yview scroll 3.0 units`** -- no `tk::ScrollByUnits` at all. So the
+library proc is innocent, and the statement of the bug is
+
+| | |
+|---|---|
+| scroll alone | returns |
+| delivery alone | returns |
+| **scroll from inside delivery** | **spins** |
+
+Note how nearly this went wrong: step 6 called `tk::ScrollByUnits .s v
+-4`, which with a one-character orient and the default factor 1.0 fails
+**both** halves of the `[string length $orient] == 2 && $factor != 1.0`
+guard, so it skipped the counting branch, and `-4/1.0` is the opposite
+sign of the binding's `-120/-40.0`. Three differences at once between a
+step that returned and a step that hung -- the same trap as
+`canvas-23.*`. 7c and 7d exist to close each of them, and both returned.
+
+Sections 7e0..7e4 split "inside delivery", which still covers four
+things: a non-empty binding at all, a widget command that touches only
+the scrollbar, a scroll of a text widget with **no** `-yscrollcommand`
+back into `.s`, and `update` versus `after`+`vwait`. **Every binding
+counts and prints its own invocation number**, because the one fact
+that decides the shape is whether the binding runs once or forever:
+`wheel #1` and then silence means one delivery whose drain never
+settles (look at what the redisplay queues -- Expose, `pointerDirty`, an
+idle handler that re-posts itself); `wheel #1 #2 #3 ...` means the event
+is being redelivered, which is this port's event source.
+
 The leftover windows are a third thing and not a mystery: `all.tcl` sets
 `-singleproc 1`, so all 97 files are sourced into one wish and every
 toplevel a test forgets to destroy stays up for the life of a process
 that never ends.
 
-**23 of the 24 are known not to be the Plan 9 backend's**, and are worth
-recording so they are not chased again:
+**23 of the 25 are known not to be the Plan 9 backend's** -- the two
+that are, or may be, ours are `geometry-4.7` and the intermittent
+`event-9.16` above. The rest are worth recording so they are not chased
+again:
 
 **Three of the five `event-9.*` were ours, and are fixed; `9.13` and
 `9.14` remain and are generic Tk's.** An
@@ -2045,8 +2108,10 @@ near this port. `sys/lib/tests/tk-geometry-test.tcl` prints `%x %y %w
 %h` for every `<Configure>` rather than counting them, which is what
 separates those two.
 
-That accounts for all 24: 23 are upstream, environment or harness
-limitations, and `geometry-4.7` is the single known-open port bug.
+That accounts for all 25: 23 are upstream, environment or harness
+limitations, `geometry-4.7` is the known-open port bug, and
+`event-9.16` is the intermittent one described at the top of this
+section.
 
 `canvas-23.*`, `listbox-4.7`, `bind-13.14`, `embed-1.1`,
 `fontchooser-2.0/2.1` and `event-9.11/9.12/9.17` **were** ours and are

--- a/sys/lib/tests/tk-mousewheel-test.tcl
+++ b/sys/lib/tests/tk-mousewheel-test.tcl
@@ -31,6 +31,26 @@
 # ORDER MATTERS. A hang has to be killed by hand, so the probe that
 # distinguishes the most comes first and the whole-event-loop case comes
 # last. Whatever the last STEP line says is the one that did not return.
+#
+# WHERE THIS HAS GOT TO. Steps 0-7d all return, and between them they
+# exonerate: crossing delivery (0 -- the <Enter> class binding does run,
+# so Priv(xEvents) is set), the plain event loop (1), every shape of
+# yview scroll including the ceil rounding and both signs (2, 2b, 2c,
+# 2d), moveto (3), .s set (4), update after all of it (5), the
+# ScrollByUnits body called directly with the binding's exact arguments
+# (6, 7c) and twelve times over so the counting branch is reached (7d),
+# and delivery of a wheel event with the class binding removed (7).
+#
+# 7e is where it stops, and its binding is a bare
+# ".t yview scroll 3.0 units" -- no ScrollByUnits at all. So the
+# statement of the bug is now exactly:
+#
+#	scroll alone		returns
+#	delivery alone		returns
+#	scroll INSIDE delivery	spins
+#
+# and sections 7e0..7e4 split that sentence, since "inside delivery"
+# still covers four different things.
 
 proc step {msg} { puts "STEP: $msg"; flush stdout }
 proc done {msg} { puts "   ok: $msg"; flush stdout }
@@ -246,19 +266,127 @@ if {[catch {
  $::tk::Priv(xEvents) yEvents $::tk::Priv(yEvents)"
 }
 
-step "7e. delivery of a <MouseWheel> whose class binding SCROLLS but\
- does not go through ScrollByUnits -- delivery plus a scroll, with the\
- library proc taken out"
+# ------------------------------------------------------------------
+# 7e HANGS, and that is the result everything below is built on. Its
+# binding was a bare
+#
+#	bind Scrollbar <MouseWheel> {.t yview scroll 3.0 units}
+#
+# so tk::ScrollByUnits is INNOCENT: 7c called it with the binding's
+# exact arguments and returned, 7d called it twelve times and returned.
+# Three facts, and only their combination spins:
+#
+#	scroll alone (step 2)		returns
+#	delivery alone (step 7)		returns
+#	scroll from inside delivery	HANGS
+#
+# "Inside delivery" is doing a lot of work in that sentence, and it
+# hides at least four different things. These sections take them one at
+# a time, cheapest first, with the known hang LAST so everything else
+# has printed before the machine has to be poked.
+#
+# The single most useful thing to know is whether the BINDING ITSELF is
+# running over and over -- that separates "the event is being
+# redelivered forever" from "one delivery, and something else will not
+# settle". So every binding here counts itself and prints, which costs
+# nothing when it returns and tells us the answer when it does not.
+
+proc wheelcount {} {
+    set ::n 0
+    set ::trace {}
+}
+
+step "7e0. delivery whose binding does something TRIVIAL -- is a\
+ non-empty binding enough on its own? (step 7's was empty)"
 build
 set saved [bind Scrollbar <MouseWheel>]
-bind Scrollbar <MouseWheel> {.t yview scroll 3.0 units}
+wheelcount
+bind Scrollbar <MouseWheel> {incr ::n}
 event generate .s <Enter>
 event generate .s <MouseWheel> -delta -120
 update
 bind Scrollbar <MouseWheel> $saved
-done "returned; index is [.t index @0,0].  If THIS hangs it is scrolling\
- from inside event delivery, and ScrollByUnits is innocent; if it\
- returns and step 8 does not, it is the proc."
+done "returned; the binding ran $::n time(s).  More than 1 means the\
+ wheel event is being REDELIVERED, which would be this port's event\
+ source rather than anything in Tk."
+
+step "7e1. binding touches the SCROLLBAR only (.s set), not the text --\
+ a widget command from inside delivery, with no text layout involved"
+build
+set saved [bind Scrollbar <MouseWheel>]
+wheelcount
+bind Scrollbar <MouseWheel> {incr ::n; .s set 0.1 0.2}
+event generate .s <Enter>
+event generate .s <MouseWheel> -delta -120
+update
+bind Scrollbar <MouseWheel> $saved
+done "returned; the binding ran $::n time(s)"
+
+step "7e2. binding scrolls a text widget that is NOT wired to the\
+ scrollbar -- scrolling from inside delivery, with no -yscrollcommand\
+ callback back into .s"
+destroy .t .s .u
+pack [scrollbar .s] -fill y -expand 1 -side left
+pack [text .u] -side left
+for {set i 1} {$i < 100} {incr i} {.u insert end "Line $i\n"}
+update
+set saved [bind Scrollbar <MouseWheel>]
+wheelcount
+bind Scrollbar <MouseWheel> {incr ::n; .u yview scroll 3.0 units}
+event generate .s <Enter>
+event generate .s <MouseWheel> -delta -120
+update
+bind Scrollbar <MouseWheel> $saved
+done "returned; the binding ran $::n time(s), index is [.u index @0,0].\
+  If this returns and 7e4 hangs, the loop is the -yscrollcommand\
+ callback, not scrolling as such."
+destroy .u
+
+step "7e3. the wired pair, but delivered through after+vwait rather\
+ than update -- is it 'update' that will not drain, or the event loop?"
+build
+set saved [bind Scrollbar <MouseWheel>]
+wheelcount
+bind Scrollbar <MouseWheel> {incr ::n; .t yview scroll 3.0 units}
+event generate .s <Enter>
+event generate .s <MouseWheel> -delta -120
+after 400 {set ::v7e3 1}
+vwait ::v7e3
+bind Scrollbar <MouseWheel> $saved
+done "returned; the binding ran $::n time(s), index is [.t index @0,0]"
+
+# ------------------------------------------------------------------
+# THE KNOWN HANG. Everything above has printed by now. The binding
+# prints its own invocation number, so the log says which of the two
+# shapes this is even though the script never gets to its "ok" line:
+#
+#   "  wheel #1" and nothing more	one delivery, and the drain after
+#					it never settles -- look at what
+#					the redisplay queues (Expose,
+#					pointerDirty, an idle handler that
+#					re-posts itself).
+#   "  wheel #1 #2 #3 ..." forever	the event is being redelivered,
+#					which is this port's event source.
+#
+# The count is capped so a redelivery loop does not fill the disk; after
+# the cap it goes quiet, and a quiet hang after exactly 8 lines is still
+# the second answer, not the first.
+step "7e4. THE HANG: the wired pair, binding scrolls .t, delivered\
+ through update.  Watch the wheel# lines below"
+build
+set saved [bind Scrollbar <MouseWheel>]
+wheelcount
+bind Scrollbar <MouseWheel> {
+    incr ::n
+    if {$::n <= 8} { puts "  wheel #$::n"; flush stdout }
+    .t yview scroll 3.0 units
+}
+event generate .s <Enter>
+event generate .s <MouseWheel> -delta -120
+update
+bind Scrollbar <MouseWheel> $saved
+done "returned after all; the binding ran $::n time(s), index is\
+ [.t index @0,0]"
 
 step "7f. the real binding body, but run from 'after idle' rather than\
  from an event -- inside the event loop, without the wheel event"


### PR DESCRIPTION
tk-mousewheel-test.tcl step 7e hangs, and its binding is a bare ".t yview scroll 3.0 units" with no tk::ScrollByUnits in it. Steps 7c and 7d had already called the proc with the binding's exact arguments (.s vh -120 -40.0) and twelve times over so the counting branch is reached, and both returned. So the bug reduces to: scroll alone returns, delivery alone returns, scroll from inside delivery spins.

New sections 7e0..7e4 split "inside delivery" -- a non-empty binding at all, a command touching only the scrollbar, a scroll of a text widget with no -yscrollcommand back into .s, and update versus after+vwait. Every binding counts and prints its own invocation number, since the one fact that decides the shape is whether the binding runs once or forever: one delivery whose drain never settles wants a different fix from an event that is redelivered.

The suite is at 25 failing tests, up from 24. The twenty-fifth is event-9.16, which passed the previous run with no C change between them -- so at least one event-9.* test is nondeterministic here. Those tests warp the pointer and this port polls the real /dev/mouse, so a moving mouse can overrule the warp. Recorded with the rule that an event-9.* result is only evidence if it repeats.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs