### PR TITLE
tk/plan9: HFILES did not list tkPlan9Int.h, so six objects went stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2136,13 +2136,23 @@ So it is loud now, and measured:
 
 `sys/lib/tests/tk-xmfbox-crash-test.tcl` asks the question without the
 suite: build the dialog with a growing number of live toplevels
-underneath, reporting at each step. Its three outcomes want three
-different next steps -- fails at zero (the suite is a red herring),
-fails past some count (accumulation, and the count goes to the table),
-never fails (**not** window count; something else survives a test file
--- a grab, a focus, a stale geometry manager). Note the table being
-innocent is a real possible answer here, and the ramp is what
-distinguishes it from a guess.
+underneath, reporting at each step.
+
+**IT IS NOT THE WINDOW COUNT.** The ramp took the third of its three
+outcomes: the dialog builds correctly at every count up to 361 live
+windows, and the table only reached `256/2048`. So the table is
+exonerated -- as a *cause*. It is still worth its new loudness, and the
+occupancy lines are now the standing answer to "did we get close?"
+(**no**: the whole 97-file suite never printed one, so it never passed
+256 either).
+
+So the suite leaves something else behind. **Look at what survives a
+test file** -- a grab, a focus, a stale geometry manager, a `place`
+registration -- rather than at anything that is merely counted.
+`Tk_MaintainGeometry` remains the standing suspect, and it fits better
+than the table did: it registers a placed window with *every* master
+between it and its parent, and it is already implicated in
+`geometry-4.7`.
 
 `unixWm.test`, `unixSelect.test`, `unixEmbed.test` and `unixFont.test`
 run here because `tcl_platform(platform)` is `unix`, so the `unix`
@@ -2947,6 +2957,58 @@ against a worse symptom -- without it, resize -> Configure ->
 re-request loops -- so the fix is the same guard at the three X entry
 points. `XConfigureWindow` sends no ConfigureNotify at all and is left
 alone.
+
+### A header not in HFILES is a header mk does not rebuild for
+
+`sys/src/cmd/mklib` makes every object depend on `$HFILES`:
+
+```
+%.$O:	$HFILES		# don't combine with following %.$O rules
+```
+
+so a header **not listed there changes nothing**. mk rebuilds only the
+`.c` files that themselves changed, and every other object keeps the
+layout it was compiled against. Plan 9 mkfiles do not scan `#include`s,
+and `HFILES` in `sys/src/ape/lib/tk/mkfile` was the single line
+`tkConfig.h`.
+
+**This cost a whole suite run, and the symptom named nothing.** Two
+`int` fields were added to `P9DisplayState` in `plan9/tkPlan9Int.h` --
+the struct behind `gP9`, the **one global all seven files in `plan9/`
+share** -- and they were put beside `nwins`, which sits *above*
+`evqueue`. Only `tkPlan9Init.c` was recompiled, because only its `.c`
+had changed. The other six went on reading `evqueue`, `evhead`,
+`focuswin` and `lastmouse` at the old offsets **of the same object**.
+
+```
+bind.test	3 failures  ->  116, every one an empty result
+		(no key event was delivered at all)
+canvWind, clipboard, clrpick	up as well
+the run				died in cmds.test
+```
+
+Every one of those is a plausible Tk regression, and the group as a
+whole reads as "the event source broke". Nothing in it points at a
+header, let alone at a build system.
+
+Two fixes, and both are wanted:
+
+- **`HFILES` now lists the port's own headers** -- `tkPlan9Int.h`,
+  `tkPlan9Port.h`, `tkPlan9Default.h`, `tkP9Draw.h`. Those are the ones
+  that change; the vendored `generic/` and `xlib/` headers do not, and
+  listing several hundred of them would make every build walk the tree.
+- **Append to a shared global struct, never insert.** The comment at
+  the end of `P9DisplayState` says so. Appending cannot move an
+  existing field, so a stale object still reads everything it knew
+  about correctly.
+
+**The same trap is waiting in every vendored tree here**, since
+`mklib`'s rule is shared and most of these mkfiles have a short
+`HFILES` or none. The tells to remember: a change that is *logically
+inert* (a counter, a field nothing reads yet) followed by *broad,
+unrelated* breakage is a layout problem, not a logic one -- and on this
+build system the first thing to suspect is which objects were actually
+recompiled. `mk nuke` in the library directory settles it in one run.
 
 ### Syntax-check Tk's Plan 9 backend on the host before shipping it
 

--- a/sys/src/ape/lib/tk/mkfile
+++ b/sys/src/ape/lib/tk/mkfile
@@ -211,8 +211,28 @@ DRAWIMPL_CFLAGS=\
 	-I$APEXPROOT/$objtype/include/ape\
 	-D_PLAN9_SOURCE\
 
+# mklib makes every object depend on HFILES, so a header that is NOT
+# listed here changes nothing: mk rebuilds only the .c files that
+# themselves changed, and everything else keeps the layout it was
+# compiled against.
+#
+# THIS COST A WHOLE RUN. Two int fields were added to P9DisplayState in
+# tkPlan9Int.h -- the struct behind the single global gP9 that all seven
+# files in plan9/ share -- and only tkPlan9Init.c was rebuilt, because
+# only its .c had changed. The other six went on reading evqueue,
+# focuswin and lastmouse at the old offsets of the same object. Key
+# events stopped arriving (bind.test 3 failures -> 116) and the suite
+# died in cmds.test, none of which mentions a header.
+#
+# So the port's own headers belong here. They are the ones that change;
+# the vendored generic/ and xlib/ headers do not, and listing several
+# hundred of them would make every build walk the tree.
 HFILES=\
 	tkConfig.h\
+	$TKSRC/plan9/tkPlan9Int.h\
+	$TKSRC/plan9/tkPlan9Port.h\
+	$TKSRC/plan9/tkPlan9Default.h\
+	$TKSRC/plan9/tkP9Draw.h\
 
 <$APEXPROOT/sys/src/cmd/mklib
 

--- a/sys/src/external/tk/plan9/tkPlan9Int.h
+++ b/sys/src/external/tk/plan9/tkPlan9Int.h
@@ -83,15 +83,6 @@ typedef struct P9DisplayState {
     /* Window table */
     P9Window     wins[TKP9_MAX_WINDOWS];
     int          nwins;
-    /*
-     * How many slots are in use, and the most ever in use at once.
-     * Occupancy is REPORTED, not merely counted: running out is a
-     * cliff, and the failure it used to produce -- XCreateWindow
-     * answering None -- is silent at every level above it. See
-     * TkP9AllocWindow.
-     */
-    int          winuse;
-    int          winhigh;
     /* Pending X events queue (simple ring buffer) */
     XEvent       evqueue[TKP9_EVQUEUE];
     int          evhead;
@@ -111,6 +102,30 @@ typedef struct P9DisplayState {
     Display     *xdisplay;
     /* Tcl event source state */
     int          eventSourceAdded;
+    /*
+     * How many window-table slots are in use, and the most ever in use
+     * at once. Occupancy is REPORTED, not merely counted: running out
+     * is a cliff, and the failure it used to produce -- XCreateWindow
+     * answering None -- is silent at every level above it. See
+     * TkP9AllocWindow.
+     *
+     * APPEND NEW FIELDS HERE, AT THE END, and nowhere else. gP9 is one
+     * global shared by all seven files in this directory, and inserting
+     * a field in the middle moves every field after it -- so a file
+     * that is not recompiled reads the wrong offsets on the same
+     * object. That is not hypothetical: these two fields were first
+     * put beside nwins, which sits above evqueue, and the event ring
+     * and focus window moved under six objects that mk did not rebuild.
+     * bind.test went from 3 failures to 116 -- every key event lost --
+     * and the suite died in cmds.test.
+     *
+     * The mkfile now lists this header in HFILES so mk rebuilds them
+     * all, which is the real fix; appending is the belt to its braces,
+     * because the same trap is waiting in every vendored tree here
+     * whose mkfile does not track headers.
+     */
+    int          winuse;
+    int          winhigh;
 } P9DisplayState;
 
 extern P9DisplayState gP9;


### PR DESCRIPTION
The window table is NOT the cause of the teardown crash. tk-xmfbox-crash-test.tcl took the third of its three outcomes: the dialog builds correctly at every count up to 361 live windows, and the table only reached 256/2048.  The whole 97-file suite never printed an occupancy line either, so it never passed 256 there.  Look at what survives a test file -- a grab, a focus, a stale geometry manager -- rather than at anything merely counted.  Tk_MaintainGeometry remains the standing suspect and fits better than the table did.

The instrumentation run also regressed the suite badly, and the cause was the header, not the code.  sys/src/cmd/mklib has

	%.$O:	$HFILES

so a header NOT listed there changes nothing: mk rebuilds only the .c files that themselves changed.  HFILES here was the single line tkConfig.h.  The two new int fields went beside nwins, which sits above evqueue, and only tkPlan9Init.c was recompiled -- so the other six files in plan9/ went on reading evqueue, evhead, focuswin and lastmouse at the old offsets of the same global gP9.

	bind.test  3 failures -> 116, every one an empty result
	canvWind, clipboard, clrpick up as well
	the run died in cmds.test

Every one of those reads as an ordinary Tk regression and none of them points at a header.

Both halves fixed:

  - HFILES lists the port's own headers now (tkPlan9Int.h, tkPlan9Port.h, tkPlan9Default.h, tkP9Draw.h).  Those are the ones that change; the vendored generic/ and xlib/ headers do not, and listing several hundred would make every build walk the tree.
  - winuse/winhigh move to the END of P9DisplayState, with a comment saying to append and never insert.  Appending cannot move an existing field, so a stale object still reads what it knew.

The same trap is waiting in every vendored tree here, since mklib's rule is shared.  The tell: a logically inert change followed by broad unrelated breakage is a layout problem, not a logic one.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs