### PR TITLE
tests: the -yscrollcommand callback is not the loop either

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1899,16 +1899,39 @@ sign of the binding's `-120/-40.0`. Three differences at once between a
 step that returned and a step that hung -- the same trap as
 `canvas-23.*`. 7c and 7d exist to close each of them, and both returned.
 
-Sections 7e0..7e4 split "inside delivery", which still covers four
-things: a non-empty binding at all, a widget command that touches only
-the scrollbar, a scroll of a text widget with **no** `-yscrollcommand`
-back into `.s`, and `update` versus `after`+`vwait`. **Every binding
-counts and prints its own invocation number**, because the one fact
-that decides the shape is whether the binding runs once or forever:
-`wheel #1` and then silence means one delivery whose drain never
-settles (look at what the redisplay queues -- Expose, `pointerDirty`, an
-idle handler that re-posts itself); `wheel #1 #2 #3 ...` means the event
-is being redelivered, which is this port's event source.
+Sections 7e0..7e2 then split "inside delivery", and narrow it twice
+more. **`7e0` (a binding that only does `incr`) and `7e1` (a binding
+that does `.s set`) each ran exactly once and returned**, so delivery
+itself is sound and the binding is not being re-run; it is *what the
+binding does* that matters. **`7e2` hangs with the text widget not
+wired to the scrollbar at all**, which disposes of the
+`-yscrollcommand` callback as well. The table is now
+
+| | |
+|---|---|
+| delivery + trivial binding | returns |
+| delivery + `.s set` | returns |
+| **delivery + a text scroll** | **hangs** |
+| a text scroll on its own | returns |
+
+so it is not delivery, not the scroll, and not the scrollbar -- it is
+the pair. `7e1b`..`7e1d` ask whether "delivery" is even the operative
+half, since an X event handler is only one way to run a script from
+inside the event loop: the same scroll from an **idle** handler, from a
+**timer** (`after 0`), and from a **`<Key>`** binding, none of which
+touch the pointer machinery. If the key event is fine and the wheel is
+not, the pointer path is implicated; if the idle handler hangs too,
+none of the event machinery is.
+
+**Every binding counts and prints its own invocation number**, because
+the one fact that decides the shape is whether the binding runs once or
+forever: `wheel #1` and then silence means one delivery whose drain
+never settles (look at what the redisplay queues -- Expose,
+`pointerDirty`, an idle handler that re-posts itself); `wheel #1 #2
+#3 ...` means the event is being redelivered, which is this port's
+event source. `7e2` originally lacked that printing and so could not
+say which -- worth remembering, since it is one line and the run that
+omits it is wasted.
 
 The leftover windows are a third thing and not a mystery: `all.tcl` sets
 `-singleproc 1`, so all 97 files are sourced into one wish and every

--- a/sys/lib/tests/tk-mousewheel-test.tcl
+++ b/sys/lib/tests/tk-mousewheel-test.tcl
@@ -322,24 +322,92 @@ update
 bind Scrollbar <MouseWheel> $saved
 done "returned; the binding ran $::n time(s)"
 
-step "7e2. binding scrolls a text widget that is NOT wired to the\
- scrollbar -- scrolling from inside delivery, with no -yscrollcommand\
- callback back into .s"
-destroy .t .s .u
-pack [scrollbar .s] -fill y -expand 1 -side left
-pack [text .u] -side left
-for {set i 1} {$i < 100} {incr i} {.u insert end "Line $i\n"}
+# ------------------------------------------------------------------
+# 7e2 HANGS, and its text widget is NOT wired to the scrollbar -- so
+# the -yscrollcommand callback is not the loop either. Combined with
+# 7e0 and 7e1, which each ran their binding exactly once and returned:
+#
+#	delivery + trivial binding	returns
+#	delivery + .s set		returns
+#	delivery + a text scroll	HANGS
+#	a text scroll on its own	returns	(step 2)
+#
+# So it is not delivery, and it is not the scroll, and it is not the
+# scrollbar. What is left is the pair, and the next question is whether
+# "delivery" is even the operative half -- an X event handler is only
+# one of the ways to end up running a script from inside the event
+# loop, and the cheap ones do not need an event at all.
+
+# The unwired pair, built once for the four sections below.
+proc build2 {} {
+    destroy .t .s .u
+    pack [scrollbar .s] -fill y -expand 1 -side left
+    pack [text .u] -side left
+    for {set i 1} {$i < 100} {incr i} {.u insert end "Line $i\n"}
+    update
+}
+
+step "7e1b. scroll the text widget from an IDLE handler -- inside the\
+ event loop, but no event and no binding"
+build2
+after idle {incr ::n; .u yview scroll 3.0 units}
+wheelcount
 update
+done "returned; ran $::n time(s), index is [.u index @0,0]"
+
+step "7e1c. the same from a TIMER handler (after 0) rather than an idle\
+ -- a different queue, still no X event"
+build2
+wheelcount
+after 0 {incr ::n; .u yview scroll 3.0 units}
+after 200 {set ::v7e1c 1}
+vwait ::v7e1c
+done "returned; ran $::n time(s), index is [.u index @0,0]"
+
+step "7e1d. the same from a <Key> binding -- a real X event, but a\
+ keyboard one, so nothing in the pointer machinery is involved"
+build2
+focus -force .s
+update
+bind .s <Key-a> {incr ::n; .u yview scroll 3.0 units}
+wheelcount
+event generate .s <Key-a>
+update
+bind .s <Key-a> {}
+done "returned; ran $::n time(s), index is [.u index @0,0].  If a key\
+ event is fine and the wheel is not, it is the POINTER path."
+
+step "7e2. THE HANG: binding scrolls a text widget that is NOT wired to\
+ the scrollbar.  Watch the wheel# lines"
+build2
 set saved [bind Scrollbar <MouseWheel>]
 wheelcount
-bind Scrollbar <MouseWheel> {incr ::n; .u yview scroll 3.0 units}
+bind Scrollbar <MouseWheel> {
+    incr ::n
+    if {$::n <= 8} { puts "  wheel #$::n"; flush stdout }
+    .u yview scroll 3.0 units
+}
 event generate .s <Enter>
 event generate .s <MouseWheel> -delta -120
 update
 bind Scrollbar <MouseWheel> $saved
-done "returned; the binding ran $::n time(s), index is [.u index @0,0].\
-  If this returns and 7e4 hangs, the loop is the -yscrollcommand\
- callback, not scrolling as such."
+done "returned after all; ran $::n time(s), index is [.u index @0,0]"
+
+step "7e2b. the same WITHOUT the preceding <Enter> -- this binding does\
+ not read Priv(xEvents), so the crossing is not needed here, and\
+ leaving it out asks whether the crossing is part of the loop"
+build2
+set saved [bind Scrollbar <MouseWheel>]
+wheelcount
+bind Scrollbar <MouseWheel> {
+    incr ::n
+    if {$::n <= 8} { puts "  wheel-noenter #$::n"; flush stdout }
+    .u yview scroll 3.0 units
+}
+event generate .s <MouseWheel> -delta -120
+update
+bind Scrollbar <MouseWheel> $saved
+done "returned; ran $::n time(s), index is [.u index @0,0]"
 destroy .u
 
 step "7e3. the wired pair, but delivered through after+vwait rather\


### PR DESCRIPTION
7e0 (a binding that only increments) and 7e1 (a binding that does .s set) each ran exactly once and returned, so delivery is sound and the binding is not being re-run -- it is what the binding does. 7e2 then hangs with the text widget NOT wired to the scrollbar, so the -yscrollcommand callback is out too. What is left is the pair: a text scroll from inside event delivery, where each half alone is fine.

New 7e1b/7e1c/7e1d ask whether "delivery" is even the operative half, since an X event handler is only one way to run a script from inside the event loop: the same scroll from an idle handler, from a timer, and from a <Key> binding, none of which touch the pointer machinery. 7e2b repeats the wheel case without the preceding <Enter>, which this binding does not need.

7e2 also gains the per-invocation printing 7e4 already had. Without it a hang cannot say whether the binding ran once or forever, which are the two shapes that want opposite fixes -- one line, and the run that omits it is wasted.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs