### PR TITLE
tk: wm minsize/maxsize units, and the three real transient rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1730,21 +1730,24 @@ below. Everything above this line in the section was a 62-file prefix;
 this is the first measurement of the whole thing, and the list has been
 re-derived rather than extended.
 
-**345 failing tests** after the `wm` work below; **485** on the first
-full run, up from 25 -- which was the expected shape of measuring 35
-files for the first time, not a regression. Attributed by file, first
-full run then after `wm`:
+**287 failing tests**, from **485** on the first full run -- which was
+up from 25 only because that run was the first to measure 35 files at
+all, not a regression. Attributed by file across the three runs:
 
-| file | 485-run | 345-run |
-|---|---|---|
-| `wm.test` | 202 | 130 |
-| `unixWm.test` | 129 | 62 |
-| `unixEmbed.test` | 29 | 29 |
-| `textDisp.test` | 23 | 23 |
-| `select.test` | 23 | 23 |
-| `unixSelect.test` | 18 | 18 |
-| `systray.test` | 13 | 13 |
-| `winfo.test` | 6 | 4 |
+| file | run 1 | run 2 | run 3 |
+|---|---|---|---|
+| `wm.test` | 202 | 130 | 74 |
+| `unixWm.test` | 129 | 62 | 60 |
+| `unixEmbed.test` | 29 | 29 | 29 |
+| `textDisp.test` | 23 | 23 | 23 |
+| `select.test` | 23 | 23 | 23 |
+| `unixSelect.test` | 18 | 18 | 18 |
+| `systray.test` | 13 | 13 | 13 |
+| `winfo.test` | 6 | 4 | 4 |
+
+**Everything outside `wm` is untouched so far**, which is the honest
+reading: the 198 fixed are all one area, and the six files below it in
+that table have had no attention at all.
 
 The first-run breakdown, kept because the reasoning below refers to it:
 
@@ -1820,11 +1823,46 @@ to the same question.
 generic-Tk reparenting operations, seven tests, and doing them wrongly
 is worse than not doing them.
 
-**The remaining wm failures are not this.** `state`, `iconify`,
-`deiconify`, `withdraw`, `minsize`, `maxsize`, `resizable`, `geometry`
-and `stackorder` were all *implemented* and still failing, so expect a
-second, different cause underneath. Do not read the next run's drop as
-"the wm work is done".
+**The remaining wm failures were not this**, as predicted -- `state`,
+`iconify`, `minsize`, `maxsize`, `resizable` and `geometry` were all
+implemented and still failing. `wm.test` went 202 -> 130 -> 74 over the
+three runs. Two more causes found, both real behaviour rather than
+bookkeeping:
+
+**`wm minsize`/`maxsize` were clamped in the wrong units.**
+`WmUpdateGeometry` converted grid units to pixels *first* and then
+clamped, so
+
+```tcl
+wm grid .t 1 1 50 50
+wm geom .t 4x4			;# 4 grid units = 200 pixels
+wm minsize .t 8 8		;# 8 GRID UNITS
+```
+
+asked whether `200 < 8` and left the window at 4x4. min/max speak grid
+units whenever the toplevel is gridded, exactly as `wm geometry` does --
+the convention already documented below, which this one place did not
+follow. The clamp now happens in those units and the conversion is last;
+both helpers are the identity when `gridWin` is NULL, so the ungridded
+path needs no branch. **The note below saying this was "inert today,
+since the defaults are 1 and unlimited" was true only while the tests
+that exercise it could not run.**
+
+**`wm transient` is behaviour, not just storage**, and three rules were
+missing:
+
+- the master is resolved to its nearest **toplevel** ancestor, so
+  `wm transient .subject .top.f` records `.top` and reads back as `.top`;
+- a transient **cannot be iconified** -- upstream refuses with
+  `can't iconify "%s": it is a transient`, because a dialog is shown and
+  hidden with the window it belongs to;
+- a transient made transient to an **iconic or withdrawn** master is
+  withdrawn at once.
+
+Only the state *at the moment of the call* is honoured. Upstream also
+tracks the master afterwards through a structure handler on it; that is
+a larger change and its tests are separate, so it is deliberately not
+done here.
 
 The eleven that were already implemented:
 `geometry`, `minsize`, `maxsize`, `withdraw`, `deiconify`, `state`,

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -223,17 +223,33 @@ WmUpdateGeometry(void *clientData)
     }
 
     /*
-     * An explicit size is in grid units while the toplevel is gridded
-     * ("-setgrid 1" on a listbox or a text widget), so convert here --
-     * this is the one place a size leaves wmPtr for the screen.
+     * WORK IN THE UNITS min/max ARE EXPRESSED IN, and convert to pixels
+     * at the very end.
+     *
+     * "wm minsize" and "wm maxsize" speak grid units whenever the
+     * toplevel is gridded, exactly as "wm geometry" does -- that is
+     * tkUnixWm.c's convention and the one the rest of this file
+     * follows. Clamping AFTER the grid-to-pixel conversion compared a
+     * grid count against a pixel count, so
+     *
+     *		wm grid .t 1 1 50 50
+     *		wm geom .t 4x4			;# 4 grid units = 200px
+     *		wm minsize .t 8 8		;# 8 grid units
+     *
+     * asked whether 200 < 8 and left the window at 4x4 (wm-minsize-2.2
+     * and its neighbours). The note in CLAUDE.md said this was "inert
+     * today, since the defaults are 1 and unlimited" -- true until the
+     * tests that exercise it could run at all.
+     *
+     * Both helpers are the identity when gridWin is NULL, so the
+     * ungridded case is unchanged and needs no branch of its own.
      */
     if (wmPtr->width >= 0 && wmPtr->height >= 0) {
-	WmGridToPixels(wmPtr, wmPtr->width, wmPtr->height, &width, &height);
+	width  = wmPtr->width;
+	height = wmPtr->height;
     } else {
-	width  = (wmPtr->width  >= 0) ? wmPtr->width
-				      : Tk_ReqWidth((Tk_Window) winPtr);
-	height = (wmPtr->height >= 0) ? wmPtr->height
-				      : Tk_ReqHeight((Tk_Window) winPtr);
+	WmPixelsToGrid(wmPtr, Tk_ReqWidth((Tk_Window) winPtr),
+		Tk_ReqHeight((Tk_Window) winPtr), &width, &height);
     }
 
     if (width  < wmPtr->minWidth)  width  = wmPtr->minWidth;
@@ -242,6 +258,8 @@ WmUpdateGeometry(void *clientData)
 	width = wmPtr->maxWidth;
     if (wmPtr->maxHeight > 0 && height > wmPtr->maxHeight)
 	height = wmPtr->maxHeight;
+
+    WmGridToPixels(wmPtr, width, height, &width, &height);
     if (width  < 1) width  = 1;
     if (height < 1) height = 1;
 
@@ -1882,7 +1900,20 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
          * ask about and pack/place react to (place-8.*, pack-18.*), so
          * it has to be distinct from withdrawn rather than folded into
          * it.
+         *
+         * A TRANSIENT CANNOT BE ICONIFIED, and that refusal is upstream's
+         * -- a dialog is shown and hidden with the window it belongs to,
+         * not on its own. wm-transient-1.4..1.9 are exactly this, and
+         * they check the message.
          */
+        if (wmPtr != NULL && wmPtr->transient != NULL) {
+            Tcl_SetObjResult(interp, Tcl_ObjPrintf(
+                    "can't iconify \"%s\": it is a transient",
+                    winPtr->pathName));
+            Tcl_SetErrorCode(interp, "TK", "WM", "ICONIFY", "TRANSIENT",
+                    (char *) NULL);
+            return TCL_ERROR;
+        }
         if (winPtr != NULL) {
             if (wmPtr != NULL) {
                 wmPtr->withdrawn = 0;
@@ -2259,10 +2290,22 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
             if (master == NULL)
                 return TCL_ERROR;
             /*
-             * A window cannot be its own master, and the master must be
-             * a toplevel -- both are upstream's checks and both are
-             * tested.
+             * The master is resolved to its nearest TOPLEVEL ancestor,
+             * as upstream does: "wm transient .subject .top.f" records
+             * .top, and reading it back must say .top rather than the
+             * frame that was named (wm-transient-2.2).
              */
+            while (!Tk_TopWinHierarchy((TkWindow *) master)) {
+                master = (Tk_Window) ((TkWindow *) master)->parentPtr;
+                if (master == NULL)
+                    break;
+            }
+            if (master == NULL) {
+                Tcl_SetObjResult(interp, Tcl_ObjPrintf(
+                        "can't find a toplevel for \"%s\"", s));
+                Tcl_SetErrorCode(interp, "TK", "WM", "TRANSIENT", (char *) NULL);
+                return TCL_ERROR;
+            }
             if (master == tkwin) {
                 Tcl_SetObjResult(interp, Tcl_ObjPrintf(
                         "can't make \"%s\" its own master", s));
@@ -2272,6 +2315,29 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
             }
             Tk_MakeWindowExist(master);
             WmSetString(&wmPtr->transient, Tk_PathName(master));
+
+            /*
+             * A transient follows its master's state: while the master
+             * is iconic or withdrawn the transient is withdrawn too,
+             * because a dialog has no business on screen without the
+             * window it belongs to. wm-transient-4.* and -8.1 check
+             * exactly this, and it is the one part of "transient" that
+             * is behaviour rather than bookkeeping.
+             *
+             * Only the state at the moment of the call is honoured
+             * here. Upstream also *tracks* the master afterwards, with
+             * a structure handler on it; that is a larger change and
+             * the tests for it are separate.
+             */
+            {
+                WmInfo *mPtr = ((TkWindow *) master)->wmInfoPtr;
+
+                if (mPtr != NULL && (mPtr->withdrawn || mPtr->iconified)) {
+                    wmPtr->withdrawn = 1;
+                    wmPtr->iconified = 0;
+                    TkpWmSetState(winPtr, WithdrawnState);
+                }
+            }
         }
         return TCL_OK;
 


### PR DESCRIPTION
345 -> ? ; wm.test is 202 -> 130 -> 74 over three runs. The second cause under the previously-implemented subcommands turned out to be two.

wm minsize/maxsize were clamped in the wrong units. WmUpdateGeometry converted grid units to pixels first and clamped afterwards, so with "wm grid .t 1 1 50 50" and "wm geom .t 4x4", a "wm minsize .t 8 8" asked whether 200 < 8 and left the window alone. min/max speak grid units whenever the toplevel is gridded, exactly as wm geometry does -- the convention this file already documents and this one place did not follow. Clamp in those units, convert last; both helpers are the identity when gridWin is NULL so the ungridded path is unchanged.

The CLAUDE.md note calling this "inert today, since the defaults are 1 and unlimited" was true only while the tests that exercise it could not run.

wm transient is behaviour rather than bookkeeping, and three rules were missing: the master resolves to its nearest toplevel ancestor, so "wm transient .subject .top.f" records and reports .top; a transient cannot be iconified, which upstream refuses by name; and a transient made transient to an iconic or withdrawn master is withdrawn at once.

Only the state at the moment of the call is honoured. Upstream also tracks the master afterwards with a structure handler on it; that is a larger change with separate tests and is deliberately not done here.

Host gcc check clean, -Wall on the changed file included.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs