### PR TITLE
tests: 7e1b hangs with no event at all -- but add the missing control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1919,9 +1919,31 @@ the pair. `7e1b`..`7e1d` ask whether "delivery" is even the operative
 half, since an X event handler is only one way to run a script from
 inside the event loop: the same scroll from an **idle** handler, from a
 **timer** (`after 0`), and from a **`<Key>`** binding, none of which
-touch the pointer machinery. If the key event is fine and the wheel is
-not, the pointer path is implicated; if the idle handler hangs too,
-none of the event machinery is.
+touch the pointer machinery.
+
+**`7e1b` hangs -- an idle handler, no event, no binding -- which
+exonerates the whole event and pointer machinery.** But it also
+introduced a second difference and so cannot yet be read that way: the
+sections from `7e1b` on use `build2`, whose widget set is **not** the
+one step 2 scrolled. `build` packs the text first and the scrollbar
+second; `build2` packs the *scrollbar* first, with `-expand 1`, and
+scrolls a different text widget. So "top level vs event loop" and "one
+widget arrangement vs another" changed together -- **the same
+three-differences-at-once trap this file has now been caught by three
+times** (`canvas-23.*`, step 6 versus step 8, and this).
+
+`7e1a1`..`7e1a3` are the missing controls, and they run first:
+`build2`'s own widgets scrolled at the **top level**, and `build`'s
+widgets scrolled from an **idle handler**. Only one of those can hang,
+and which one it is decides whether any of this is about the event loop
+at all.
+
+Both builders now print `winfo width`/`height`/`ismapped` for each
+widget, which is a specific suspicion rather than tidiness: `build2`
+gives the scrollbar the expanding half of the cavity, and **a text
+widget laid out into no height** is a very good way to make
+`tkTextDisp.c` loop while looking exactly like a scrolling bug from
+Tcl.
 
 **Every binding counts and prints its own invocation number**, because
 the one fact that decides the shape is whether the binding runs once or

--- a/sys/lib/tests/tk-mousewheel-test.tcl
+++ b/sys/lib/tests/tk-mousewheel-test.tcl
@@ -71,6 +71,10 @@ proc build {} {
     for {set i 1} {$i < 100} {incr i} {.t insert end "Line $i\n"}
     pack [scrollbar .s -command {.t yview}] -fill y -expand 1 -side left
     update
+    puts "   .t [winfo width .t]x[winfo height .t] mapped\
+ [winfo ismapped .t];  .s [winfo width .s]x[winfo height .s] mapped\
+ [winfo ismapped .s]"
+    flush stdout
 }
 
 puts "--- what the binding actually is on this build ---"
@@ -338,20 +342,59 @@ done "returned; the binding ran $::n time(s)"
 # one of the ways to end up running a script from inside the event
 # loop, and the cheap ones do not need an event at all.
 
-# The unwired pair, built once for the four sections below.
+# The unwired pair, built once for the sections below.
+#
+# NOTE the geometry printout, and do not remove it. This proc packs the
+# SCROLLBAR first, with -expand 1, and the text second -- the reverse
+# of build's order -- so the cavity is divided differently. A text
+# widget laid out into no height at all is a very good way to make
+# tkTextDisp.c loop, and it would look exactly like a scrolling bug
+# from Tcl. One line settles it.
 proc build2 {} {
     destroy .t .s .u
     pack [scrollbar .s] -fill y -expand 1 -side left
     pack [text .u] -side left
     for {set i 1} {$i < 100} {incr i} {.u insert end "Line $i\n"}
     update
+    puts "   .u [winfo width .u]x[winfo height .u] mapped\
+ [winfo ismapped .u];  .s [winfo width .s]x[winfo height .s] mapped\
+ [winfo ismapped .s]"
+    flush stdout
 }
 
-step "7e1b. scroll the text widget from an IDLE handler -- inside the\
- event loop, but no event and no binding"
+# ------------------------------------------------------------------
+# THE CONTROL THAT WAS MISSING, and it has to come first.
+#
+# Step 2 scrolled .t, from build, at the top level, and returned. 7e1b
+# scrolls .u, from build2, inside the event loop, and hangs. That is
+# TWO differences, not one -- the widget set changed when build2 was
+# written -- and this file has now been caught by exactly that three
+# times (canvas-23.*, step 6 vs step 8, and here). So ask each half on
+# its own before believing either.
+step "7e1a1. build2's OWN widgets, scrolled at the TOP LEVEL -- if this\
+ hangs, it is the widget arrangement and not the event loop at all"
 build2
-after idle {incr ::n; .u yview scroll 3.0 units}
 wheelcount
+.u yview scroll 3.0 units
+done "scroll returned; index is [.u index @0,0]"
+step "7e1a2. ... and the update after it"
+update
+done "update returned"
+
+step "7e1a3. build's widgets (.t, the wired pair), scrolled from an\
+ IDLE handler -- the other half: the original widget set, inside the\
+ event loop"
+build
+wheelcount
+after idle {incr ::n; .t yview scroll 3.0 units}
+update
+done "returned; ran $::n time(s), index is [.t index @0,0]"
+
+step "7e1b. build2's widgets scrolled from an IDLE handler -- inside\
+ the event loop, but no event and no binding"
+build2
+wheelcount
+after idle {incr ::n; .u yview scroll 3.0 units}
 update
 done "returned; ran $::n time(s), index is [.u index @0,0]"
 


### PR DESCRIPTION
Scrolling the text widget from an "after idle" handler hangs, with no event, no binding and no pointer involved. Read alone that exonerates the whole event and pointer machinery.

It cannot be read alone yet. build2 -- written for 7e2 -- is not the widget set step 2 scrolled: build packs the text first and the scrollbar second, build2 packs the scrollbar first with -expand 1 and scrolls a different text widget. So "top level vs event loop" and "one arrangement vs another" changed together, which is the same three-differences-at-once trap as canvas-23.* and step 6 vs step 8.

7e1a1..7e1a3 are the controls and run first: build2's own widgets scrolled at the top level, and build's widgets scrolled from an idle handler. Only one of those can hang.

Both builders now print winfo width/height/ismapped. That is a suspicion, not tidiness: build2 gives the scrollbar the expanding half of the cavity, and a text widget laid out into no height is a good way to make tkTextDisp.c loop while looking like a scrolling bug from Tcl.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs