### PR TITLE
tk: implement TkWmStackorderToplevel, and make the wm usage error gen…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1730,9 +1730,23 @@ below. Everything above this line in the section was a 62-file prefix;
 this is the first measurement of the whole thing, and the list has been
 re-derived rather than extended.
 
-**485 failing tests** (970 `FAILED` lines, two per test), up from 25 --
-which is the expected shape of measuring 35 files for the first time,
-not a regression. Attributed by file:
+**345 failing tests** after the `wm` work below; **485** on the first
+full run, up from 25 -- which was the expected shape of measuring 35
+files for the first time, not a regression. Attributed by file, first
+full run then after `wm`:
+
+| file | 485-run | 345-run |
+|---|---|---|
+| `wm.test` | 202 | 130 |
+| `unixWm.test` | 129 | 62 |
+| `unixEmbed.test` | 29 | 29 |
+| `textDisp.test` | 23 | 23 |
+| `select.test` | 23 | 23 |
+| `unixSelect.test` | 18 | 18 |
+| `systray.test` | 13 | 13 |
+| `winfo.test` | 6 | 4 |
+
+The first-run breakdown, kept because the reasoning below refers to it:
 
 | file | failing |
 |---|---|
@@ -1755,13 +1769,38 @@ an implementation cannot repeat this silently. (A check that the two
 lists match: `awk` the `enum` block for `OPT_*` and compare against
 `grep -o 'case OPT_[A-Z]*'` -- 33 and 33 today.)
 
+**Result: 485 -> 345.** `wm.test` 202 -> 130, `unixWm.test` 129 -> 62.
+Every storage subcommand dropped to one remaining failure each, and
+that one is the usage case below.
+
 Three of them were worth more than the storage:
 
-- **`wm stackorder` answered an empty list**, which is 32 tests on its
-  own and was needless: `TkWmStackorderToplevel` is implemented *in the
-  same file* and `dispPtr->firstWmPtr` has kept the order all along.
-  It now returns the list, and the `isabove`/`isbelow` form with
-  upstream's not-a-toplevel and not-mapped errors.
+- **`wm stackorder` answered an empty list**, 32 tests on its own.
+  **The first attempt at this made it worse, on a claim that was
+  false.** The note here said `TkWmStackorderToplevel` was "implemented
+  in the same file" -- read out of a `grep` of the *name*, never the
+  body. It was a three-line stub returning NULL. So rewriting
+  `wm stackorder` to call it turned 31 of the 32 from answering an
+  empty list into raising an error. **Open the function before saying
+  it exists**; a grep hit is a name, not an implementation.
+
+  It is real now. On X this needs `XQueryTree`, because the server owns
+  the order and a window manager may have reparented every toplevel;
+  here *this port* owns it and `dispPtr->firstWmPtr` is already the
+  order the function must return, bottom first. So the whole job is to
+  intersect that list with the mapped, non-embedded toplevels under
+  `parentPtr` -- upstream's `TkWmStackorderToplevelWrapperMap` walk,
+  minus the hash table, since there are no wrapper windows to key on.
+
+- **The usage message was per-subcommand where it must be generic.**
+  `wm stackorder` with no window answered
+  `wm stackorder window ?isabove|isbelow window?`; every Tk answers
+  `wm option window ?arg ...?`. Upstream checks `objc < 3` once, after
+  resolving the subcommand index and before dispatching, so a
+  subcommand's own `Tcl_WrongNumArgs` is only ever reached with a
+  window present. That is **one failing test per subcommand** -- the
+  `wm-*-1.1` "usage" cases -- and it is why the storage subcommands
+  each still had exactly one failure after being implemented.
 - **`wm iconify` and `wm grid` had no case at all**, so the new erroring
   `default:` would have turned two silent no-ops into hard failures --
   caught before shipping only by listing `opts[]` against the cases.

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -1128,11 +1128,102 @@ TkWmRemoveFromColormapWindows(TkWindow *winPtr)
     (void)winPtr;
 }
 
+/*
+ * Count, then collect, the toplevels in winPtr's family that would
+ * appear in a stacking order: mapped, a toplevel, and not embedded.
+ * Upstream's TkWmStackorderToplevelWrapperMap does the same walk into a
+ * hash table keyed by the X wrapper window; there are no wrappers here,
+ * so an array and a linear scan are enough for the handful of toplevels
+ * a program has.
+ */
+static int
+WmStackCount(TkWindow *winPtr)
+{
+    TkWindow *childPtr;
+    int n = 0;
+
+    if (Tk_IsMapped((Tk_Window) winPtr) && Tk_IsTopLevel(winPtr)
+            && !Tk_IsEmbedded(winPtr))
+	n = 1;
+    for (childPtr = winPtr->childList; childPtr != NULL;
+	    childPtr = childPtr->nextPtr)
+	n += WmStackCount(childPtr);
+    return n;
+}
+
+static void
+WmStackCollect(TkWindow *winPtr, TkWindow **list, int *np)
+{
+    TkWindow *childPtr;
+
+    if (Tk_IsMapped((Tk_Window) winPtr) && Tk_IsTopLevel(winPtr)
+            && !Tk_IsEmbedded(winPtr))
+	list[(*np)++] = winPtr;
+    for (childPtr = winPtr->childList; childPtr != NULL;
+	    childPtr = childPtr->nextPtr)
+	WmStackCollect(childPtr, list, np);
+}
+
+/*
+ * TkWmStackorderToplevel --
+ *
+ *	The toplevels under parentPtr, bottom of the stacking order first,
+ *	NULL-terminated; the caller ckfrees it. NULL means failure, which
+ *	is not the same as an empty list and is what "wm stackorder"
+ *	reports as an error.
+ *
+ *	THIS WAS A STUB RETURNING NULL, and the note in CLAUDE.md claiming
+ *	it was implemented was wrong -- read from a grep of the name
+ *	rather than the body. That mattered: `wm stackorder` was rewritten
+ *	to call it, so 31 of wm.test's 32 stackorder tests went from
+ *	answering an empty list to raising an error.
+ *
+ *	On X this needs XQueryTree, because the server owns the order and
+ *	a window manager may have reparented every toplevel into a frame.
+ *	Here this port owns it: dispPtr->firstWmPtr is the list, bottom
+ *	first (see the stacking-order section in CLAUDE.md), which is
+ *	already the order this function must return. So the whole job is
+ *	to intersect that list with the family under parentPtr.
+ */
 TkWindow **
 TkWmStackorderToplevel(TkWindow *parentPtr)
 {
-    (void)parentPtr;
-    return NULL;
+    TkWindow **windows, **found;
+    WmInfo *wmPtr;
+    int n, i, k = 0, got = 0;
+
+    n = WmStackCount(parentPtr);
+    windows = (TkWindow **) ckalloc((n + 1) * sizeof *windows);
+    if (n == 0) {
+	windows[0] = NULL;
+	return windows;
+    }
+    found = (TkWindow **) ckalloc(n * sizeof *found);
+    WmStackCollect(parentPtr, found, &got);
+
+    for (wmPtr = parentPtr->dispPtr->firstWmPtr; wmPtr != NULL;
+	    wmPtr = wmPtr->nextPtr)
+	for (i = 0; i < got; i++)
+	    if (found[i] == wmPtr->winPtr) {
+		windows[k++] = found[i];
+		found[i] = NULL;		/* once only */
+		break;
+	    }
+
+    /*
+     * Anything mapped but absent from firstWmPtr, in discovery order.
+     * There should be none -- every toplevel is linked in by
+     * TkWmNewWindow -- but returning a SHORT list would be a silently
+     * wrong stacking order, and "wm stackorder ." answering the empty
+     * list is one of the cases the tests check by name.
+     */
+    for (i = 0; i < got; i++)
+	if (found[i] != NULL)
+	    windows[k++] = found[i];
+
+    windows[k] = NULL;
+    ckfree(found);
+    return windows;
 }
 
 void
@@ -1623,6 +1714,22 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
     if (Tcl_GetIndexFromObjStruct(interp, objv[1], opts,
             sizeof(char *), "option", 0, &index) != TCL_OK)
         return TCL_ERROR;
+
+    /*
+     * Every subcommand needs a window, and the message for leaving it
+     * out is the GENERIC one -- "wm option window ?arg ...?" -- not the
+     * per-subcommand usage. Upstream checks this after resolving the
+     * index and before dispatching, and each subcommand's own
+     * Tcl_WrongNumArgs is then only ever reached with a window present.
+     *
+     * Without it every "wm <sub>" with no window answered
+     * "wm stackorder window ?isabove|isbelow window?" and so on, which
+     * is one failing test per subcommand -- the wm-*-1.1 "usage" cases.
+     */
+    if (objc < 3) {
+        Tcl_WrongNumArgs(interp, 1, objv, "option window ?arg ...?");
+        return TCL_ERROR;
+    }
 
     /*
      * Resolve the window. This used to be skipped entirely, so every


### PR DESCRIPTION
…eric

485 -> 345 from the previous commit, but stackorder went the wrong way and the reason is a claim I made without checking.

TkWmStackorderToplevel was described here as "implemented in the same file". It was a three-line stub returning NULL -- read out of a grep of the name, never the body. Rewriting wm stackorder to call it therefore turned 31 of its 32 tests from answering an empty list into raising an error. A grep hit is a name, not an implementation.

It is real now. On X it needs XQueryTree because the server owns the order and a wm may have reparented every toplevel; here this port owns it and dispPtr->firstWmPtr is already the required order, bottom first, so the job is to intersect that list with the mapped, non-embedded toplevels under parentPtr -- upstream's WrapperMap walk without the hash table, since there are no wrapper windows to key on. Anything mapped but absent from firstWmPtr is appended rather than dropped: a short list would be a silently wrong stacking order.

Second bug, one failing test per subcommand: the usage message for a missing window was per-subcommand where every Tk gives the generic "wm option window ?arg ...?". Upstream checks objc < 3 once, after resolving the index and before dispatching. That is why each storage subcommand still had exactly one failure after being implemented.

The host gcc check earned its keep again: the first version of this stranded "TkWindow **" above a comment, which is the trap in the "Syntax-check Tk's Plan 9 backend" section, met from a new direction.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs