### PR TITLE
tests: the teardown crash is a use-after-free; add a reproducer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1894,16 +1894,85 @@ empty string.
 
 **It does not exit cleanly.** There is still no
 `tk-runall: runAllTests returned` marker, because after the last test
-of the last file `wish` dies:
+of the last file `wish` dies, at the same address every run:
 
 ```
 ==== xmfbox-2.6 FAILED
-wish 11179: suicide: sys: trap: general protection violation pc=0x26f694
+wish 16510: suicide: sys: trap: general protection violation pc=0x26f694
 ```
 
-A crash rather than a hang this time, and at teardown rather than in a
-test. That is its own bug and wants `pc=0x26f694` resolved against the
-binary.
+**Resolve a pc with acid, statically, on the binary.** This is *not*
+the interactive acid the note above warns about -- there is no process,
+so nothing fights `wish` for the rio window:
+
+```
+acid /bin/wish
+acid: pcfile(0x26f694)
+acid: pcline(0x26f694)
+acid: src(0x26f694)		/* prints the line, with context */
+```
+
+It answers `generic/tkGeometry.c:153`, which is `Tk_GeometryRequest`:
+
+```c
+148  if ((reqWidth == winPtr->reqWidth) && ...) return;
+151  winPtr->reqWidth = reqWidth;
+152  winPtr->reqHeight = reqHeight;
+153> if ((winPtr->geomMgrPtr != NULL)
+154      && (winPtr->geomMgrPtr->requestProc != NULL)) {
+```
+
+**Read the shape of the fault, not just the line number.** Lines 148,
+151 and 152 read *and write* through `winPtr` without faulting, and
+only 153/154 die. A null or unmapped `winPtr` would have faulted at
+148. **APE's malloc never unmaps a freed block** (see the allocator
+note below), so a freed `TkWindow` stays readable and writable, and the
+first thing that actually fails is the **pointer chase** through a
+garbage `geomMgrPtr` to reach `requestProc`. So this is a
+use-after-free of a `TkWindow`, and "it wrote to the struct first" is
+no evidence the struct was alive. That reasoning generalises: on this
+allocator, a wild pointer shows up at the first *double* indirection,
+not the first access.
+
+**The suspect, and it is a suspect.** The one place in
+`plan9/tkPlan9Wm.c` that calls `Tk_GeometryRequest` on a *stored*
+window pointer is `TkP9EmbedGeometryRequest`, which uses
+`containerPtr->parentPtr`. `EmbedWindowDeleted` clears that when the
+container is destroyed, so for it to dangle that cleanup must not have
+run -- and there is a hole big enough:
+
+`Tk_MakeContainer` registers `ContainerEventProc` with **`winPtr`** as
+its client data, and the proc opens with
+
+```c
+containerPtr = FindContainer(winPtr->window);
+if (containerPtr == NULL)
+	return;			/* cleanup skipped */
+```
+
+Upstream's equivalent, `EmbedStructureProc` in `unix/tkUnixEmbed.c`,
+registers the **`Container *` itself** as client data, so it never
+looks anything up and can never fail to find it. That is a real
+difference and a real hole.
+
+**It is not yet shown to be this crash.** `-singleproc 1` leaves ~30
+toplevels alive at exit -- safe.test's "Untrusted Tcl applet"
+containers among them -- and teardown touches all of them, so there is
+more than one route to a dead window.
+`sys/lib/tests/tk-embed-destroy-test.tcl` exists to make the answer a
+printed line rather than an argument: it builds container/embedded
+pairs, destroys each half first in turn, and **provokes a geometry
+request afterwards**, which is the step that matters -- destroying the
+container proves nothing on its own, because nothing dereferences the
+stale pointer until something asks for a resize.
+
+**The crash hides nothing.** `xmfbox` is the last file alphabetically,
+so all 97 files and every failure are already measured; only the
+summary line and the marker are lost. It is still worth doing early,
+because a general protection violation is a memory-safety signal and
+this port has form -- `TkpDeleteFont` and `TkpFreeColor` both freed a
+struct they did not own (see the hook section above), and both were
+invisible until something released a resource for real.
 
 `unixWm.test`, `unixSelect.test`, `unixEmbed.test` and `unixFont.test`
 run here because `tcl_platform(platform)` is `unix`, so the `unix`

--- a/sys/lib/tests/tk-embed-destroy-test.tcl
+++ b/sys/lib/tests/tk-embed-destroy-test.tcl
@@ -1,0 +1,201 @@
+# Does a destroyed container leave a dangling pointer behind?
+#
+#	wish tk-embed-destroy-test.tcl
+#
+# WHERE THIS COMES FROM. The Tk suite runs all 97 files and then wish
+# dies at the very end, always at the same address:
+#
+#	==== xmfbox-2.6 FAILED
+#	wish 16510: suicide: sys: trap: general protection violation
+#	                                pc=0x26f694
+#
+# acid resolves that -- statically, on the binary, with no process, so
+# the "acid fights wish for the rio window" warning in CLAUDE.md does
+# not apply:
+#
+#	acid /bin/wish
+#	acid: src(0x26f694)
+#	.../tk/generic/tkGeometry.c:153
+#
+# which is Tk_GeometryRequest:
+#
+#	148  if ((reqWidth == winPtr->reqWidth) && ...) return;
+#	151  winPtr->reqWidth = reqWidth;
+#	152  winPtr->reqHeight = reqHeight;
+#	153> if ((winPtr->geomMgrPtr != NULL)
+#	154      && (winPtr->geomMgrPtr->requestProc != NULL)) {
+#
+# READ THE SHAPE OF THAT FAULT, because it says more than the line
+# number does. Lines 148, 151 and 152 read and WRITE through winPtr
+# without faulting, and only 153/154 die. A null or unmapped winPtr
+# would have faulted at 148. APE's malloc never unmaps a freed block
+# (see the malloc note in CLAUDE.md), so a freed TkWindow is still
+# perfectly readable and writable -- and the first thing that actually
+# fails is the POINTER CHASE through a garbage geomMgrPtr to reach
+# requestProc.
+#
+# So this is a use-after-free of a TkWindow, not a null dereference,
+# and "it wrote to the struct first" is not evidence that the struct
+# was alive.
+#
+# THE SUSPECT, and it is a suspect rather than a conclusion. The one
+# place in plan9/tkPlan9Wm.c that calls Tk_GeometryRequest on a STORED
+# window pointer is TkP9EmbedGeometryRequest:
+#
+#	containerPtr = FindContainerByEmbedded(winPtr);
+#	if (containerPtr == NULL || containerPtr->parentPtr == NULL)
+#		return;
+#	Tk_GeometryRequest((Tk_Window) containerPtr->parentPtr, w, h);
+#
+# containerPtr->parentPtr is cleared by EmbedWindowDeleted when the
+# container is destroyed, so for it to dangle EmbedWindowDeleted must
+# not have run. And there is a hole big enough for that:
+#
+#	Tk_MakeContainer registers ContainerEventProc with WINPTR as its
+#	client data, and the proc opens with
+#
+#		containerPtr = FindContainer(winPtr->window);
+#		if (containerPtr == NULL)
+#			return;		<- cleanup skipped
+#
+#	Upstream's equivalent (unix/tkUnixEmbed.c EmbedStructureProc)
+#	registers the Container* ITSELF as the client data, so it never
+#	looks anything up and can never fail to find it.
+#
+# That is a real difference from upstream and a real hole. It is NOT
+# yet shown to be this crash: the suite leaves roughly thirty
+# toplevels alive at exit -- safe.test's "Untrusted Tcl applet"
+# containers among them -- and teardown touches all of them, so there
+# is more than one way to reach a dead window. This file is here to
+# make the answer a printed line rather than an argument.
+#
+# ORDER: every case that should survive comes before any case that
+# might not, and each prints a flushed marker BEFORE it runs, so the
+# last STEP line names the statement that killed wish. That rule is in
+# CLAUDE.md because ignoring it has cost whole round trips.
+
+proc step {m} { puts "STEP: $m"; flush stdout }
+proc ok   {m} { puts "   ok: $m"; flush stdout }
+
+proc state {what} {
+    foreach w {.c .c.f .e} {
+	if {[winfo exists $w]} {
+	    puts "     $w exists, [winfo class $w],\
+ [winfo width $w]x[winfo height $w]"
+	} else {
+	    puts "     $w gone"
+	}
+    }
+    flush stdout
+}
+
+# A container and an embedded toplevel, the way safe::loadTk builds
+# them: a frame with -container 1, and a toplevel with -use naming it.
+proc pair {} {
+    destroy .c .e
+    toplevel .c
+    pack [frame .c.f -container 1 -width 200 -height 150]
+    update
+    toplevel .e -use [winfo id .c.f]
+    update
+}
+
+step "1. build a container/embedded pair at all"
+pair
+state "after build"
+ok "built"
+
+step "2. ask the embedded window to resize -- the ordinary path\
+ through TkP9EmbedGeometryRequest, with both halves alive"
+.e configure -width 120 -height 90
+update
+ok "resize returned"
+
+step "3. destroy the EMBEDDED half, then poke the container"
+pair
+destroy .e
+update
+.c.f configure -width 210 -height 160
+update
+state "after destroying .e"
+ok "returned"
+
+# ------------------------------------------------------------------
+# The suspicious one. Destroying the container should reach
+# EmbedWindowDeleted and clear containerPtr->parentPtr; if it does not,
+# the next geometry request from the embedded half calls
+# Tk_GeometryRequest on freed memory.
+#
+# Note the request has to be provoked: simply destroying the container
+# proves nothing, because nothing dereferences the stale pointer until
+# something asks for a resize.
+step "4. destroy the CONTAINER half, then provoke a geometry request\
+ from the embedded half -- if parentPtr dangles this is the crash"
+pair
+destroy .c
+update
+state "after destroying .c"
+if {[winfo exists .e]} {
+    .e configure -width 130 -height 100
+    update
+    ok "the embedded half survived its container"
+} else {
+    ok "the embedded half went with its container, so nothing to poke"
+}
+
+step "5. the same, but destroying the container's TOPLEVEL rather than\
+ the -container frame, so the frame dies as part of a subtree"
+destroy .c .e
+toplevel .c
+pack [frame .c.f -container 1 -width 200 -height 150]
+update
+toplevel .e -use [winfo id .c.f]
+update
+destroy .c
+update
+state "after destroying the container toplevel"
+if {[winfo exists .e]} {
+    .e configure -width 140 -height 110
+    update
+}
+ok "returned"
+
+# ------------------------------------------------------------------
+# Teardown, which is where the suite actually dies: many pairs alive at
+# once, destroyed in whatever order Tk picks rather than by hand.
+step "6. five live pairs, then destroy them all in one go -- this is\
+ the shape of the suite's exit, where ~30 toplevels are still up"
+destroy .c .e
+for {set i 0} {$i < 5} {incr i} {
+    toplevel .c$i
+    pack [frame .c$i.f -container 1 -width 120 -height 90]
+    update
+    toplevel .e$i -use [winfo id .c$i.f]
+    update
+}
+ok "five pairs built"
+
+step "6b. ... destroy every container first, embedded halves last"
+for {set i 0} {$i < 5} {incr i} { destroy .c$i }
+update
+ok "containers destroyed"
+for {set i 0} {$i < 5} {incr i} { if {[winfo exists .e$i]} { destroy .e$i } }
+update
+ok "returned"
+
+step "7. and the real exit path: build five more and let Tk tear them\
+ down itself"
+for {set i 0} {$i < 5} {incr i} {
+    catch {destroy .c$i .e$i}
+    toplevel .c$i
+    pack [frame .c$i.f -container 1 -width 120 -height 90]
+    update
+    toplevel .e$i -use [winfo id .c$i.f]
+    update
+}
+ok "built; exiting now, which destroys them in Tk's own order"
+
+puts ""
+puts "reached the end -- nothing crashed"
+flush stdout
+exit 0


### PR DESCRIPTION
acid resolves pc=0x26f694 statically on the binary -- no process, so the "acid fights wish for the rio window" warning does not apply -- to generic/tkGeometry.c:153, Tk_GeometryRequest.

The shape of the fault says more than the line number. Lines 148, 151 and 152 read AND WRITE through winPtr without faulting, and only 153/154 die. A null or unmapped winPtr would have faulted at 148. APE's malloc never unmaps a freed block, so a freed TkWindow stays readable and writable and the first thing that fails is the pointer chase through a garbage geomMgrPtr to reach requestProc. So it is a use-after-free of a TkWindow, and having written to the struct is no evidence it was alive. On this allocator a wild pointer surfaces at the first double indirection, not the first access.

The suspect: TkP9EmbedGeometryRequest is the one place in tkPlan9Wm.c calling Tk_GeometryRequest on a stored window pointer, via containerPtr->parentPtr. EmbedWindowDeleted clears that, so for it to dangle the cleanup must not have run -- and Tk_MakeContainer registers ContainerEventProc with winPtr as client data, whose proc looks the container up by window id and returns early if that fails, skipping the cleanup. Upstream's EmbedStructureProc registers the Container* itself and can never fail to find it.

Not yet shown to be this crash, and deliberately not "fixed" on that argument: -singleproc leaves ~30 toplevels alive at exit and teardown touches all of them. tk-embed-destroy-test.tcl builds pairs, destroys each half first in turn, and provokes a geometry request afterwards -- the step that matters, since destroying the container dereferences nothing until something asks for a resize.

Also recorded: the crash hides nothing (xmfbox is last alphabetically, so every failure is already measured), but a general protection violation is a memory-safety signal and this port has form for freeing structs it does not own.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs