### PR TITLE
tk/plan9: the window table failed silently when it filled up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,8 +154,10 @@ itself are `bool-test.c`, `bitfield-test.c`, `compound-assign-test.c`,
 `format-arg-test.c`, `unget-pipe-test.c`, `isatty-test.c`,
 `sincos-test.c`, `explog-test.c`, `fparith-test.c`,
 `float-overflow-test.c`, `malloc-reuse-test.c` and
-`stdio-test.c`. The three `tk-*.tcl` scripts there are Tcl, run with
-`wish`; see the Tk section below. `sys/src/ape/lib/libressl/test/` is separate: it is
+`stdio-test.c`. The eighteen `tk-*.tcl` scripts there are Tcl, run with
+`wish`; see the Tk section below. `tk-runall.tcl` is the harness for
+Tk's own suite rather than a test of its own, and `tk-runtest.tcl` runs
+a single file from it. `sys/src/ape/lib/libressl/test/` is separate: it is
 upstream's own ML-KEM and SHA-3 vectors, run by `mk test` there.
 
 Beyond that, testing is still mostly ad-hoc — compile a program under
@@ -2066,16 +2068,81 @@ absent here: `win` 280, `secureserver` 71, `nonPortable` 69, `nt` 55,
 
 **The crash hides nothing.** `xmfbox` is the last file alphabetically,
 so all 97 files and every failure are already measured; only the
-summary line is lost. **The next full run settles where the fault is
-without any further work**: `tk-runall.tcl` now prints its marker from
-inside a wrapper around `::exit`, so a `tk-runall: every file ran, now
-entering exit` line followed by the fault confirms the fault is in
-`Tcl_Exit`/teardown, and a fault with no marker moves it back into a
-test file. It is still worth doing early,
-because a general protection violation is a memory-safety signal and
-this port has form -- `TkpDeleteFont` and `TkpFreeColor` both freed a
-struct they did not own (see the hook section above), and both were
-invisible until something released a resource for real.
+summary line is lost. It is still worth doing early, because a general
+protection violation is a memory-safety signal and this port has form
+-- `TkpDeleteFont` and `TkpFreeColor` both freed a struct they did not
+own (see the hook section above), and both were invisible until
+something released a resource for real.
+
+**IT IS NOT IN TEARDOWN.** The `::exit` marker settled that on its
+first run: the marker is **absent**, and so is `runAllTests`' own
+`Tests ended at` line, which it prints *before* `cleanupTests`
+(`tcltest.tcl:2996`). So wish dies between the last test reporting and
+`xmfbox.test`'s own trailing `cleanup; cleanupTests` -- inside the test
+file. The banner line confirms the wrapper was installed, so the
+absence means what it says this time.
+
+**And xmfbox-2.6 itself fails with something impossible**, which is a
+better lead than the fault:
+
+```
+bad window path name ".foo.top"
+    while executing
+"pack $w.top -side top -expand yes -fill both"
+```
+
+`library/xmfbox.tcl`'s `MotifFDialog_BuildUI` is
+
+```tcl
+329  toplevel $w -class TkMotifFDialog
+330  set top [frame $w.top -relief raised -bd 1]
+331  set bot [frame $w.bot -relief raised -bd 1]
+333  pack $w.bot -side bottom -fill x
+334> pack $w.top -side top -expand yes -fill both
+```
+
+`.foo.top` is created at 330 and **gone** at 334, with one `frame` and
+one `pack` in between. A window does not leave the name table on its
+own -- and a damaged widget tree is also what the fault two lines later
+says, so the two symptoms are probably one cause and the Tcl-level one
+is far cheaper to chase.
+
+**Something accumulated is needed**, because both halves ran clean and
+`[n-z]` contains `xmfbox.test`. With `-singleproc 1` all 97 files are
+sourced into one wish, so what accumulates is **live windows** -- every
+toplevel a test forgets to destroy.
+
+**The first suspect is the window table, because it is a fixed array
+that used to fail silently.** `tkPlan9Int.h` has `TKP9_MAX_WINDOWS
+2048`, and on exhaustion `TkP9AllocWindow` returned NULL and
+`XCreateWindow` answered `None` -- which every caller above it reads as
+*no window*, never as *no room*. A frame that exists to Tk and not to
+this port is exactly the shape of ".foo.top is gone". That is the
+`XLoadFont` family again (see "four wm and keysym stubs that answered
+plausibly"): **a stub that answers "failure" is not the same as one
+that answers "nothing to do", and a table that answers `None` when
+full is not answering at all.**
+
+So it is loud now, and measured:
+
+- exhaustion **panics**, naming the table and its size. A panic where
+  it happens beats a general protection violation twenty minutes later.
+- occupancy is reported as it climbs, one line per 256 slots:
+  `tkp9: window table 256/2048 in use`. **Unconditional, not under
+  `$TKP9DEBUG`** -- that flag turns on a torrent of drawing traces, and
+  a number that only appears beside them is a number nobody reads.
+  Eight lines over a process's life is the whole cost, and it makes the
+  next full run answer "did we get close?" by itself.
+
+`sys/lib/tests/tk-xmfbox-crash-test.tcl` asks the question without the
+suite: build the dialog with a growing number of live toplevels
+underneath, reporting at each step. Its three outcomes want three
+different next steps -- fails at zero (the suite is a red herring),
+fails past some count (accumulation, and the count goes to the table),
+never fails (**not** window count; something else survives a test file
+-- a grab, a focus, a stale geometry manager). Note the table being
+innocent is a real possible answer here, and the ramp is what
+distinguishes it from a guess.
 
 `unixWm.test`, `unixSelect.test`, `unixEmbed.test` and `unixFont.test`
 run here because `tcl_platform(platform)` is `unix`, so the `unix`

--- a/sys/lib/tests/tk-xmfbox-crash-test.tcl
+++ b/sys/lib/tests/tk-xmfbox-crash-test.tcl
@@ -1,0 +1,226 @@
+# Why does building the Motif file dialog kill wish at the end of the
+# Tk suite, and does it need the other 96 files to have run first?
+#
+#	wish tk-xmfbox-crash-test.tcl
+#
+# WHERE THIS COMES FROM. The full 97-file run ends:
+#
+#	==== xmfbox-2.6 FAILED
+#	wish 7597: suicide: sys: trap: general protection violation
+#	                                pc=0x26f694
+#
+# and pc=0x26f694 is generic/tkGeometry.c:153, Tk_GeometryRequest,
+# faulting on the pointer chase through a garbage geomMgrPtr -- a
+# use-after-free of a TkWindow. (APE's malloc never unmaps a freed
+# block, so a wild pointer here shows at the first DOUBLE indirection,
+# not the first access. See CLAUDE.md.)
+#
+# TWO FACTS THAT TOGETHER SAY WHERE TO LOOK.
+#
+# 1. The fault is inside xmfbox.test, not in exit. tk-runall.tcl now
+#    wraps ::exit and prints a marker before the real one; the marker
+#    is ABSENT, and so is runAllTests' own "Tests ended at" line, which
+#    it prints before cleanupTests. So wish died between the last test
+#    reporting and the file's own trailing "cleanup; cleanupTests".
+#
+#    (Do not read the marker's absence as "the suite did not finish" --
+#    that was the old, unreachable marker. This one is reachable.)
+#
+# 2. xmfbox-2.6 itself fails with something impossible:
+#
+#	bad window path name ".foo.top"
+#	    while executing
+#	"pack $w.top -side top -expand yes -fill both"
+#
+#    library/xmfbox.tcl builds the dialog like this:
+#
+#	329  toplevel $w -class TkMotifFDialog
+#	330  set top [frame $w.top -relief raised -bd 1]
+#	331  set bot [frame $w.bot -relief raised -bd 1]
+#	333  pack $w.bot -side bottom -fill x
+#	334> pack $w.top -side top -expand yes -fill both
+#
+#    .foo.top is created at 330 and gone at 334. Line 331 and line 333
+#    are all that happen in between. A window does not leave the name
+#    table on its own, so either something destroyed it or the tree it
+#    is in is already damaged -- and a damaged tree is what the fault
+#    two lines later says as well.
+#
+# THE QUESTION THIS FILE ASKS, and it is the one the two half-runs
+# raised: "wish tk-runall.tcl -file {[a-m]*.test}" and "{[n-z]*.test}"
+# BOTH ran to completion, and the second includes xmfbox.test. So
+# xmfbox alone is not enough; something accumulated over the other 50
+# files is needed too. What accumulates?
+#
+#	all.tcl sets -singleproc 1, so all 97 files are sourced into
+#	ONE wish, and every toplevel a test forgets to destroy stays
+#	up for the life of the process.
+#
+# The first suspect is therefore simply the NUMBER OF LIVE WINDOWS,
+# because this port has a fixed-size window table:
+#
+#	tkPlan9Int.h:  #define TKP9_MAX_WINDOWS 2048
+#
+# and until now XCreateWindow answered None when it filled up -- which
+# every caller above it reads as "no window", never as "no room". A
+# frame that exists to Tk and not to this port is exactly the shape of
+# ".foo.top is gone".
+#
+# So the port now PANICS on exhaustion rather than answering None, and
+# prints one line per 256 slots as occupancy climbs:
+#
+#	tkp9: window table 256/2048 in use
+#
+# Those lines are unconditional, not under $TKP9DEBUG -- the debug flag
+# turns on a torrent of drawing traces, and a number that only appears
+# beside them is a number nobody reads.
+#
+# WHAT THIS FILE DOES. Build the dialog with a growing number of live
+# toplevels underneath it, and report at each step. Three outcomes,
+# wanting three different next steps:
+#
+#	fails at every count, even 0   -> nothing to do with accumulation;
+#	                                  it is xmfbox or this port's
+#	                                  toplevel handling, and the
+#	                                  suite is a red herring
+#	fails only past some count     -> accumulation, and the count is
+#	                                  the measurement to take to the
+#	                                  window table
+#	never fails here               -> it is not window COUNT; the
+#	                                  suite leaves something else
+#	                                  behind (a grab, a focus, a
+#	                                  stale geometry manager)
+#
+# ORDER: cheap and expected-to-pass cases first, then the ramp, because
+# a failure here may kill wish rather than raise an error. Each step
+# prints a flushed marker BEFORE it runs, so the last STEP line names
+# the statement that did not return. That rule is in CLAUDE.md because
+# ignoring it has cost whole round trips.
+
+proc step {m} { puts "STEP: $m"; flush stdout }
+proc ok   {m} { puts "   ok: $m"; flush stdout }
+proc bad  {m} { puts " FAIL: $m"; flush stdout }
+
+# Count every window Tk knows about, so "how many are live" is a number
+# in the log rather than a guess. winfo children walks the whole tree.
+proc countwins {{w .}} {
+    set n 1
+    foreach c [winfo children $w] { incr n [countwins $c] }
+    return $n
+}
+
+# Exactly what xmfbox.tcl's MotifFDialog_BuildUI does for the first six
+# lines -- the ones that failed -- with a check after each. Written out
+# rather than calling tk::MotifFDialog_Create so that a failure names
+# the line, and so this runs without the test suite's machinery.
+proc buildui {w} {
+    toplevel $w -class TkMotifFDialog
+    frame $w.top -relief raised -bd 1
+    frame $w.bot -relief raised -bd 1
+
+    set missing {}
+    foreach c [list $w.top $w.bot] {
+	if {![winfo exists $c]} { lappend missing $c }
+    }
+    if {[llength $missing]} {
+	return "gone right after creation: $missing"
+    }
+
+    if {[catch {pack $w.bot -side bottom -fill x} err]} {
+	return "pack \$w.bot failed: $err"
+    }
+    # THE LINE THAT FAILS IN THE SUITE.
+    if {![winfo exists $w.top]} {
+	return "\$w.top vanished during 'pack \$w.bot' -- the suite's failure"
+    }
+    if {[catch {pack $w.top -side top -expand yes -fill both} err]} {
+	return "pack \$w.top failed: $err"
+    }
+    return ""
+}
+
+step "0. how many windows exist in a bare wish"
+ok "[countwins] windows"
+
+step "1. build the dialog with nothing else up -- if THIS fails, the\
+ 97-file suite is a red herring and the bug is here"
+catch {destroy .foo}
+set why [buildui .foo]
+if {$why eq ""} {
+    ok "built; [countwins] windows now"
+} else {
+    bad "$why"
+    puts ""
+    puts "It fails with no accumulation at all. Stop reading the suite:"
+    puts "reproduce from here."
+    flush stdout
+    exit 1
+}
+destroy .foo
+
+step "2. build and destroy it twenty times -- a leak in the port's\
+ window table would show as the count not returning to where it started"
+set before [countwins]
+for {set i 0} {$i < 20} {incr i} {
+    catch {destroy .foo}
+    set why [buildui .foo]
+    if {$why ne ""} { bad "iteration $i: $why"; break }
+    destroy .foo
+}
+set after [countwins]
+if {$after == $before} {
+    ok "$before windows before, $after after -- Tk's own count is clean"
+} else {
+    bad "$before before, $after after -- Tk is leaking windows too"
+}
+
+# ------------------------------------------------------------------
+# The ramp. Each round leaves a toplevel with a few children up, the way
+# a test file that forgets to destroy its windows does, and then tries
+# the dialog again. If the port's window table is the thing running out,
+# there is a count at which this stops working -- and the
+# "tkp9: window table N/2048 in use" lines on stderr say how close it
+# got, whether or not it fails.
+#
+# 40 rounds x 8 children is 360 or so windows, which is the order the
+# suite leaves behind. Going much past that is the table's job to
+# report, not this file's.
+step "3. the ramp: leave live toplevels up, retry the dialog after each"
+
+set failedat -1
+for {set round 1} {$round <= 40} {incr round} {
+    toplevel .leak$round
+    for {set j 0} {$j < 8} {incr j} {
+	pack [frame .leak$round.f$j -width 20 -height 10]
+    }
+    update
+
+    catch {destroy .foo}
+    set why [buildui .foo]
+    if {$why ne ""} {
+	bad "round $round ([countwins] windows live): $why"
+	set failedat $round
+	break
+    }
+    destroy .foo
+
+    if {$round % 10 == 0} {
+	ok "round $round: [countwins] windows live, dialog still builds"
+    }
+}
+
+puts ""
+if {$failedat < 0} {
+    puts "reached the end -- the dialog built at every count, up to\
+ [countwins] live windows."
+    puts "So it is NOT the number of windows. The suite leaves something"
+    puts "else behind; look at what survives a test file rather than at"
+    puts "the window table."
+} else {
+    puts "broke at round $failedat, [countwins] live windows."
+    puts "That is a count, so take it to the window table:"
+    puts "the 'tkp9: window table N/2048 in use' lines above say whether"
+    puts "the table was anywhere near full when it happened."
+}
+flush stdout
+exit 0

--- a/sys/src/external/tk/plan9/tkPlan9Init.c
+++ b/sys/src/external/tk/plan9/tkPlan9Init.c
@@ -37,6 +37,27 @@ TkP9FindWindow(Window xid)
     return NULL;
 }
 
+/*
+ * The window table is a fixed array, so it can run out -- and the way it
+ * used to run out was the worst available: XCreateWindow answered None,
+ * which every caller reads as "no window" rather than "no room". A
+ * frame would then exist to Tk and not to this port, and the first
+ * thing to notice would be something a long way away.
+ *
+ * Two rules here, both about not being quiet:
+ *
+ *   - exhaustion PANICS, naming the table and its size. A panic at the
+ *     point of failure beats a general protection violation twenty
+ *     minutes later, which is what this cost once already.
+ *   - occupancy is reported as it climbs, one line per TKP9_WINREPORT
+ *     slots, unconditionally rather than under $TKP9DEBUG -- the debug
+ *     flag turns on a torrent of drawing traces, so a number that only
+ *     appears alongside them is a number nobody will see. Eight lines
+ *     over the life of a process is the whole cost, and it turns "did
+ *     we get close?" into something the log answers by itself.
+ */
+#define TKP9_WINREPORT 256
+
 P9Window *
 TkP9AllocWindow(void)
 {
@@ -46,9 +67,20 @@ TkP9AllocWindow(void)
             memset(&gP9.wins[i], 0, sizeof(P9Window));
             gP9.wins[i].inuse = 1;
             if (i >= gP9.nwins) gP9.nwins = i + 1;
+            gP9.winuse++;
+            if (gP9.winuse > gP9.winhigh) {
+                int prev = gP9.winhigh;
+                gP9.winhigh = gP9.winuse;
+                if (gP9.winhigh / TKP9_WINREPORT != prev / TKP9_WINREPORT)
+                    fprintf(stderr, "tkp9: window table %d/%d in use\n",
+                            gP9.winhigh, TKP9_MAX_WINDOWS);
+            }
             return &gP9.wins[i];
         }
     }
+    Tcl_Panic("tkp9: window table full (%d entries); "
+              "every XCreateWindow from here would answer None",
+              TKP9_MAX_WINDOWS);
     return NULL;
 }
 
@@ -90,7 +122,10 @@ void
 TkP9FreeWindow(Window xid)
 {
     P9Window *w = TkP9FindWindow(xid);
-    if (w) w->inuse = 0;
+    if (w) {
+        w->inuse = 0;
+        gP9.winuse--;
+    }
 }
 
 /* ------------------------------------------------------------------ */

--- a/sys/src/external/tk/plan9/tkPlan9Int.h
+++ b/sys/src/external/tk/plan9/tkPlan9Int.h
@@ -83,6 +83,15 @@ typedef struct P9DisplayState {
     /* Window table */
     P9Window     wins[TKP9_MAX_WINDOWS];
     int          nwins;
+    /*
+     * How many slots are in use, and the most ever in use at once.
+     * Occupancy is REPORTED, not merely counted: running out is a
+     * cliff, and the failure it used to produce -- XCreateWindow
+     * answering None -- is silent at every level above it. See
+     * TkP9AllocWindow.
+     */
+    int          winuse;
+    int          winhigh;
     /* Pending X events queue (simple ring buffer) */
     XEvent       evqueue[TKP9_EVQUEUE];
     int          evhead;


### PR DESCRIPTION
The ::exit marker earned its keep on its first run: it is ABSENT from the full 97-file log, and so is runAllTests' own "Tests ended at" line (tcltest.tcl:2996, printed before cleanupTests).  So the general protection violation is not in Tcl_Exit teardown at all -- wish dies inside xmfbox.test, between its last test reporting and its trailing "cleanup; cleanupTests".

xmfbox-2.6 itself reports something impossible, and it is a better lead than the fault:

	bad window path name ".foo.top"
	    while executing
	"pack $w.top -side top -expand yes -fill both"

library/xmfbox.tcl creates .foo.top four lines earlier, with one frame and one pack in between.  A window does not leave the name table on its own, and a damaged widget tree is also what the fault two lines later says.

Both half-runs were clean and [n-z] contains xmfbox.test, so something accumulated is needed, and with -singleproc 1 what accumulates is live windows.  The first suspect is this port's fixed window table: TKP9_MAX_WINDOWS is 2048, and on exhaustion TkP9AllocWindow returned NULL so XCreateWindow answered None -- which every caller above it reads as "no window", never as "no room".  A frame that exists to Tk and not to this port is exactly the shape of ".foo.top is gone".  That is the XLoadFont family again: a stub answering "failure" is not the same as one answering "nothing to do".

Make it loud rather than guess:

  - exhaustion now panics, naming the table and its size.  A panic where it happens beats a GP fault twenty minutes later.
  - occupancy is reported as it climbs, one line per 256 slots. Unconditional, not under $TKP9DEBUG: that flag turns on a torrent of drawing traces, and a number that only appears beside them is a number nobody reads.  Eight lines over a process's life, and the next full run answers "did we get close?" by itself.

Add sys/lib/tests/tk-xmfbox-crash-test.tcl, which asks the question without the suite -- build the dialog with a growing number of live toplevels underneath and report at each step.  Its three outcomes want three different next steps, and "not the window count" is a real one of them.

Host gcc syntax check over plan9/*.c is clean.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs