### PR TITLE
tk/plan9: damage repair confirmed; expose children in stacking order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2378,7 +2378,10 @@ port's code:
   record of it". They redraw *less* than X does, which is the expected
   direction.
 - **8 are Expose granularity** (`7.1`..`7.8`), and chasing them found a
-  bug far bigger than the tests -- see the next section.
+  bug far bigger than the tests -- see the next section. They are
+  likely fixed by it: the damage the port now reports for exactly
+  `textDisp-7.1`'s sequence is a partial rectangle with an **empty**
+  relayout, which is X's answer.
 
 The arithmetic for the whole exercise: of 106 failures in the four
 untouched files, **3 were ours** and 103 need a second wish (53),
@@ -2452,18 +2455,56 @@ there is no backing store and no server to ask. That asymmetry is why
 this went in as "expose the parent subtree over the rectangle" rather
 than anything cleverer.
 
-**This is not yet known to fix `textDisp-7.1..7.8`, and probably does
-not.** Those eight relayout the whole widget where X relays out
-nothing -- and with *no* Expose arriving before this change, the
-relayout must have had another cause all along. The test file's redraw
-half will name it, and **it could not on the first run**: `tk_textRelayout`
-and `tk_textRedraw` are only recorded while the widget's own debugging
-is on (`textDisp.test:139` is `.t debug on`), which the script did not
-do, so every `relayout:` line came back empty for the wrong reason.
-Worse, its `build` proc *assigned* both variables, so the "does this Tk
-report them at all?" check could never fail either. **A check that
-cannot fail is not a check** -- it now probes with a separate widget
-before `build` touches anything.
+**It works, and the rectangles are right.** With `.t debug on` added
+so the redraw half reports at all -- `tk_textRelayout` and
+`tk_textRedraw` are only recorded while the widget's own debugging is
+on, `textDisp.test:139` -- the second run of the script says:
+
+```
+STEP: 2. destroy .f2, then update
+      exposes: {.t 52 26 144 55 count=0}
+      relayout:
+      redraw:   2.0 2.40 3.0 3.40 4.0 4.40
+STEP: 3. rebuild, map a frame over .t, then 'place forget' it
+      exposes: {.t 28 14 96 40 count=0}
+STEP: 4. two overlapping frames in .t, raise the lower one
+      exposes: {.t 28 14 120 50} {.fb 0 0 72 30} {.fa 0 0 120 50}
+```
+
+`.f2` was 60% x 55% of a 248x108 `.t` at 20%,22%, so `52 26 144 55` is
+its rectangle: **partial damage, clipped correctly**, not the whole
+widget. Section 4 shows the recursion doing the right thing too -- the
+parent over `.fa`'s rectangle, then `.fb` clipped to the *intersection*
+(72x30), then `.fa` whole.
+
+**And the relayout line is empty**, which is exactly what X does and
+what `textDisp-7.1` asks for (`{}` relayout, a redraw of the display
+lines in the damaged strip). **So the prediction written here -- "this
+is not yet known to fix textDisp-7.1..7.8, and probably does not" --
+was wrong, in the good direction.** Those eight have a real chance now;
+the next full run says.
+
+**Section 4 was right by luck, though, and that is a second bug.**
+`P9ExposeRect` walks `gP9.wins` in **slot order**, which is roughly
+creation order and has nothing to do with what is on top -- while the
+events *are* the stacking here, because drawing is immediate into the
+one rio window with no clipping and whoever repaints last wins the
+pixels. `.fa` had just been raised above `.fb` and happened to sit in a
+later slot. Create the two frames the other way round and the raise
+would have repainted `.fb` last, i.e. done nothing visible.
+
+Tk owns the order and always has: `parentPtr->childList`, lowest first
+(`Tk_RestackWindow`). `P9ExposeRectStacked` walks that instead, falling
+back to the slot walk when `Tk_IdToWindow` cannot answer -- during
+teardown it returns NULL for a window this table still has. The comment
+claiming "the order of the events is the stacking" is true now rather
+than accidentally true.
+
+**A check that cannot fail is not a check**, and the first run of this
+script had one: its `build` proc *assigned* `tk_textRelayout`, so the
+"does this Tk report it at all?" test could never fire, and every
+`relayout:` line read empty for the wrong reason. It probes with a
+separate widget before `build` touches anything now.
 
 #### Tk on Plan 9: TkpClaimFocus, and an embedded wm geometry
 

--- a/sys/lib/tests/tk-expose-test.tcl
+++ b/sys/lib/tests/tk-expose-test.tcl
@@ -58,19 +58,49 @@
 # too little leaves stale pixels that nothing here will ever correct,
 # since there is no backing store and no server to ask.
 #
-# WHAT THIS FILE STILL HAS TO SETTLE. textDisp-7.1 relaid out the whole
-# widget where X relaid out nothing, and that was NOT the Expose --
-# there wasn't one. So a second cause is still unidentified, and the
-# redraw half of this file is what will name it.
+# SECOND RUN: IT WORKS, AND THE RECTANGLES ARE RIGHT.
 #
-# THE FIRST RUN COULD NOT MEASURE THAT HALF, and the reason is worth
-# keeping: tk_textRelayout and tk_textRedraw are only recorded while
-# the widget's own debugging is on -- textDisp.test's line 139 is
+#	STEP: 2. destroy .f2, then update
+#	      exposes: {.t 52 26 144 55 count=0}
+#	      relayout:
+#	      redraw:   2.0 2.40 3.0 3.40 4.0 4.40
+#	STEP: 3. ... 'place forget' it
+#	      exposes: {.t 28 14 96 40 count=0}
+#	STEP: 4. ... raise the lower one
+#	      exposes: {.t 28 14 120 50} {.fb 0 0 72 30} {.fa 0 0 120 50}
+#
+# .f2 was 60% x 55% of a 248x108 .t at 20%,22%, so "52 26 144 55" is its
+# rectangle -- partial damage, clipped, not the whole widget. Section 4
+# shows the recursion right too: the parent over .fa's rectangle, then
+# .fb clipped to the INTERSECTION, then .fa whole.
+#
+# AND THE RELAYOUT LINE IS EMPTY, which is what X does and what
+# textDisp-7.1 asks for. The prediction in the commit that added the fix
+# -- "probably does not fix textDisp-7.1..7.8" -- was wrong in the good
+# direction; the suite says whether those eight go with it.
+#
+# SECTION 4 WAS RIGHT BY LUCK, AND THAT WAS A SECOND BUG. P9ExposeRect
+# walked gP9.wins in SLOT order, roughly creation order, which has
+# nothing to do with what is on top -- while the events ARE the
+# stacking here, since drawing is immediate with no clipping and
+# whoever repaints last wins the pixels. .fa had just been raised above
+# .fb and happened to sit in a later slot. Create the two frames the
+# other way round and the raise would have repainted .fb last, i.e.
+# done nothing visible. P9ExposeRectStacked walks
+# parentPtr->childList instead, which is Tk's own order, lowest first.
+#
+# SO KEEP SECTION 4, and read its order rather than just its presence:
+# .fa must come after .fb in the list whichever way round they were
+# created.
+#
+# The first run could not measure the redraw half at all:
+# tk_textRelayout and tk_textRedraw are only recorded while the widget's
+# own debugging is on -- textDisp.test's line 139 is
 #
 #	.t debug on
 #
 # and this file did not do it, so every "relayout:" line came back
-# empty and said nothing. Worse, `build` here *assigns* the two
+# empty and said nothing. Worse, `build` here *assigned* the two
 # variables, so the "does this Tk report them at all?" check could
 # never fail either. A check that cannot fail is not a check.
 #
@@ -80,9 +110,10 @@
 proc step {m} { puts "STEP: $m"; flush stdout }
 proc note {m} { puts "      $m"; flush stdout }
 
-# Every Expose that arrives anywhere we care about, with its rectangle.
-# The rectangle is the whole point: "0 0 <full width> <full height>" is
-# prediction (b), nothing at all is (a).
+# Every Expose that arrives anywhere we care about, with its rectangle
+# and in ARRIVAL ORDER. Both halves matter: the rectangle says whether
+# the clipping is right, and the order says whether the stacking is --
+# whoever repaints last wins the pixels here.
 set exposes {}
 proc watch {w} {
     bind $w <Expose> [list lappend ::exposes "$w %x %y %w %h count=%c"]
@@ -214,6 +245,25 @@ if {[llength $e] == 0} {
     note "REGRESSION: raising a sibling repainted nothing. raise/lower on"
     note "a widget goes through XConfigureWindow with CWStackMode, NOT"
     note "XRaiseWindow -- see Tk_RestackWindow in generic/tkWindow.c."
+} else {
+    # THE ORDER IS THE POINT, not the presence. .fa was just raised
+    # above .fb, so .fa must repaint LAST or the raise is invisible.
+    # This was right by luck once, when the walk was in slot order.
+    set ia -1; set ib -1
+    for {set i 0} {$i < [llength $e]} {incr i} {
+	set win [lindex [lindex $e $i] 0]
+	if {$win eq ".fa"} { set ia $i }
+	if {$win eq ".fb"} { set ib $i }
+    }
+    if {$ia < 0} {
+	note "REGRESSION: .fa was raised and got no Expose at all."
+    } elseif {$ib >= 0 && $ia < $ib} {
+	note "REGRESSION: .fb repaints AFTER .fa, so the raise is invisible."
+	note "The child walk is not in stacking order -- it must follow"
+	note "parentPtr->childList (lowest first), not gP9.wins slot order."
+    } else {
+	note "ok: .fa repaints last, so the raise is visible"
+    }
 }
 destroy .fa .fb
 

--- a/sys/src/external/tk/plan9/tkPlan9Init.c
+++ b/sys/src/external/tk/plan9/tkPlan9Init.c
@@ -657,6 +657,81 @@ P9ExposeRect(Display *display, Window w, int x, int y, int width, int height)
 }
 
 /*
+ * Expose w and its children over a rectangle, IN STACKING ORDER.
+ *
+ * P9ExposeRect above walks gP9.wins in slot order, which is roughly
+ * creation order and has nothing to do with what is on top. The events
+ * are the stacking here -- drawing is immediate into the one rio window
+ * with no clipping, so whoever repaints last wins the pixels -- so slot
+ * order is a coin toss. tk-expose-test.tcl section 4 got the right
+ * answer by luck:
+ *
+ *	exposes: {.t 28 14 120 50} {.fb 0 0 72 30} {.fa 0 0 120 50}
+ *
+ * .fa had just been raised above .fb and happened to sit in a later
+ * slot. Create the two frames the other way round and the raise would
+ * have repainted .fb last, i.e. done nothing visible.
+ *
+ * Tk owns the order and always has: parentPtr->childList, lowest
+ * first (Tk_RestackWindow). Use it when the window is one Tk knows,
+ * and fall back to the slot walk when it is not -- during teardown
+ * Tk_IdToWindow can answer NULL for a window this table still has.
+ */
+static void
+P9ExposeRectStacked(Display *display, Window w, int x, int y, int w0, int h0)
+{
+    TkWindow *winPtr = (TkWindow *) Tk_IdToWindow(display, w);
+    P9Window *pw = TkP9FindWindow(w);
+    TkWindow *childPtr;
+
+    if (pw == NULL || !pw->mapped || pw->ispixmap)
+        return;
+    if (winPtr == NULL) {
+        P9ExposeRect(display, w, x, y, w0, h0);
+        return;
+    }
+
+    /* The window itself, clipped, without P9ExposeRect's child walk. */
+    {
+        int cx = x, cy = y, cw = w0, ch = h0;
+        XEvent ev;
+
+        if (cx < 0) { cw += cx; cx = 0; }
+        if (cy < 0) { ch += cy; cy = 0; }
+        if (cx + cw > pw->width)  cw = pw->width  - cx;
+        if (cy + ch > pw->height) ch = pw->height - cy;
+        if (cw <= 0 || ch <= 0)
+            return;
+
+        memset(&ev, 0, sizeof(ev));
+        ev.type            = Expose;
+        ev.xexpose.display = display;
+        ev.xexpose.window  = w;
+        ev.xexpose.x       = cx;
+        ev.xexpose.y       = cy;
+        ev.xexpose.width   = cw;
+        ev.xexpose.height  = ch;
+        ev.xexpose.count   = 0;
+        TkP9EnqueueEvent(&ev);
+
+        x = cx; y = cy; w0 = cw; h0 = ch;
+    }
+
+    for (childPtr = winPtr->childList; childPtr != NULL;
+            childPtr = childPtr->nextPtr) {
+        P9Window *c;
+
+        if (childPtr->window == None)
+            continue;
+        c = TkP9FindWindow(childPtr->window);
+        if (c == NULL)
+            continue;
+        P9ExposeRectStacked(display, childPtr->window,
+                x - c->x, y - c->y, w0, h0);
+    }
+}
+
+/*
  * A window is going away, or moving, or being restacked: repair what it
  * was covering.
  *
@@ -695,7 +770,8 @@ P9DamageUnder(Display *display, P9Window *pw)
     parent = TkP9FindWindow(pw->parent);
     if (parent == NULL)
         return;
-    P9ExposeRect(display, parent->xid, pw->x, pw->y, pw->width, pw->height);
+    P9ExposeRectStacked(display, parent->xid,
+            pw->x, pw->y, pw->width, pw->height);
 }
 
 int


### PR DESCRIPTION
Second run of tk-expose-test.tcl, with ".t debug on" added so the redraw half reports at all:

	STEP: 2. destroy .f2, then update
	      exposes: {.t 52 26 144 55 count=0}
	      relayout:
	      redraw:   2.0 2.40 3.0 3.40 4.0 4.40
	STEP: 3. ... 'place forget' it
	      exposes: {.t 28 14 96 40 count=0}
	STEP: 4. ... raise the lower one
	      exposes: {.t 28 14 120 50} {.fb 0 0 72 30} {.fa 0 0 120 50}

.f2 was 60% x 55% of a 248x108 .t at 20%,22%, so "52 26 144 55" is its rectangle: partial damage, clipped correctly, not the whole widget. Section 4 shows the recursion right as well -- the parent over .fa's rectangle, then .fb clipped to the INTERSECTION, then .fa whole.

AND THE RELAYOUT LINE IS EMPTY, which is what X does and what textDisp-7.1 asks for.  The prediction in the previous commit -- "probably does not fix textDisp-7.1..7.8" -- was wrong in the good direction.  Those eight have a real chance now; the next full run says.

SECTION 4 WAS RIGHT BY LUCK, and that is a second bug.  P9ExposeRect walked gP9.wins in SLOT order, roughly creation order, which has nothing to do with what is on top -- while the events ARE the stacking here, because drawing is immediate into the one rio window with no clipping and whoever repaints last wins the pixels.  .fa had just been raised above .fb and happened to sit in a later slot.  Create the two frames the other way round and the raise would have repainted .fb last, i.e. done nothing visible.

Tk owns the order and always has: parentPtr->childList, lowest first (Tk_RestackWindow).  P9ExposeRectStacked walks that instead, falling back to the slot walk when Tk_IdToWindow cannot answer -- during teardown it returns NULL for a window this table still has.  The comment claiming "the order of the events is the stacking" is true now rather than accidentally true.

Section 4 of the script checks the ORDER rather than the presence now: .fa must repaint after .fb whichever way round they were created.

Host gcc syntax check over plan9/*.c is clean.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs