### PR TITLE
tk: TkScrollWindow waited for a NoExpose this port never sends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1966,7 +1966,49 @@ returns or re-posts its own idle handler forever. No event is involved
 and the Expose theory is dead. Everything from here is `tkTextDisp.c`
 and what this port's drawing does underneath it.
 
-**Misleading: the distances do not mean what they look like.**
+**FOUND: `TkScrollWindow` waits for an event this port never sends.**
+`unix/tkUnixDraw.c` -- which `sys/src/ape/lib/tk/mkfile:147` builds --
+issues the `XCopyArea` and then waits for the X server to say how much
+of it succeeded:
+
+```c
+while (!info.done) {
+	Tcl_ServiceEvent(TCL_WINDOW_EVENTS);
+}
+```
+
+`info.done` is set **only** by a `NoExpose` or the last
+`GraphicsExpose` for that window, and **neither event name appears
+anywhere in `plan9/`** -- `XCopyArea` there begins `(void)gc;` and
+never looks at `graphics_exposures`. So the loop has no exit at all: an
+infinite loop inside one Tk call, which is exactly "`update idletasks`
+never returns, CPU pinned, nothing written".
+
+`win/tkWinDraw.c` and `macosx/tkMacOSXImage.c` each define
+`TkScrollWindow` themselves for precisely this reason and neither waits
+for an event. **The condition is not the operating system, it is that
+there is no X server to answer** -- the same shape as
+`SendEnterLeaveForDestroy` above. `plan9/tkPlan9Draw.c` now defines it:
+copy, then return 0, which is what a `NoExpose` means. The unix version
+is wrapped in `#ifndef PLAN9` rather than dropped from the mkfile,
+because the same file's `Tk_DrawHighlightBorder` and `TkpDrawFrameEx`
+are still wanted.
+
+**Do not "fix" this by sending NoExpose from `XCopyArea` instead.**
+`tkGC.c:188` defaults `graphics_exposures` to **True** for every GC Tk
+creates, so that would enqueue an event for every copy in the program
+-- every photo blit, every 3D border -- into a 1024-entry ring that
+drops silently when full.
+
+The one thing lost is the case X repairs and this port cannot: a copy
+whose source was overlapped by a sibling window has already picked up
+the sibling's pixels, and with no backing store there is no record of
+it. Returning the whole rectangle as damage would repaint correctly and
+make every scroll a full redraw, which is the cost the copy exists to
+avoid.
+
+**Misleading, and the reason this took four extra rounds: the distances
+do not mean what they look like.**
 
 | | reaches | |
 |---|---|---|
@@ -1975,26 +2017,30 @@ and what this port's drawing does underneath it.
 | `scroll 100 units` | 77, clamped to the end | ok |
 | `scroll 20 units` | **21** | **hangs** |
 
-`moveto 0.5` lands mid-file and works, so the overlap/full-repaint
-story above is **wrong** -- a mid-file top index is reachable without
-hanging. But those two rows differ in *two* ways again, the command and
-the position, which is the fourth time in this file. Section 10 reaches
-the same position by both commands:
+**`moveto 0.2` reaches index 21 and hangs**, while `moveto 0.5` reaches
+51 and does not -- same command, so `YScrollByLines` and its
+display-line walk are innocent, and so is the command/position question
+the test was built to settle.
 
-- **`scroll 50 units` (to 51, where `moveto` survived) hangs** -- it is
-  the **command**. `yview scroll N units` goes through
-  `YScrollByLines`, which walks display lines with `LayoutDLine`;
-  `moveto` does not. That is the loop with the `do/while` that never
-  ends if a display line comes back zero bytes long -- see the note in
-  `tk-mousewheel-test.tcl`'s header, which suspected it early and was
-  set aside when the scroll commands all returned. **They return
-  because the walk is not where it hangs; the redisplay that follows
-  is.**
-- **it works** -- it is the **position**, and both commands are
-  innocent.
+The overlap story *was* right; **the arithmetic used to refute it was
+wrong.** `moveto 1.0` reports a top index of 77 on a 100-display-line
+widget, so about **24 lines are visible**, not the ~15 assumed when the
+theory was dropped. Measured from the freshly-built top:
 
-`scroll ... pixels` and the old `yview <index>` form are asked too:
-they reach the same place without the display-line walk.
+| | distance | overlap? | |
+|---|---|---|---|
+| `moveto 1.0` | 76 | no | ok |
+| `moveto 0.5` | 50 | no | ok |
+| `moveto 0.2` | 20 | **yes** | **hangs** |
+| `scroll 20 units` | 20 | **yes** | **hangs** |
+| `scroll 3 units` | 3 | **yes** | **hangs** |
+
+Every row fits: `tkTextDisp.c` copies only when the old and new views
+overlap and repaints outright when they do not, so only the copying
+path reaches `TkScrollWindow`. **Check what a widget's actual geometry
+is before ruling a mechanism out on line counts** -- one `winfo height`
+divided by the line height would have kept this on the right track two
+rounds earlier.
 
 **This now lives in `sys/lib/tests/tk-textscroll-hang-test.tcl`**, and
 `tk-mousewheel-test.tcl` is finished -- kept as the record of how the

--- a/sys/lib/tests/tk-textscroll-hang-test.tcl
+++ b/sys/lib/tests/tk-textscroll-hang-test.tcl
@@ -94,6 +94,54 @@ proc try {tag what script} {
     done "update returned"
 }
 
+# ------------------------------------------------------------------
+# THE ANSWER, found by case 3 below plus one grep.
+#
+# "moveto 0.2" reaches index 21 and hangs; "moveto 0.5" reaches 51 and
+# does not. Same command, so the display-line walk this file was built
+# to accuse is innocent -- it is the POSITION, or rather the distance.
+#
+# unix/tkUnixDraw.c's TkScrollWindow, which this port builds, issues the
+# XCopyArea and then waits for the X server to say how much of it
+# succeeded:
+#
+#	while (!info.done) {
+#	    Tcl_ServiceEvent(TCL_WINDOW_EVENTS);
+#	}
+#
+# info.done is set ONLY by a NoExpose or the last GraphicsExpose for
+# that window, and neither event name appears anywhere in plan9/. So
+# the loop has no exit: an infinite loop inside one Tk call, which is
+# precisely "update idletasks never returns, CPU pinned, nothing
+# written". win/tkWinDraw.c and macosx/tkMacOSXImage.c define
+# TkScrollWindow themselves for this reason; plan9/tkPlan9Draw.c now
+# does too.
+#
+# WHY ONLY SHORT SCROLLS. tkTextDisp.c copies only when the old and new
+# views overlap, and repaints outright when they do not -- so only the
+# copying path reaches TkScrollWindow at all. The widget here shows
+# about 24 lines ("moveto 1.0" reports a top index of 77 of 100), so:
+#
+#	moveto 1.0	 76 lines	no overlap	ok
+#	moveto 0.5	 50 lines	no overlap	ok
+#	moveto 0.2	 20 lines	OVERLAP		hung
+#	scroll 20 units	 20 lines	OVERLAP		hung
+#	scroll 3 units	  3 lines	OVERLAP		hung
+#
+# The overlap theory was dropped one round earlier on the strength of a
+# guess that ~15 lines were visible. It is 24. Measure the widget.
+#
+# WITH THE FIX IN, every case below returns and the file runs to the
+# end. It is kept as the regression test: case 10 is the wheel scroll
+# scrollbar-10.1 actually performs.
+
+puts "--- visible lines, since the whole rule turns on this ---"
+pair
+puts "   .t is [winfo height .t]px tall, top index [.t index @0,0],\
+ bottom index [.t index @0,[expr {[winfo height .t]-1}]]"
+flush stdout
+
+puts ""
 puts "--- cases expected to return ---"
 flush stdout
 

--- a/sys/src/external/tk/plan9/tkPlan9Draw.c
+++ b/sys/src/external/tk/plan9/tkPlan9Draw.c
@@ -207,6 +207,73 @@ XCopyArea(Display *display, Drawable src, Drawable dst, GC gc,
     return 0;
 }
 
+/*
+ * TkScrollWindow --
+ *
+ *	Scroll a rectangle of a window in place, and report how much of it
+ *	the platform could NOT copy. Returns 0 for "all of it arrived", 1
+ *	with damageRgn filled in otherwise.
+ *
+ *	Note what the return value is not: it is not the strip the scroll
+ *	uncovers. tkTextDisp.c knows about that already and redraws it
+ *	itself (tkTextDisp.c:4349 and the comment at 4513). This reports
+ *	only the EXTRA damage from a copy that could not be satisfied --
+ *	on X, the part of the source that was obscured by another window,
+ *	which the server reports with GraphicsExpose.
+ *
+ *	WHY THIS IS HERE AT ALL. unix/tkUnixDraw.c's version issues the
+ *	XCopyArea and then waits for the server to say which it was:
+ *
+ *		while (!info.done) {
+ *		    Tcl_ServiceEvent(TCL_WINDOW_EVENTS);
+ *		}
+ *
+ *	and info.done is set ONLY by a NoExpose or the last GraphicsExpose
+ *	for that window. This port sends neither -- the two event names
+ *	appear nowhere in plan9/ -- so that loop had no exit at all. It is
+ *	an infinite loop inside one Tk call, which is why it presented as
+ *	"update idletasks never returns" with the CPU pinned and nothing
+ *	written, and why only a scroll SHORT ENOUGH FOR THE OLD AND NEW
+ *	VIEWS TO OVERLAP could trigger it: tkTextDisp.c only copies when
+ *	there is something worth copying, and repaints outright otherwise.
+ *	A three-line wheel scroll overlaps; "yview moveto 0.5" on a
+ *	99-line file does not.
+ *
+ *	win/tkWinDraw.c and macosx/tkMacOSXImage.c each define this
+ *	function themselves for exactly this reason, and neither waits for
+ *	an event. The condition is not the operating system, it is that
+ *	there is no X server to answer.
+ *
+ *	We answer 0 -- what a NoExpose means -- because nothing here can
+ *	say otherwise: drawing goes straight into the one rio window with
+ *	no backing store, so a copy whose source was overlapped by a
+ *	sibling has already picked up the sibling's pixels and there is no
+ *	record of it having happened. That is a visual artefact in a case
+ *	X repairs and this port cannot; returning the whole rectangle as
+ *	damage instead would repaint correctly but make every scroll a
+ *	full redraw, which is the cost the copy exists to avoid.
+ */
+int
+TkScrollWindow(
+    Tk_Window tkwin,		/* The window to be scrolled. */
+    GC gc,			/* GC for window to be scrolled. */
+    int x, int y, int width, int height,
+				/* Position rectangle to be scrolled. */
+    int dx, int dy,		/* Distance rectangle should be moved. */
+    Region damageRgn)		/* Region to accumulate damage in. */
+{
+    XCopyArea(Tk_Display(tkwin), Tk_WindowId(tkwin), Tk_WindowId(tkwin), gc,
+	    x, y, (unsigned) width, (unsigned) height, x + dx, y + dy);
+
+    /*
+     * Leave damageRgn as the caller set it up -- empty -- and say so.
+     * Do not call XEmptyRegion here to decide: the caller only consults
+     * damageRgn when we return 1.
+     */
+    (void) damageRgn;
+    return 0;
+}
+
 int
 XCopyPlane(Display *display, Drawable src, Drawable dst, GC gc,
            int src_x, int src_y,

--- a/sys/src/external/tk/unix/tkUnixDraw.c
+++ b/sys/src/external/tk/unix/tkUnixDraw.c
@@ -15,6 +15,25 @@
 #include "tkUnixInt.h"
 #endif
 
+#ifndef PLAN9
+/*
+ * TkScrollWindow below waits for the X server to report, with a
+ * GraphicsExpose or a NoExpose, how much of the copy it could not
+ * satisfy. Its loop
+ *
+ *	while (!info.done) {
+ *	    Tcl_ServiceEvent(TCL_WINDOW_EVENTS);
+ *	}
+ *
+ * has NO other exit, so on a platform with no server to send those it
+ * spins forever with the CPU pinned. That is why win/tkWinDraw.c and
+ * macosx/tkMacOSXImage.c each define TkScrollWindow themselves rather
+ * than build this one; plan9/tkPlan9Draw.c now does the same, and the
+ * rest of this file -- Tk_DrawHighlightBorder and TkpDrawFrameEx -- is
+ * still wanted there, which is why the guard is here rather than in the
+ * mkfile.
+ */
+
 /*
  * The following structure is used to pass information to ScrollRestrictProc
  * from TkScrollWindow.
@@ -171,6 +190,7 @@ ScrollRestrictProc(
     }
     return TK_DISCARD_EVENT;
 }
+#endif /* !PLAN9 */
 
 /*
  *----------------------------------------------------------------------


### PR DESCRIPTION
This is the scrollbar.test hang, and it is an infinite loop inside one Tk call rather than anything to do with events, bindings, the mouse wheel or tk::ScrollByUnits.

unix/tkUnixDraw.c, which sys/src/ape/lib/tk/mkfile builds, issues the XCopyArea for a scroll and then waits for the X server to report how much of it succeeded:

	while (!info.done) {
		Tcl_ServiceEvent(TCL_WINDOW_EVENTS);
	}

info.done is set only by a NoExpose or the last GraphicsExpose for that window. Neither event name appears anywhere in plan9/ -- XCopyArea there opens with (void)gc and never looks at graphics_exposures -- so the loop has no exit at all.

win/tkWinDraw.c and macosx/tkMacOSXImage.c each define TkScrollWindow themselves for exactly this reason and neither waits for an event: the condition is not the operating system, it is that there is no X server to answer, the same shape as SendEnterLeaveForDestroy. plan9 defines it now -- copy, then return 0, which is what a NoExpose means. The unix version is wrapped in #ifndef PLAN9 rather than dropped from the mkfile, since that file's Tk_DrawHighlightBorder and TkpDrawFrameEx are still wanted.

Not fixed by sending NoExpose from XCopyArea instead: tkGC.c:188 defaults graphics_exposures to True for every GC Tk creates, so that would enqueue an event for every copy in the program into a 1024-entry ring that drops silently when full.

Only short scrolls hang because tkTextDisp.c copies only when the old and new views overlap and repaints outright otherwise, so only the copying path reaches TkScrollWindow. The widget shows ~24 lines, so distances of 3 and 20 overlap and hang while 50 and 76 do not. The overlap theory had been dropped a round earlier on a guess that ~15 lines were visible; it is 24, and one winfo height would have settled it.

Both files pass the host gcc syntax check.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs