### PR TITLE
tk/plan9: nothing repaired what a window had been covering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1734,11 +1734,11 @@ table below is the whole thing, and the list has been re-derived rather
 than extended.
 
 ```
-all.tcl:  Total 10027  Passed 8320  Skipped 1429  Failed 278
+all.tcl:  Total 10027  Passed 8321  Skipped 1429  Failed 277
 Sourced 97 Test Files.
 ```
 
-**278 failing tests**, from **485** on the first full run -- which was
+**277 failing tests**, from **485** on the first full run -- which was
 up from 25 only because that run was the first to measure 35 files at
 all, not a regression. Attributed by file across the runs:
 
@@ -2377,28 +2377,93 @@ port's code:
   picked up the sibling's pixels, and with no backing store there is no
   record of it". They redraw *less* than X does, which is the expected
   direction.
-- **8 are Expose granularity** (`7.1`..`7.8`), and this is the one that
-  is a genuine open question. **There is no partial Expose anywhere in
-  this port**: `P9ExposeTree` always reports `0,0,width,height` and is
-  reached only from `XMapWindow`, `XRaiseWindow` and `XLowerWindow` --
-  `XUnmapWindow` and `XDestroyWindow` send **none at all**.
-
-  Those two facts predict two different bugs, and they want opposite
-  fixes: either no Expose reaches the text widget (in which case
-  destroying a window leaves its pixels on screen, which is worse than
-  the test, and the full relayout has another cause) or a whole-window
-  one does (in which case the fix is damage rectangles). **Print the
-  events before choosing**: `sys/lib/tests/tk-expose-test.tcl` runs
-  `textDisp-7.1` with an `<Expose>` binding that reports `%x %y %w %h`,
-  and says which. Note the asymmetry it warns about -- too *much*
-  damage costs a repaint, too *little* leaves stale pixels nothing will
-  ever correct.
+- **8 are Expose granularity** (`7.1`..`7.8`), and chasing them found a
+  bug far bigger than the tests -- see the next section.
 
 The arithmetic for the whole exercise: of 106 failures in the four
 untouched files, **3 were ours** and 103 need a second wish (53),
 `tktest` (14), a system tray (13), a scalable font (13), or the backing
 store this port does not have (2), with 8 still open. That ratio is the
 thing to carry into the next file rather than the raw count.
+
+#### Tk on Plan 9: nothing repaired what a window had been covering
+
+**Destroying a widget left its pixels on the screen.** So did
+`place forget`. So did raising a widget above its siblings. This port
+repaired damage in exactly **one** place -- `XMapWindow`, which exposes
+the window that has just appeared -- and nowhere else, for the whole
+life of the port.
+
+`sys/lib/tests/tk-expose-test.tcl` says it in four empty lines: it
+binds `<Expose>`, prints `%x %y %w %h`, and reported
+
+```
+STEP: 2. destroy .f2, then update
+      exposes:
+STEP: 3. rebuild, map a frame over .t, then 'place forget' it
+      exposes:
+STEP: 4. two overlapping frames in .t, raise the lower one
+      exposes:
+```
+
+**Section 4 is what pinned it down**, and it is the one that reads as a
+contradiction: `XRaiseWindow` *does* call `P9ExposeTree`, so raising
+was the one path the code said should work. It reported nothing, which
+sends you to `Tk_RestackWindow` in `generic/tkWindow.c`:
+
+```c
+if (winPtr->window != None) {
+    XWindowChanges changes;
+    unsigned int mask = CWStackMode;
+    ...
+    XConfigureWindow(winPtr->display, winPtr->window, mask, &changes);
+```
+
+**A non-toplevel never reaches `XRaiseWindow` at all.** Tk reorders
+`parentPtr->childList` itself and tells the server about a *sibling*
+with `CWStackMode`; only a toplevel goes through `TkWmRestackToplevel`
+and so through `XRaiseWindow`. And `XConfigureWindow` here was pure
+bookkeeping -- it copied x/y/width/height into the `P9Window` and
+returned.
+
+**Why every test still passed.** `Tk_CoordsToWindow` answers from Tk's
+own `childList`, so `winfo containing` was right the whole time and
+`raise.test` was satisfied: **the hit test was correct and only the
+pixels were stale.** That is precisely the trap the stacking section
+above warns about -- "restacking with no hit-test reports nothing and
+hit-testing with no restacking reports a stale but plausible answer" --
+met from the other side, and it hid this for the whole port.
+
+**The fix** is `P9ExposeRect` and `P9DamageUnder` in `tkPlan9Init.c`.
+`P9ExposeRect` is `P9ExposeTree` over a rectangle: expose a window and
+its mapped children, each clipped to the part of the rectangle that
+falls inside it, children after their parent so they repaint on top --
+drawing here goes straight into the one rio window with no clipping, so
+the order of the events *is* the stacking. `P9DamageUnder` takes a
+window's rectangle **in its parent's coordinates**, which is where
+`P9Window.x/y` already are, and exposes the parent over it. Called from
+`XDestroyWindow` (before the slot is freed -- the rectangle and the
+parent are both gone the moment `TkP9FreeWindow` runs), `XUnmapWindow`,
+and `XConfigureWindow`'s `CWStackMode` path.
+
+**Err towards more damage, always.** Too much costs a repaint; too
+little leaves stale pixels that nothing here will ever correct, because
+there is no backing store and no server to ask. That asymmetry is why
+this went in as "expose the parent subtree over the rectangle" rather
+than anything cleverer.
+
+**This is not yet known to fix `textDisp-7.1..7.8`, and probably does
+not.** Those eight relayout the whole widget where X relays out
+nothing -- and with *no* Expose arriving before this change, the
+relayout must have had another cause all along. The test file's redraw
+half will name it, and **it could not on the first run**: `tk_textRelayout`
+and `tk_textRedraw` are only recorded while the widget's own debugging
+is on (`textDisp.test:139` is `.t debug on`), which the script did not
+do, so every `relayout:` line came back empty for the wrong reason.
+Worse, its `build` proc *assigned* both variables, so the "does this Tk
+report them at all?" check could never fail either. **A check that
+cannot fail is not a check** -- it now probes with a separate widget
+before `build` touches anything.
 
 #### Tk on Plan 9: TkpClaimFocus, and an embedded wm geometry
 
@@ -2417,6 +2482,29 @@ Here both halves share this process and this window table, so the round
 trip is the identity: `Tk_GetOtherWindow` to find the container, then
 `TkSetFocusWin` on it. Same reduction as the rest of this port's
 embedding.
+
+**Result: `unixEmbed-10.2` passes; `8.2` is half fixed.** `[focus]` in
+the container's interpreter is `.f1` now, where it used to be `.f2`, so
+the claim reaches the container. What is still wrong is the *other*
+half -- the embedded application's own `[focus]` is `{}` where it
+should be `.`.
+
+That is `displayFocusPtr->focusWinPtr`, which is per main window, and
+`TkSetFocusWin` (tkFocus.c:633) deliberately leaves it NULL on the
+claiming side: on X the application learns it has the focus from the
+**real FocusIn the server then delivers to the embedded window**, and
+`TkFocusFilterEvent`'s ordinary path sets it. Windows does the same
+thing concretely -- its container answers `TK_CLAIMFOCUS` with
+`SetFocus(containerPtr->embeddedHWnd)`, i.e. it moves the OS focus *to
+the embedded window*, and Tk sees `WM_SETFOCUS` there.
+
+So the missing step is generating that second FocusIn on the embedded
+toplevel. **Do not send it with mode `EMBEDDED_APP_WANTS_FOCUS`**: that
+mode routes back into `TkSetFocusWin` (tkFocus.c:295) and would claim
+again, which is a loop. It wants an ordinary FocusIn, and getting the
+mode and detail wrong in the focus machinery is how `bind.test` went
+from 3 failures to 116 once already -- so it is left alone until it can
+be measured rather than guessed.
 
 **`WmUpdateGeometry` threw away an explicit `wm geometry` on an
 embedded toplevel.** The `TK_EMBEDDED` branch sat *above* the size

--- a/sys/lib/tests/tk-expose-test.tcl
+++ b/sys/lib/tests/tk-expose-test.tcl
@@ -21,39 +21,58 @@
 # inside it, relaying out nothing. We relaid out and redrew the whole
 # widget, borders included.
 #
-# TWO PREDICTIONS FROM THE CODE, AND THEY WANT OPPOSITE FIXES. Reading
-# plan9/tkPlan9Init.c:
+# THE ANSWER IS (a): NO EXPOSE AT ALL, IN ANY OF THE FOUR SECTIONS.
+# The first run printed an empty "exposes:" line for every one of them,
+# including section 4, which raises a frame -- and that is the result
+# that pinned it down, because raising is the one path the code says
+# does expose.
+#
+# Reading plan9/tkPlan9Init.c with that in hand:
 #
 #   - XUnmapWindow sends UnmapNotify and NO Expose.
-#   - XDestroyWindow sends no Expose either.
-#   - P9ExposeTree -- the only thing that makes one, and it is reached
-#     only from XMapWindow, XRaiseWindow and XLowerWindow -- always
-#     exposes 0,0,pw->width,pw->height. THE WHOLE WINDOW, NEVER A
-#     RECTANGLE. There is no partial Expose anywhere in this port.
+#   - XDestroyWindow sent none either.
+#   - P9ExposeTree -- the only thing that makes one -- is reached from
+#     XMapWindow, XRaiseWindow and XLowerWindow, and always exposes
+#     0,0,pw->width,pw->height. There was no partial Expose anywhere.
+#   - AND generic Tk only calls XRaiseWindow/XLowerWindow for a
+#     TOPLEVEL. Tk_RestackWindow (tkWindow.c) reorders
+#     parentPtr->childList itself and tells the server about a sibling
+#     with XConfigureWindow + CWStackMode -- which was pure bookkeeping
+#     here, no repaint.
 #
-# So either
+# So this port repaired damage in exactly ONE case, XMapWindow, and:
 #
-#   (a) no Expose reaches .t at all, in which case destroying a window
-#       leaves its pixels on screen -- a visible bug quite apart from
-#       the test -- and the full relayout comes from somewhere else
-#       entirely (a resize, a ConfigureNotify, a geometry re-request),
-#       which is where to look next; or
+#	destroy a widget that overlapped another	-> pixels stayed
+#	place forget a widget				-> pixels stayed
+#	raise/lower a widget among its siblings		-> no repaint
 #
-#   (b) one whole-window Expose reaches .t, in which case the fix is
-#       damage RECTANGLES: on unmap or destroy, expose each sibling
-#       below with the departing window's rectangle intersected with
-#       that sibling and translated into its coordinates.
+# None of it visible from Tcl, because Tk believes it asked. And the
+# stacking tests still passed throughout, because Tk_CoordsToWindow
+# answers from Tk's own childList: the HIT TEST was right and only the
+# pixels were stale -- the trap the stacking section in CLAUDE.md warns
+# about, met from the other side.
 #
-# Those are different bugs in different files. Print the events rather
-# than guessing which -- the record in CLAUDE.md is that a confident
-# mechanism has been wrong here five times, and a printed intermediate
-# value settled it in one round each time.
+# FIXED by P9ExposeRect/P9DamageUnder in tkPlan9Init.c, called from
+# XDestroyWindow, XUnmapWindow and XConfigureWindow's CWStackMode path.
+# Erring towards MORE damage is deliberate: too much costs a repaint,
+# too little leaves stale pixels that nothing here will ever correct,
+# since there is no backing store and no server to ask.
 #
-# BE CAREFUL WITH (b). Sending too LITTLE damage is worse than sending
-# too much: too much costs a repaint, too little leaves stale pixels
-# that nothing will ever correct, because there is no backing store and
-# no server to ask. Any move in that direction wants this file re-run
-# with the rectangles printed, not just the test suite.
+# WHAT THIS FILE STILL HAS TO SETTLE. textDisp-7.1 relaid out the whole
+# widget where X relaid out nothing, and that was NOT the Expose --
+# there wasn't one. So a second cause is still unidentified, and the
+# redraw half of this file is what will name it.
+#
+# THE FIRST RUN COULD NOT MEASURE THAT HALF, and the reason is worth
+# keeping: tk_textRelayout and tk_textRedraw are only recorded while
+# the widget's own debugging is on -- textDisp.test's line 139 is
+#
+#	.t debug on
+#
+# and this file did not do it, so every "relayout:" line came back
+# empty and said nothing. Worse, `build` here *assigns* the two
+# variables, so the "does this Tk report them at all?" check could
+# never fail either. A check that cannot fail is not a check.
 #
 # ORDER: cheap and expected-to-return cases first, each printing a
 # flushed marker before it runs.
@@ -79,9 +98,10 @@ proc exposes {} {
 # on the way textDisp.test turns them on.
 proc build {} {
     destroy .t .f2
-    catch {unset ::tk_textRelayout}
-    catch {unset ::tk_textRedraw}
     pack [text .t -width 40 -height 10 -wrap char -bd 2 -relief sunken]
+    # WITHOUT THIS the two variables are never written and every
+    # "relayout:" line below reads empty for the wrong reason.
+    .t debug on
     for {set i 1} {$i <= 8} {incr i} {
 	.t insert end "Line $i of the text widget, long enough to wrap\n"
     }
@@ -93,14 +113,23 @@ proc build {} {
 }
 
 puts "--- does this Tk report relayout/redraw at all? ---"
+destroy .t
+catch {unset ::tk_textRelayout}
+pack [text .tprobe -width 20 -height 4]
+.tprobe debug on
+.tprobe insert end "probe\n"
+update
+if {![info exists ::tk_textRelayout]} {
+    note "tk_textRelayout still does not exist after '.t debug on' and an"
+    note "insert -- this wish records nothing, so the redraw half of this"
+    note "file cannot report anything. The Expose half still can."
+} else {
+    note "yes: tk_textRelayout is '$::tk_textRelayout'"
+}
+destroy .tprobe
 build
 note ".t is [winfo width .t]x[winfo height .t] at\
  [winfo rootx .t],[winfo rooty .t]"
-if {![info exists ::tk_textRelayout]} {
-    note "tk_textRelayout does not exist -- this wish was not built with"
-    note "the text widget's debugging hooks, so the redraw half of this"
-    note "file cannot report anything. The Expose half still can."
-}
 
 puts ""
 puts "--- 1. map: the case that is known to work ---"
@@ -124,18 +153,23 @@ note "relayout: [expr {[info exists ::tk_textRelayout] ? $::tk_textRelayout : {n
 note "redraw:   [expr {[info exists ::tk_textRedraw] ? $::tk_textRedraw : {n/a}}]"
 puts ""
 if {[llength $e] == 0} {
-    puts "  => (a) NO Expose reached .t."
-    puts "     Destroying a window leaves its pixels on screen here, and"
-    puts "     the relayout above came from something else. Look at what"
-    puts "     else fired: a ConfigureNotify on .t, or a geometry"
-    puts "     re-request from place forgetting the slave."
+    puts "  => REGRESSION: no Expose reached .t."
+    puts "     This is what the first run reported and what P9DamageUnder"
+    puts "     was written to fix. Destroying a window is leaving its"
+    puts "     pixels on screen again."
 } else {
     set r [lindex $e 0]
-    puts "  => (b) an Expose DID reach .t: $r"
-    puts "     Compare its w/h against .t's [winfo width .t]x[winfo height .t]."
-    puts "     Equal means whole-window damage and the fix is rectangles;"
-    puts "     smaller means the granularity is already there and the"
-    puts "     relayout has another cause."
+    puts "  => an Expose reached .t: $r"
+    puts "     .t is [winfo width .t]x[winfo height .t]. The rectangle should"
+    puts "     be .f2's, not the whole widget -- .f2 was 60% x 55% of .t"
+    puts "     placed at 20%,22%, so roughly 148x59 at +49+23."
+    puts "     Whole-widget means P9ExposeRect's clipping is wrong."
+    puts ""
+    puts "     Then read the relayout line above. X relays out NOTHING"
+    puts "     here and redraws six display lines; a full relayout means"
+    puts "     the second cause behind textDisp-7.1 is still there and is"
+    puts "     NOT the Expose -- look for a ConfigureNotify on .t or a"
+    puts "     geometry re-request from place forgetting the slave."
 }
 
 puts ""
@@ -154,7 +188,12 @@ note "relayout: [expr {[info exists ::tk_textRelayout] ? $::tk_textRelayout : {n
 destroy .f3
 
 puts ""
-puts "--- 4. raise/lower, the paths that DO expose today ---"
+# THE DECISIVE SECTION ON THE FIRST RUN. Reading the code, raising is
+# the ONE path that was supposed to expose -- and it reported nothing,
+# which is what sent the search to Tk_RestackWindow and found that a
+# non-toplevel never reaches XRaiseWindow at all. Keep it as the
+# regression test for the CWStackMode path.
+puts "--- 4. raise/lower: the sibling path, which reaches XConfigureWindow ---"
 step "4. two overlapping frames in .t, raise the lower one"
 build
 frame .fa -bg green
@@ -162,13 +201,20 @@ frame .fb -bg yellow
 place .fa -in .t -relx 0.1 -rely 0.1 -relwidth 0.5 -relheight 0.5
 place .fb -in .t -relx 0.3 -rely 0.3 -relwidth 0.5 -relheight 0.5
 watch .fa
+watch .fb
 update
 exposes
 raise .fa
 update
-note "exposes: [exposes]"
-note "(.fa is [winfo width .fa]x[winfo height .fa] -- an Expose of exactly"
-note " that size is P9ExposeTree doing whole-window damage, by design)"
+set e [exposes]
+note "exposes: $e"
+note "(.fa is [winfo width .fa]x[winfo height .fa]; .fb is\
+ [winfo width .fb]x[winfo height .fb])"
+if {[llength $e] == 0} {
+    note "REGRESSION: raising a sibling repainted nothing. raise/lower on"
+    note "a widget goes through XConfigureWindow with CWStackMode, NOT"
+    note "XRaiseWindow -- see Tk_RestackWindow in generic/tkWindow.c."
+}
 destroy .fa .fb
 
 puts ""

--- a/sys/src/external/tk/plan9/tkPlan9Init.c
+++ b/sys/src/external/tk/plan9/tkPlan9Init.c
@@ -431,10 +431,14 @@ XCreateSimpleWindow(
                          CopyFromParent, CWBackPixel|CWBorderPixel, &attr);
 }
 
+/* Repair what a window was covering; defined with P9ExposeTree below. */
+static void P9DamageUnder(Display *display, P9Window *pw);
+
 int
 XDestroyWindow(Display *display, Window w)
 {
     TkWindow *winPtr;
+    P9Window *pw;
 
     /*
      * tkPointer.c remembers the window the pointer was last in; a dead
@@ -444,6 +448,16 @@ XDestroyWindow(Display *display, Window w)
     winPtr = (TkWindow *) Tk_IdToWindow(display, w);
     if (winPtr != NULL)
         TkPointerDeadWindow(winPtr);
+
+    /*
+     * Repair the hole BEFORE the slot is freed -- P9DamageUnder needs
+     * this window's rectangle and its parent, and both are gone the
+     * moment TkP9FreeWindow marks the slot unused.
+     */
+    pw = TkP9FindWindow(w);
+    if (pw != NULL && pw->mapped)
+        P9DamageUnder(display, pw);
+
     TkP9FreeWindow(w);
     gP9.pointerDirty = 1;
     return 0;
@@ -544,6 +558,9 @@ XUnmapWindow(Display *display, Window w)
     ev.xunmap.event      = w;
     ev.xunmap.window     = w;
     TkP9EnqueueEvent(&ev);
+
+    /* Whatever it was covering has to repaint; see P9DamageUnder. */
+    P9DamageUnder(display, pw);
     return 0;
 }
 
@@ -591,6 +608,94 @@ P9ExposeTree(Display *display, Window w)
         if (c->inuse && !c->ispixmap && c->parent == w && c->xid != w)
             P9ExposeTree(display, c->xid);
     }
+}
+
+/*
+ * The same thing over a RECTANGLE rather than a whole window: expose w
+ * and its mapped children, each clipped to the part of the rectangle
+ * that falls inside it. x,y,width,height are in w's own coordinates.
+ *
+ * Children are exposed after their parent so they repaint on top of it:
+ * drawing here goes straight into the one rio window with no clipping,
+ * so the order of the events IS the stacking, and P9ExposeTree above
+ * relies on the same thing.
+ */
+static void
+P9ExposeRect(Display *display, Window w, int x, int y, int width, int height)
+{
+    P9Window *pw = TkP9FindWindow(w);
+    XEvent ev;
+    int i;
+
+    if (pw == NULL || !pw->mapped || pw->ispixmap)
+        return;
+
+    /* Clip to the window itself; nothing outside it was ever its to paint. */
+    if (x < 0)          { width  += x; x = 0; }
+    if (y < 0)          { height += y; y = 0; }
+    if (x + width  > pw->width)  width  = pw->width  - x;
+    if (y + height > pw->height) height = pw->height - y;
+    if (width <= 0 || height <= 0)
+        return;
+
+    memset(&ev, 0, sizeof(ev));
+    ev.type            = Expose;
+    ev.xexpose.display = display;
+    ev.xexpose.window  = w;
+    ev.xexpose.x       = x;
+    ev.xexpose.y       = y;
+    ev.xexpose.width   = width;
+    ev.xexpose.height  = height;
+    ev.xexpose.count   = 0;
+    TkP9EnqueueEvent(&ev);
+
+    for (i = 0; i < gP9.nwins; i++) {
+        P9Window *c = &gP9.wins[i];
+        if (c->inuse && !c->ispixmap && c->parent == w && c->xid != w)
+            P9ExposeRect(display, c->xid, x - c->x, y - c->y, width, height);
+    }
+}
+
+/*
+ * A window is going away, or moving, or being restacked: repair what it
+ * was covering.
+ *
+ * NOTHING DID THIS. Damage was repaired in exactly one place --
+ * XMapWindow, which exposes the window that just appeared -- and in
+ * XRaiseWindow/XLowerWindow, which generic Tk only calls for TOPLEVELS
+ * (Tk_RestackWindow sends a sibling through XConfigureWindow with
+ * CWStackMode instead, and that was a pure bookkeeping call here). So
+ *
+ *	destroy a widget that overlapped another	-> its pixels stayed
+ *	place forget a widget				-> same
+ *	raise/lower a widget among its siblings		-> no repaint
+ *
+ * and none of it was visible from Tcl, because Tk believes it asked for
+ * the repaint. sys/lib/tests/tk-expose-test.tcl reports the Expose
+ * events with their rectangles and found all four cases silent.
+ *
+ * The rectangle is the departing window's, in its PARENT's coordinates,
+ * which is where P9Window.x/y already are -- the recurring trap in this
+ * port is confusing those with screen coordinates (see the stacking
+ * section in CLAUDE.md), and here the parent is exactly the frame the
+ * damage is expressed in.
+ *
+ * Erring towards MORE damage is the safe direction and is what this
+ * does: too much costs a repaint, too little leaves stale pixels that
+ * nothing here will ever correct, since there is no backing store and
+ * no server to ask.
+ */
+static void
+P9DamageUnder(Display *display, P9Window *pw)
+{
+    P9Window *parent;
+
+    if (pw == NULL || pw->ispixmap || pw->parent == pw->xid)
+        return;
+    parent = TkP9FindWindow(pw->parent);
+    if (parent == NULL)
+        return;
+    P9ExposeRect(display, parent->xid, pw->x, pw->y, pw->width, pw->height);
 }
 
 int
@@ -735,13 +840,32 @@ XConfigureWindow(Display *display, Window w,
                  unsigned int value_mask, XWindowChanges *values)
 {
     P9Window *pw = TkP9FindWindow(w);
-    (void)display;
+
     if (!pw || !values) return 0;
     if (value_mask & CWX)           pw->x            = values->x;
     if (value_mask & CWY)           pw->y            = values->y;
     if (value_mask & CWWidth)       pw->width        = values->width  > 0 ? values->width  : 1;
     if (value_mask & CWHeight)      pw->height       = values->height > 0 ? values->height : 1;
     if (value_mask & CWBorderWidth) pw->border_width = values->border_width;
+
+    /*
+     * CWStackMode is how "raise"/"lower" reaches a NON-TOPLEVEL. Tk
+     * reorders parentPtr->childList itself and then tells the server
+     * with this call (tkWindow.c Tk_RestackWindow); only a toplevel
+     * goes through TkWmRestackToplevel and so through XRaiseWindow.
+     *
+     * That is why raising a widget among its siblings repainted
+     * nothing here while raising a toplevel worked -- and why the
+     * stacking tests still passed: Tk_CoordsToWindow answers from Tk's
+     * own childList, so the HIT TEST was right and only the pixels were
+     * stale. Exactly the trap the stacking section in CLAUDE.md warns
+     * about, met from the other side.
+     *
+     * The order changed, so everything this window overlaps has to
+     * repaint, itself included -- damage its rectangle in the parent.
+     */
+    if ((value_mask & CWStackMode) && pw->mapped)
+        P9DamageUnder(display, pw);
     return 0;
 }
 


### PR DESCRIPTION
tk-expose-test.tcl answered its own question in four empty lines: no Expose reached anything, in any of its four sections.  Destroying a widget left its pixels on the screen.  So did "place forget".  So did raising a widget above its siblings.  This port repaired damage in exactly ONE place -- XMapWindow, which exposes the window that has just appeared -- and nowhere else, for the whole life of the port.

SECTION 4 IS WHAT PINNED IT DOWN, and it reads as a contradiction: XRaiseWindow does call P9ExposeTree, so raising was the one path the code said should work.  It reported nothing, which sends you to Tk_RestackWindow in generic/tkWindow.c -- a NON-TOPLEVEL never reaches XRaiseWindow at all.  Tk reorders parentPtr->childList itself and tells the server about a sibling with XConfigureWindow + CWStackMode, and that was pure bookkeeping here.

Why every test still passed: Tk_CoordsToWindow answers from Tk's own childList, so "winfo containing" was right the whole time and raise.test was satisfied.  The hit test was correct and only the pixels were stale -- precisely the trap the stacking section in CLAUDE.md warns about, met from the other side, and it hid this indefinitely.

The fix is P9ExposeRect and P9DamageUnder.  P9ExposeRect is P9ExposeTree over a rectangle: expose a window and its mapped children, each clipped to the part of the rectangle inside it, children after their parent so they repaint on top -- drawing goes straight into the one rio window with no clipping, so the order of the events is the stacking.  P9DamageUnder takes a window's rectangle in its PARENT's coordinates, which is where P9Window.x/y already are, and exposes the parent over it.  Called from XDestroyWindow (before the slot is freed; the rectangle and the parent are both gone the moment TkP9FreeWindow runs), XUnmapWindow, and XConfigureWindow's CWStackMode path.

Err towards more damage, always: too much costs a repaint, too little leaves stale pixels nothing here will ever correct.  These three paths sent nothing at all before, so this cannot make anything staler.

This is not known to fix textDisp-7.1..7.8 and probably does not: those relayout the whole widget where X relays out nothing, and with no Expose arriving at all before this, the relayout had another cause all along.  The test file's redraw half will name it -- and could not on the first run, because tk_textRelayout is only recorded while the widget's debugging is on (textDisp.test:139 is ".t debug on") and the script did not do it.  Worse, its build proc ASSIGNED both variables, so the "does this Tk report them at all?" check could never fail either.  A check that cannot fail is not a check; it probes with a separate widget now.

Suite: 278 -> 277.  unixEmbed-10.2 passes, so the embedded wm geometry fix landed.  unixEmbed-8.2 is half fixed: [focus] in the container's interpreter is .f1 now, where it was .f2, so TkpClaimFocus reaches the container.  The embedded application's own [focus] is still {} where it should be "." -- that is displayFocusPtr->focusWinPtr, which TkSetFocusWin deliberately leaves NULL on the claiming side because on X the application learns it has the focus from the real FocusIn the server then delivers to the embedded window.  Windows does the same concretely: its container answers TK_CLAIMFOCUS with SetFocus(embeddedHWnd).  Generating that second FocusIn is the missing step, and it must NOT use EMBEDDED_APP_WANTS_FOCUS (that routes back into TkSetFocusWin and loops).  Left alone until it can be measured: getting mode and detail wrong in the focus machinery is how bind.test went from 3 failures to 116 once already.

Host gcc syntax check over plan9/*.c is clean.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs