### PR TITLE
tk: embedded toplevels have no position; tktest's flags, all four

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1734,24 +1734,52 @@ table below is the whole thing, and the list has been re-derived rather
 than extended.
 
 ```
-all.tcl:  Total 10027  Passed 8330  Skipped 1429  Failed 268
+all.tcl:  Total 10027  Passed 8427  Skipped 1429  Failed 171
 Sourced 97 Test Files.
 ```
 
-**268 failing tests**, from **485** on the first full run -- which was
+**171 failing tests**, from **485** on the first full run -- which was
 up from 25 only because that run was the first to measure 35 files at
 all, not a regression. Attributed by file across the runs:
 
-| file | run 1 | run 2 | run 3 | run 4 | run 5 | run 6 |
-|---|---|---|---|---|---|---|
-| `wm.test` | 202 | 130 | 74 | 66 | 62 | 62 |
-| `unixWm.test` | 129 | 62 | 60 | 59 | 59 | 59 |
-| `unixEmbed.test` | 29 | 29 | 29 | 29 | 28 | 28 |
-| `textDisp.test` | 23 | 23 | 23 | 23 | 23 | **14** |
-| `select.test` | 23 | 23 | 23 | 23 | 23 | 23 |
-| `unixSelect.test` | 18 | 18 | 18 | 18 | 18 | 18 |
-| `systray.test` | 13 | 13 | 13 | 13 | 12 | 12 |
-| `winfo.test` | 6 | 4 | 4 | 4 | 4 | 4 |
+| file | run 1 | run 2 | run 3 | run 4 | run 5 | run 6 | run 7 |
+|---|---|---|---|---|---|---|---|
+| `wm.test` | 202 | 130 | 74 | 66 | 62 | 62 | **14** |
+| `unixWm.test` | 129 | 62 | 60 | 59 | 59 | 59 | **10** |
+| `unixEmbed.test` | 29 | 29 | 29 | 29 | 28 | 28 | **30** |
+| `textDisp.test` | 23 | 23 | 23 | 23 | 23 | 14 | 14 |
+| `select.test` | 23 | 23 | 23 | 23 | 23 | 23 | 23 |
+| `unixSelect.test` | 18 | 18 | 18 | 18 | 18 | 18 | 18 |
+| `systray.test` | 13 | 13 | 13 | 13 | 12 | 12 | 12 |
+| `winfo.test` | 6 | 4 | 4 | 4 | 4 | 4 | 4 |
+
+**Run 7 is the wm work: 268 -> 171, and `wm` plus `unixWm` went 121 to
+24.** It is also the run that shows why the per-file comparison is
+worth doing rather than reading a total -- **`unixEmbed` went UP, 28 to
+30**, and the total falling by 97 would have hidden it completely.
+
+The two are `unixEmbed-10.1` and `10.2`, and `10.2` is one this file
+had recorded as *fixed* two runs earlier. Both want `+0+0` from
+`wm geometry` on an embedded toplevel and got back what was set. The
+cause is the negative-geometry change in the same commit: the query now
+reports `wmPtr->x/y` rather than `winPtr->changes.x/y`, which is right
+for every other toplevel -- a window asked for at `-0-0` has to read
+back as `-0-0`, not as the large positive coordinate it landed on --
+and wrong for an embedded one, which has no position of its own.
+Upstream zeroes it explicitly, with its own comment saying why:
+
+```c
+/* UpdateGeometryInfo, tkUnixWm.c */
+wmPtr->x = wmPtr->y = 0;
+wmPtr->flags &= ~(WM_NEGATIVE_X|WM_NEGATIVE_Y);
+```
+
+"embedded windows are not allowed to move". Upstream gates that on
+`TK_EMBEDDED|TK_BOTH_HALVES` -- embedded *and* the container in this
+same process, since otherwise it cannot know where the other
+application put it; here both halves always share the process, so
+`TK_EMBEDDED` alone is the same condition. Fixed in
+`WmUpdateGeometry`'s embedded branch.
 
 **Compare two runs by file before reading anything into a total.**
 Run 6 differs from run 5 in exactly one line of that table -- textDisp
@@ -2405,11 +2433,47 @@ anyway in the attempt before this one, so that would have been a
 working `tktest` with quietly wrong image tables -- a fault that would
 have surfaced as image tests failing and been chased in `plan9/`.
 
-So `STUBCFLAGS` in `cmd/wish/mkfile` carries both trees' include paths
-and leaves `MODULE_SCOPE` at its default, and the two stub objects use
-it. **`nm` on the host settles this class of question in one command**
-and is worth reaching for whenever an object is compiled with flags it
-was not written for.
+**AND THE SCOPE OF THAT WAS MISJUDGED TWICE.** The first attempt built
+all four extra objects with `CFLAGS` and did not link. The second moved
+only the two **stub** files -- because the link error named only the
+stub symbols -- and left `tkTest.c` and `tkSquare.c` on `CFLAGS`. They
+linked, and `tktest` then died before printing a byte:
+
+```
+tktest 10315: suicide: sys: trap: fault read addr=0x0 pc=0x5523a1
+acid: src(0x5523a1)  ->  ap/arch/amd64/strlen.s:11, REPN SCASB
+```
+
+`strlen(NULL)` -- which is what a string table that should have been
+initialised and is all zeroes gives you. `tkTest.o` was defining 35
+extra symbols including `tkMainWindowList`, `tkPhotoImageType`,
+`tkImgFmtGIF`, `tkStateStrings` and `tkTextCharType`, and the linker
+kept the zeroed copies.
+
+| object | `CFLAGS` | `TESTCFLAGS` |
+|---|---|---|
+| `tkTest.o` | 36 | **1** |
+| `tkSquare.o` | 25 | **1** |
+| `tclStubLib.o` | 38 | **6** |
+| `tkStubLib.o` | 30 | **6** |
+
+**A link error is a poor guide to which objects are wrong**: the two it
+named were wrong, and so were the two it did not. The right value is
+not a judgement call either -- `sys/src/ape/lib/tk/mkfile:198` and
+`lib/tcl/mkfile:107` build the libraries with `-DMODULE_SCOPE=extern`,
+so that is simply what anything linked beside them wants.
+
+`TESTCFLAGS` in `cmd/wish/mkfile` carries both trees' include paths and
+`-DMODULE_SCOPE=extern`, and all four use it. `CFLAGS` keeps the empty
+`MODULE_SCOPE` and is harmless for the two objects that use it, because
+`tkAppInit.c` includes `tk.h` and **not** `tkInt.h` -- 2 symbols either
+way, measured. That is why the flag survived there for the life of the
+port, and why anything else added to that directory needs `TESTCFLAGS`.
+
+**Check every object built against a library for the flags that library
+was built with, not just the ones the linker complained about.** One
+`nm -g --defined-only x.o | wc -l` per object answers it, and it is the
+cheapest check in this whole file -- no VM, no link, one second.
 
 What it unlocks, from the skip tally of run 6:
 

--- a/sys/src/ape/cmd/wish/mkfile
+++ b/sys/src/ape/cmd/wish/mkfile
@@ -107,37 +107,21 @@ tkAppInit.$O: $TKSRC/unix/tkAppInit.c
 # the next Tk update would silently revert, to avoid compiling two
 # vendored files that already exist and already build clean.
 #
-# AND THEY DO NOT BUILD WITH THIS FILE'S CFLAGS, which is the second
-# thing a first attempt got wrong. A stub object is compiled against the
-# tree it is the client of, so tclStubLib.c wants TCL's flags -- see
-# STUBCFLAGS below -- and only tkStubLib.c can use the ones above. Two
-# separate reasons:
+# AND NONE OF THE FOUR BUILDS WITH THIS FILE'S CFLAGS, which took two
+# further attempts to get right. See the TESTCFLAGS block below: the
+# short of it is that CFLAGS empties MODULE_SCOPE, which is fine for
+# tkAppInit.c and wrong for anything that includes tkInt.h or tclInt.h.
 #
-#  1. -I. tclStubLib.c reaches tclInt.h -> tclPort.h -> tclUnixPort.h,
-#     and neither that nor tclConfig.h is on Tk's include path. The
-#     symptom is honest ("tclUnixPort.h: No such file"), so this half
-#     announces itself.
+# The scope of that was misjudged twice. The first attempt used CFLAGS
+# for all four and did not link. The second moved the two STUB files and
+# left tkTest.c and tkSquare.c on CFLAGS -- because the link error named
+# only the stub symbols, and a link error is a poor guide to which
+# objects are wrong: the other two linked and then died at run time,
+# before printing anything.
 #
-#  2. -DMODULE_SCOPE=/***/ IS SILENT AND IS THE DANGEROUS ONE. Emptying
-#     it turns every "MODULE_SCOPE const Tcl_ObjType tclFooType;" in
-#     tclInt.h from an extern DECLARATION into a tentative DEFINITION,
-#     so the object defines them. Measured on the host with nm:
-#
-#	tclStubLib.o, tclsh's flags	 6 symbols -- the wanted ones
-#	tclStubLib.o, this file's flags	38 symbols
-#	tkStubLib.o,  MODULE_SCOPE kept	 6 symbols
-#	tkStubLib.o,  MODULE_SCOPE empty 30 symbols
-#
-#     The extras are tclEmptyString, tclBignumType, tkPhotoImageType,
-#     tkImgFmtGIF, tkMainWindowList and so on -- every one of which
-#     libtcl.a and libtk.a also define, properly initialised. Which
-#     copy the linker keeps is not something to leave to chance: take
-#     the stub object's and Tk has a NULL photo image type. tkStubLib.c
-#     linked anyway in the attempt before this one, so this would have
-#     been a working tktest with quietly wrong image tables.
-#
-# So MODULE_SCOPE is left at its default (extern) for both stub objects,
-# and that is what STUBCFLAGS exists for.
+# **Check every object built against a library for the flags that
+# library was built with, not just the ones the linker complained
+# about.** One "nm | wc -l" per object would have shown all four.
 #
 # WHY IT IS WORTH BUILDING: 448 tests in Tk's suite are SKIPPED for want
 # of these commands -- a third as many again as the 268 that fail --
@@ -158,16 +142,49 @@ tkTestInit.$O: $TKSRC/unix/tkAppInit.c
 	$CC $CFLAGS -DTK_TEST -o $target $TKSRC/unix/tkAppInit.c
 
 tkTest.$O: $TKSRC/generic/tkTest.c
-	$CC $CFLAGS $TKSRC/generic/tkTest.c
+	$CC $TESTCFLAGS $TKSRC/generic/tkTest.c
 
 tkSquare.$O: $TKSRC/generic/tkSquare.c
-	$CC $CFLAGS $TKSRC/generic/tkSquare.c
+	$CC $TESTCFLAGS $TKSRC/generic/tkSquare.c
 
-# The client side of the stub interfaces, compiled against the tree each
-# belongs to. MODULE_SCOPE is deliberately NOT overridden here -- see the
-# measured symbol counts above; emptying it makes these objects define
-# variables that libtcl.a and libtk.a already define for real.
-STUBCFLAGS=\
+# EVERY OBJECT THAT INCLUDES tkInt.h OR tclInt.h USES THESE, not CFLAGS
+# above, and the difference that matters is MODULE_SCOPE.
+#
+# -DMODULE_SCOPE=extern is what sys/src/ape/lib/tk/mkfile:198 and
+# lib/tcl/mkfile:107 build the libraries with, so it is simply the right
+# value; CFLAGS above empties it instead, which turns every
+# "MODULE_SCOPE const Tk_ObjType tkFooType;" in tkInt.h from an extern
+# DECLARATION into a tentative DEFINITION. Measured on the host with nm:
+#
+#	object		CFLAGS above	these flags
+#	tkTest.o	36 symbols	 1   (Tktest_Init)
+#	tkSquare.o	25		 1
+#	tclStubLib.o	38		 6
+#	tkStubLib.o	30		 6
+#
+# The 35 extras in tkTest.o are tkMainWindowList, tkPhotoImageType,
+# tkImgFmtGIF, tkStateStrings, tkTextCharType and the rest -- every one
+# of which libtk.a also defines, initialised. The linker keeps one, and
+# when it kept the zeroed one tktest died before printing anything:
+#
+#	tktest 10315: suicide: sys: trap: fault read addr=0x0 pc=0x5523a1
+#	acid: src(0x5523a1)  ->  ap/arch/amd64/strlen.s:11, REPN SCASB
+#
+# strlen(NULL), which is what a string table that should have been
+# initialised and is all zeroes gives you.
+#
+# CFLAGS above is harmless for the two objects that use it because
+# tkAppInit.c includes tk.h and NOT tkInt.h, so it has no MODULE_SCOPE
+# variable declarations to turn into definitions -- 2 symbols either way,
+# measured. That is exactly why the flag has survived there, and why
+# anything else added to this directory must take TESTCFLAGS instead.
+#
+# The include path differs too, and that half announces itself:
+# tclStubLib.c reaches tclInt.h -> tclPort.h -> tclUnixPort.h, and
+# neither that nor tclConfig.h is on Tk's path. A stub object is
+# compiled against the tree it is the CLIENT of, not the binary it is
+# linked into.
+TESTCFLAGS=\
 	-c\
 	-I$TKSRC/generic\
 	-I$TKSRC/xlib\
@@ -182,14 +199,15 @@ STUBCFLAGS=\
 	-DHAVE_TCL_CONFIG_H\
 	-DHAVE_TK_CONFIG_H\
 	-DPLAN9\
+	-DMODULE_SCOPE=extern\
 	-DWCHAR=char\
 	-DSTATIC_BUILD\
 
 tclStubLib.$O: $TCLSRC/generic/tclStubLib.c
-	$CC $STUBCFLAGS $TCLSRC/generic/tclStubLib.c
+	$CC $TESTCFLAGS $TCLSRC/generic/tclStubLib.c
 
 tkStubLib.$O: $TKSRC/generic/tkStubLib.c
-	$CC $STUBCFLAGS $TKSRC/generic/tkStubLib.c
+	$CC $TESTCFLAGS $TKSRC/generic/tkStubLib.c
 
 clean:V:
 	rm -f *.[$OS] tktest $BIN/$TARG

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -329,6 +329,28 @@ WmUpdateGeometry(void *clientData)
      * other thing the early return skipped.
      */
     if (winPtr->flags & TK_EMBEDDED) {
+	/*
+	 * AN EMBEDDED TOPLEVEL HAS NO POSITION OF ITS OWN. It sits at its
+	 * container's origin, so upstream zeroes x/y here -- "embedded
+	 * windows are not allowed to move", UpdateGeometryInfo's own
+	 * comment -- and clears the negative flags with them.
+	 *
+	 * This was invisible until "wm geometry" started reporting
+	 * wmPtr->x/y rather than winPtr->changes.x/y, which is right for
+	 * every other toplevel (a window asked for at "-0-0" must read
+	 * back as "-0-0", not as the large positive coordinate it landed
+	 * on). For an embedded one it meant "wm geometry .t1 +40+50"
+	 * read back as +40+50 where X says +0+0: unixEmbed-10.1 and
+	 * 10.2, which had been passing and broke on that change.
+	 *
+	 * Upstream gates this on TK_EMBEDDED|TK_BOTH_HALVES -- embedded
+	 * AND the container in this same process -- because otherwise it
+	 * cannot know where the other application put it. Here both
+	 * halves always share the process, so TK_EMBEDDED alone is the
+	 * same condition.
+	 */
+	wmPtr->x = wmPtr->y = 0;
+	wmPtr->flags &= ~(WM_NEGATIVE_X | WM_NEGATIVE_Y);
 	TkP9EmbedGeometryRequest(winPtr, width, height);
 	return;
     }


### PR DESCRIPTION
Run 7: 268 -> 171, and wm plus unixWm went 121 to 24.

AND unixEmbed went UP, 28 to 30, which a total falling by 97 would have hidden completely -- the argument for comparing per file.  The two are unixEmbed-10.1 and 10.2, and 10.2 was recorded as fixed two runs ago.  Both want +0+0 from "wm geometry" on an embedded toplevel and got back what was set.  The cause is the negative-geometry change in the same commit: the query reports wmPtr->x/y now rather than winPtr->changes.x/y, which is right for every other toplevel -- a window asked for at -0-0 must read back as -0-0 and not as the large positive coordinate it landed on -- and wrong for an embedded one, which sits at its container's origin.  Upstream zeroes it explicitly in UpdateGeometryInfo with its own comment, "embedded windows are not allowed to move", gated on TK_EMBEDDED|TK_BOTH_HALVES; here both halves always share the process, so TK_EMBEDDED alone is that condition.

tktest linked and then died before printing a byte:

	suicide: sys: trap: fault read addr=0x0 pc=0x5523a1
	acid: src(0x5523a1) -> ap/arch/amd64/strlen.s:11, REPN SCASB

strlen(NULL).  The MODULE_SCOPE hazard fixed last time for the two stub objects applies to tkTest.c and tkSquare.c as well, and was not applied there because the link error had named only the stub symbols. tkTest.o was defining 35 extra zeroed globals -- tkMainWindowList, tkPhotoImageType, tkImgFmtGIF, tkStateStrings, tkTextCharType -- and the linker kept those instead of libtk.a's initialised ones.

	object		CFLAGS	TESTCFLAGS
	tkTest.o	36	 1
	tkSquare.o	25	 1
	tclStubLib.o	38	 6
	tkStubLib.o	30	 6

A link error is a poor guide to which objects are wrong: the two it named were, and so were the two it did not.  The right value is not a judgement call either -- lib/tk/mkfile:198 and lib/tcl/mkfile:107 build the libraries with -DMODULE_SCOPE=extern.  STUBCFLAGS is TESTCFLAGS now and all four use it.  CFLAGS keeps the empty MODULE_SCOPE and stays harmless for the two objects that use it, because tkAppInit.c includes tk.h and not tkInt.h: 2 symbols either way, measured.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs