### PR TITLE
tk: build tktest's stub objects with the flags they were written for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2373,6 +2373,44 @@ compiling two vendored files that already exist and already build
 clean. **Prefer the link over the patch** whenever the missing symbols
 turn out to live in a file the upstream tree already ships.
 
+**A STUB OBJECT IS COMPILED AGAINST THE TREE IT IS THE CLIENT OF, not
+against the binary it is being linked into.** This is the second thing
+a first attempt got wrong, and half of it is silent. Both stub files
+were built with `cmd/wish/mkfile`'s `CFLAGS`, and they must not be:
+
+- **The include path.** `tclStubLib.c` reaches `tclInt.h` ->
+  `tclPort.h` -> `tclUnixPort.h`, and neither that nor `tclConfig.h` is
+  on Tk's. It needs `$TCLSRC/plan9`, `$TCLSRC/unix`,
+  `$TCLSRC/libtommath` and `sys/src/ape/lib/tcl`, which is what
+  `cmd/tclsh/mkfile` passes. This half announces itself --
+  `tclUnixPort.h: No such file`.
+- **`-DMODULE_SCOPE=/***/`, and this one does not.** Emptying it turns
+  every `MODULE_SCOPE const Tcl_ObjType tclFooType;` in `tclInt.h` from
+  an extern *declaration* into a tentative *definition*, so the object
+  defines them. Measured on the build host with `nm`:
+
+| object | flags | symbols |
+|---|---|---|
+| `tclStubLib.o` | tclsh's | **6** |
+| `tclStubLib.o` | wish's | 38 |
+| `tkStubLib.o` | `MODULE_SCOPE` kept | **6** |
+| `tkStubLib.o` | `MODULE_SCOPE` empty | 30 |
+
+The extras are `tclEmptyString`, `tclBignumType`, `tkPhotoImageType`,
+`tkImgFmtGIF`, `tkMainWindowList` and the rest -- every one of which
+`libtcl.a` and `libtk.a` also define, properly initialised. Which copy
+the linker keeps is not a thing to leave to chance: take the stub
+object's and Tk has a **NULL photo image type**. `tkStubLib.c` linked
+anyway in the attempt before this one, so that would have been a
+working `tktest` with quietly wrong image tables -- a fault that would
+have surfaced as image tests failing and been chased in `plan9/`.
+
+So `STUBCFLAGS` in `cmd/wish/mkfile` carries both trees' include paths
+and leaves `MODULE_SCOPE` at its default, and the two stub objects use
+it. **`nm` on the host settles this class of question in one command**
+and is worth reaching for whenever an object is compiled with flags it
+was not written for.
+
 What it unlocks, from the skip tally of run 6:
 
 | constraint | tests |
@@ -2428,6 +2466,13 @@ test binary is built differently and nothing says so. That is the
 `HFILES` lesson in another form, and on this build system a
 configuration that drifts is expensive to diagnose. **Put a test binary
 in the directory whose flags it shares.**
+
+**But read that rule with the stub note above beside it**, because as
+first written it was too simple and it is what produced the second bad
+attempt. `tktest` shares wish's flags for the three Tk objects and
+*does not* for `tclStubLib.c`, which belongs to the other tree. "The
+directory whose flags it shares" is the right home for a test binary;
+it does not follow that every object in it takes the same flags.
 
 No object collides between the two targets in `cmd/wish`: `tkAppInit.$O`
 is wish's and `tkTestInit.$O` is tktest's, from the same source built

--- a/sys/src/ape/cmd/wish/mkfile
+++ b/sys/src/ape/cmd/wish/mkfile
@@ -30,7 +30,7 @@ CFLAGS=\
 	-I$TCLSRC/generic\
 	-I$APEXPROOT/sys/include/ape\
 	-I$APEXPROOT/$objtype/include/ape\
-	-I$APEXPROOT/sys/ape/lib/tcl\
+	-I$APEXPROOT/sys/src/ape/lib/tcl\
 	-DHAVE_TCL_CONFIG_H\
 	-DPLAN9\
 	-DMODULE_SCOPE=/***/\
@@ -69,7 +69,7 @@ tkAppInit.$O: $TKSRC/unix/tkAppInit.c
 #	cd sys/src/ape/cmd/wish && mk tktest
 #	./tktest $home/APExp/sys/lib/tests/tk-runall.tcl >/tmp/tk-all.out >[2=1]
 #
-# The three objects are upstream's TKTEST_OBJS exactly. The
+# The first three objects are upstream's TKTEST_OBJS exactly. The
 # $(@TK_WINDOWINGSYSTEM@_TKTEST_OBJS) it appends is empty for X11 in
 # this Tk, so there is no fourth, platform-specific object to find or
 # write -- worth checking before assuming a test binary needs porting.
@@ -107,6 +107,38 @@ tkAppInit.$O: $TKSRC/unix/tkAppInit.c
 # the next Tk update would silently revert, to avoid compiling two
 # vendored files that already exist and already build clean.
 #
+# AND THEY DO NOT BUILD WITH THIS FILE'S CFLAGS, which is the second
+# thing a first attempt got wrong. A stub object is compiled against the
+# tree it is the client of, so tclStubLib.c wants TCL's flags -- see
+# STUBCFLAGS below -- and only tkStubLib.c can use the ones above. Two
+# separate reasons:
+#
+#  1. -I. tclStubLib.c reaches tclInt.h -> tclPort.h -> tclUnixPort.h,
+#     and neither that nor tclConfig.h is on Tk's include path. The
+#     symptom is honest ("tclUnixPort.h: No such file"), so this half
+#     announces itself.
+#
+#  2. -DMODULE_SCOPE=/***/ IS SILENT AND IS THE DANGEROUS ONE. Emptying
+#     it turns every "MODULE_SCOPE const Tcl_ObjType tclFooType;" in
+#     tclInt.h from an extern DECLARATION into a tentative DEFINITION,
+#     so the object defines them. Measured on the host with nm:
+#
+#	tclStubLib.o, tclsh's flags	 6 symbols -- the wanted ones
+#	tclStubLib.o, this file's flags	38 symbols
+#	tkStubLib.o,  MODULE_SCOPE kept	 6 symbols
+#	tkStubLib.o,  MODULE_SCOPE empty 30 symbols
+#
+#     The extras are tclEmptyString, tclBignumType, tkPhotoImageType,
+#     tkImgFmtGIF, tkMainWindowList and so on -- every one of which
+#     libtcl.a and libtk.a also define, properly initialised. Which
+#     copy the linker keeps is not something to leave to chance: take
+#     the stub object's and Tk has a NULL photo image type. tkStubLib.c
+#     linked anyway in the attempt before this one, so this would have
+#     been a working tktest with quietly wrong image tables.
+#
+# So MODULE_SCOPE is left at its default (extern) for both stub objects,
+# and that is what STUBCFLAGS exists for.
+#
 # WHY IT IS WORTH BUILDING: 448 tests in Tk's suite are SKIPPED for want
 # of these commands -- a third as many again as the 268 that fail --
 # and none of them has ever been measured here. EXPECT THE FAILURE COUNT
@@ -131,11 +163,33 @@ tkTest.$O: $TKSRC/generic/tkTest.c
 tkSquare.$O: $TKSRC/generic/tkSquare.c
 	$CC $CFLAGS $TKSRC/generic/tkSquare.c
 
+# The client side of the stub interfaces, compiled against the tree each
+# belongs to. MODULE_SCOPE is deliberately NOT overridden here -- see the
+# measured symbol counts above; emptying it makes these objects define
+# variables that libtcl.a and libtk.a already define for real.
+STUBCFLAGS=\
+	-c\
+	-I$TKSRC/generic\
+	-I$TKSRC/xlib\
+	-I$TKSRC/plan9\
+	-I$TCLSRC/generic\
+	-I$TCLSRC/plan9\
+	-I$TCLSRC/unix\
+	-I$TCLSRC/libtommath\
+	-I$APEXPROOT/sys/src/ape/lib/tcl\
+	-I$APEXPROOT/sys/include/ape\
+	-I$APEXPROOT/$objtype/include/ape\
+	-DHAVE_TCL_CONFIG_H\
+	-DHAVE_TK_CONFIG_H\
+	-DPLAN9\
+	-DWCHAR=char\
+	-DSTATIC_BUILD\
+
 tclStubLib.$O: $TCLSRC/generic/tclStubLib.c
-	$CC $CFLAGS -DSTATIC_BUILD $TCLSRC/generic/tclStubLib.c
+	$CC $STUBCFLAGS $TCLSRC/generic/tclStubLib.c
 
 tkStubLib.$O: $TKSRC/generic/tkStubLib.c
-	$CC $CFLAGS -DSTATIC_BUILD $TKSRC/generic/tkStubLib.c
+	$CC $STUBCFLAGS $TKSRC/generic/tkStubLib.c
 
 clean:V:
 	rm -f *.[$OS] tktest $BIN/$TARG


### PR DESCRIPTION
A stub object is compiled against the tree it is the CLIENT of, not against the binary it is being linked into.  Both were built with cmd/wish/mkfile's CFLAGS and must not be.  Two faults, and only one of them announces itself.

The include path.  tclStubLib.c reaches tclInt.h -> tclPort.h -> tclUnixPort.h, and neither that nor tclConfig.h is on Tk's path; it needs $TCLSRC/plan9, $TCLSRC/unix, $TCLSRC/libtommath and sys/src/ape/lib/tcl, which is what cmd/tclsh/mkfile passes.  That is why the link still wanted Tcl_InitStubs and tclStubsPtr while every Tk symbol had been resolved: the object was empty of them.

-DMODULE_SCOPE=/***/, which is silent and is the dangerous one. Emptying it turns every "MODULE_SCOPE const Tcl_ObjType tclFooType;" in tclInt.h from an extern declaration into a tentative definition, so the object defines them.  Measured with nm on the host:

	tclStubLib.o, tclsh's flags		 6 symbols
	tclStubLib.o, wish's flags		38
	tkStubLib.o,  MODULE_SCOPE kept		 6
	tkStubLib.o,  MODULE_SCOPE empty	30

The extras are tclEmptyString, tclBignumType, tkPhotoImageType, tkImgFmtGIF, tkMainWindowList and the rest, every one of which libtcl.a and libtk.a also define and initialise.  Which copy the linker keeps is not a thing to leave to chance: take the stub object's and Tk has a NULL photo image type.  tkStubLib.c linked anyway last time, so that would have been a working tktest with quietly wrong image tables.

STUBCFLAGS carries both trees' include paths and leaves MODULE_SCOPE alone; both stub objects now come out at exactly the six symbols that were undefined.

Also corrects the tcl include added to CFLAGS in 00cee253: sys/ape/lib/tcl does not exist, the directory holding tclConfig.h and tclUuid.h is sys/src/ape/lib/tcl, so the -I was a no-op.

The "put a test binary in the directory whose flags it shares" note was too simple as written and is qualified in CLAUDE.md: it is the right home, but it does not follow that every object in it takes the same flags.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs