### PR TITLE
tests: the hang is the redisplay, not the event loop -- add the 2x2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1921,29 +1921,43 @@ inside the event loop: the same scroll from an **idle** handler, from a
 **timer** (`after 0`), and from a **`<Key>`** binding, none of which
 touch the pointer machinery.
 
-**`7e1b` hangs -- an idle handler, no event, no binding -- which
-exonerates the whole event and pointer machinery.** But it also
-introduced a second difference and so cannot yet be read that way: the
-sections from `7e1b` on use `build2`, whose widget set is **not** the
-one step 2 scrolled. `build` packs the text first and the scrollbar
-second; `build2` packs the *scrollbar* first, with `-expand 1`, and
-scrolls a different text widget. So "top level vs event loop" and "one
-widget arrangement vs another" changed together -- **the same
-three-differences-at-once trap this file has now been caught by three
-times** (`canvas-23.*`, step 6 versus step 8, and this).
+**The event loop is not the operative half, and every sentence above
+about "inside delivery" was describing the wrong thing.** The control
+settled it: `build2`'s widgets scrolled **at the top level** --
+nothing delivered, no binding, no idle handler -- and the *scroll
+returned*. The **`update` after it** is what hangs. So the sequence is
+scroll completes, then the **redisplay** that follows never settles;
+every earlier section that hung was hanging in its trailing `update`,
+not in the delivery it was written to test.
 
-`7e1a1`..`7e1a3` are the missing controls, and they run first:
-`build2`'s own widgets scrolled at the **top level**, and `build`'s
-widgets scrolled from an **idle handler**. Only one of those can hang,
-and which one it is decides whether any of this is about the event loop
-at all.
+Geometry is ruled out too, and cheaply: both text widgets come out
+`486x246` and mapped, so a text widget laid out into no height -- a
+good way to make `tkTextDisp.c` loop -- is not it.
 
-Both builders now print `winfo width`/`height`/`ismapped` for each
-widget, which is a specific suspicion rather than tidiness: `build2`
-gives the scrollbar the expanding half of the cavity, and **a text
-widget laid out into no height** is a very good way to make
-`tkTextDisp.c` loop while looking exactly like a scrolling bug from
-Tcl.
+What remains is the difference between `build` and `build2`, and there
+are **two**: pack order, and whether the pair is wired to each other.
+The 2x2 in the test asks all four with **one widget name throughout**,
+changing one thing at a time, known-hanging arrangement last:
+
+| | pack order | wired | |
+|---|---|---|---|
+| A | text first | yes | `build`'s; step 2+5 returned |
+| B | text first | no | |
+| C | scrollbar first | yes | |
+| D | scrollbar first | no | `build2`'s; hangs |
+
+and each outcome points somewhere different:
+
+- **only D** -- the pair of differences, not either alone.
+- **C and D** -- **pack order**, i.e. the text widget sitting at `x=10`
+  rather than `x=0`. A scroll is a copy of a rectangle from one place
+  to another, and this port has a documented history of confusing
+  parent-relative with screen coordinates in exactly that way (see the
+  stacking section above, where `WindowAtPoint` and
+  `GenerateMouseEvent` both made it).
+- **B and D** -- the **wiring**: with `-yscrollcommand` set, `.s set`
+  runs after every scroll and evidently settles something that
+  otherwise does not.
 
 **Every binding counts and prints its own invocation number**, because
 the one fact that decides the shape is whether the binding runs once or

--- a/sys/lib/tests/tk-mousewheel-test.tcl
+++ b/sys/lib/tests/tk-mousewheel-test.tcl
@@ -363,40 +363,92 @@ proc build2 {} {
 }
 
 # ------------------------------------------------------------------
-# THE CONTROL THAT WAS MISSING, and it has to come first.
+# THE 2x2, and it supersedes everything above.
 #
-# Step 2 scrolled .t, from build, at the top level, and returned. 7e1b
-# scrolls .u, from build2, inside the event loop, and hangs. That is
-# TWO differences, not one -- the widget set changed when build2 was
-# written -- and this file has now been caught by exactly that three
-# times (canvas-23.*, step 6 vs step 8, and here). So ask each half on
-# its own before believing either.
-step "7e1a1. build2's OWN widgets, scrolled at the TOP LEVEL -- if this\
- hangs, it is the widget arrangement and not the event loop at all"
-build2
-wheelcount
-.u yview scroll 3.0 units
-done "scroll returned; index is [.u index @0,0]"
-step "7e1a2. ... and the update after it"
-update
-done "update returned"
+# 7e1a1 answered the control: build2's widgets scrolled AT THE TOP
+# LEVEL -- the scroll RETURNED, and the "update" after it hung. So the
+# event loop is not the operative half after all: nothing is delivered,
+# no binding runs, the scroll completes, and the REDISPLAY that follows
+# never settles. Every section above that talked about "inside
+# delivery" was describing the update that came after it.
+#
+# Geometry is not the answer either: both text widgets come out
+# 486x246 and mapped, so the zero-height layout loop is ruled out.
+#
+# What is left is the difference between build and build2, and there
+# are TWO of them -- pack order and whether the pair is wired to each
+# other. That is the same mistake as before, so this asks all four
+# combinations with ONE widget name throughout, changing one thing at a
+# time. The known-hanging arrangement is last so the other three print.
+#
+#	A  text first,      wired	build's arrangement; step 2+5 returned
+#	B  text first,      unwired
+#	C  scrollbar first, wired
+#	D  scrollbar first, unwired	build2's arrangement; hangs
+#
+# What each outcome means:
+#   only D hangs		it is the pair of differences, not either
+#				alone -- look at what an unwired scrollbar
+#				packed first leaves undamaged
+#   C and D hang		PACK ORDER, i.e. the text widget sitting at
+#				x=10 instead of x=0. This port has a
+#				documented history of confusing
+#				parent-relative and screen coordinates in
+#				exactly this way (see the stacking section
+#				in CLAUDE.md), and a scroll is a copy of a
+#				rectangle from one place to another.
+#   B and D hang		the WIRING: with -yscrollcommand set, .s set
+#				runs after every scroll and evidently
+#				settles something that otherwise does not.
 
-step "7e1a3. build's widgets (.t, the wired pair), scrolled from an\
- IDLE handler -- the other half: the original widget set, inside the\
- event loop"
-build
+proc pair {sbfirst wired} {
+    destroy .t .s
+    if {$wired} {
+	set t [text .t -yscrollcommand {.s set}]
+	set s [scrollbar .s -command {.t yview}]
+    } else {
+	set t [text .t]
+	set s [scrollbar .s]
+    }
+    if {$sbfirst} {
+	pack $s -fill y -expand 1 -side left
+	pack $t -side left
+    } else {
+	pack $t -side left
+	pack $s -fill y -expand 1 -side left
+    }
+    for {set i 1} {$i < 100} {incr i} {.t insert end "Line $i\n"}
+    update
+    puts "   .t at [winfo x .t],[winfo y .t] size\
+ [winfo width .t]x[winfo height .t] mapped [winfo ismapped .t];\
+ .s at [winfo x .s],[winfo y .s] size [winfo width .s]x[winfo height .s]"
+    flush stdout
+}
+
+foreach {tag sbfirst wired what} {
+    A 0 1 {text packed first, WIRED -- this is build's arrangement}
+    B 0 0 {text packed first, unwired}
+    C 1 1 {scrollbar packed first, WIRED}
+    D 1 0 {scrollbar packed first, unwired -- this is build2's, and it hangs}
+} {
+    step "7e1$tag. $what: scroll at the top level"
+    pair $sbfirst $wired
+    .t yview scroll 3.0 units
+    done "scroll returned; index is [.t index @0,0]"
+    step "7e1$tag. ... and the update after it -- THIS is the one that\
+ hangs for D"
+    update
+    done "update returned"
+}
+
+step "7e1b. arrangement A scrolled from an IDLE handler -- with the\
+ update question settled, this asks whether the event loop matters at\
+ all on an arrangement that works"
+pair 0 1
 wheelcount
 after idle {incr ::n; .t yview scroll 3.0 units}
 update
 done "returned; ran $::n time(s), index is [.t index @0,0]"
-
-step "7e1b. build2's widgets scrolled from an IDLE handler -- inside\
- the event loop, but no event and no binding"
-build2
-wheelcount
-after idle {incr ::n; .u yview scroll 3.0 units}
-update
-done "returned; ran $::n time(s), index is [.u index @0,0]"
 
 step "7e1c. the same from a TIMER handler (after 0) rather than an idle\
  -- a different queue, still no X event"


### PR DESCRIPTION
7e1a1 scrolled build2's widgets at the TOP LEVEL: the scroll returned, and the update after it hung. Nothing delivered, no binding, no idle handler. So the event loop is not the operative half and every earlier section was hanging in its trailing update rather than in the delivery it was written to test.

Geometry is out as well: both text widgets come out 486x246 and mapped, so a zero-height layout loop is not it.

What is left is build vs build2, which differ in two ways: pack order, and whether the pair is wired to each other. The 2x2 asks all four with one widget name throughout, one variable at a time, the known-hanging arrangement last. Only D hanging means the pair; C and D means pack order, i.e. the text widget at x=10 rather than x=0, which matters because a scroll is a copy of a rectangle and this port has a history of confusing parent-relative with screen coordinates; B and D means the -yscrollcommand callback settles something that otherwise does not.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs