### PR TITLE
fix(tk): destroy the menubar with its toplevel; record that run 9 cra…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2727,6 +2727,86 @@ Tk's own test commands, and it skips itself under `wish`. Its last
 section *prints* the two known-wrong answers rather than asserting them,
 so that today's limitation is not frozen in as the requirement.
 
+#### Run 9: the freeze is gone and the run still does not finish
+
+**IT CRASHED, AND IT LOOKED LIKE IT HAD FINISHED.** `tk-menubar-test.tcl`
+passes every case, and the suite no longer hangs -- but the log ends
+
+```
+==== unixWm-49.2 FAILED
+
+tktest 17077: suicide: sys: trap: fault write addr=0x3a3a79007393 pc=0x2d1856
+```
+
+with no `Tests ended`, no `all.tcl: Total`, and no
+`tk-runall: every file ran` marker. `visual`, `winfo`, `winWm`, `wm` and
+`xmfbox` are **still unmeasured**, and `grep -c FAILED` halved gives 185
+-- the same 185 as run 8, off a prefix that is slightly *shorter*
+(run 8 reached `unixWm-50.1`; this stops at `49.2`).
+
+**A fault returns you to the shell prompt exactly as a clean finish
+does.** That is the whole of why this read as a complete run: there is
+no `$` to tell them apart. **The discriminator is the marker, and it is
+there for this** -- `tk-runall: every file ran, now entering exit` is
+printed from inside the `::exit` wrapper, so its absence means the run
+did not reach the end. Check for it before reading a total, the same way
+`git merge-base` is checked before reading a result. `79174e01` *was* in
+the build, so this is ours.
+
+**Both menubar tests report exactly what the section above predicted** --
+`unixWm-49.2` gives `52 7 12 32` against `52 7 12 62`, the missing
+`menuHeight` offset -- so the diagnosis holds and the fault is something
+else, after the result was printed.
+
+**The address is the useful part.** `0x3a3a79007393` is not a plausible
+heap or stack address; its bytes read as text (`:`, `:`, `y`). That is a
+**pointer fetched out of a block that has been freed and reused for a
+string** -- the shape this file already records twice (`TkpDeleteFont`,
+`TkpFreeColor`), and on this allocator the first thing that fails is the
+dereference, not the read.
+
+**One hole found by reading upstream rather than guessing, and it is
+fixed -- but it is NOT established to be this crash.** Upstream's
+`TkWmDeadWindow` opens with
+
+```c
+if (wmPtr->menubar != NULL) {
+    Tk_DestroyWindow(wmPtr->menubar);
+}
+```
+
+and the port's did not. Why it matters is invisible from `unixWm.test`,
+where the menubar is a **child** (`.t.menu`) and so is already gone --
+generic Tk destroys the whole `childList` at `tkWindow.c:1485`, well
+before `TkWmDeadWindow` at :1580. The case it is for is
+`$w configure -menu .menubar`, the ordinary way a program sets one:
+`tkUnixMenu.c` hands `TkUnixSetMenubar` the **menu widget**, normally a
+*sibling*. Nothing destroys that with the toplevel, so the `ckfree`
+leaves `menubarPtr->wmInfoPtr` dangling and `MenubarDestroyProc` later
+writes `wmPtr->menubar` through it and reads `wmPtr->winPtr` back out to
+schedule an update. Same shape as the icon relationship in the same
+function.
+
+Because the suite's menubar is a child, **that fix probably does not
+explain this fault**, and saying otherwise would be the mistake this
+file has recorded four times. `tk-menubar-test.tcl` grew a section 5
+that separates the orderings -- child menubar, sibling menubar, and the
+`deleteWindows` / `wm withdraw .` / new-toplevel sequence `unixWm.test`
+runs immediately after 49.2 -- so it can answer without the suite.
+
+**The decisive step is the pc, and it needs no rebuild** -- static
+`acid` on the binary, as the crash section above already records:
+
+```
+acid $home/APExp/sys/src/ape/cmd/wish/tktest
+acid: src(0x2d1856)
+```
+
+Do that before anything else. Reading the shape of the fault matters as
+much as the line: a wild pointer here shows up at the first *double*
+indirection, so the function that faults is often one step past the one
+that is wrong.
+
 #### The four untouched files: 106 failures, and three of them are ours
 
 `unixEmbed` 29, `select` 23, `textDisp` 23, `unixSelect` 18, `systray`

--- a/sys/lib/tests/tk-menubar-test.tcl
+++ b/sys/lib/tests/tk-menubar-test.tcl
@@ -116,7 +116,58 @@ puts "  ok: no fault"
 flush stdout
 
 # ------------------------------------------------------------------
-step "5. KNOWN WRONG, recorded rather than asserted"
+step "5. destroy the TOPLEVEL while a menubar is in force"
+
+# This is the half section 4 does not cover, and it is where the suite
+# faulted: run 9 crashed immediately after unixWm-49.2, which is a
+# menubar test, with
+#
+#	tktest: suicide: sys: trap: fault write addr=0x3a3a79007393
+#
+# -- a write through a pointer whose bytes read like text, i.e. one
+# fetched out of a block that has been freed and reused. Two orderings
+# have to be told apart, so they are separate steps.
+
+step "5a. menubar is a CHILD of the toplevel (what unixWm-49.2 does)"
+destroy .t
+toplevel .t -width 300 -height 200 -bd 2 -relief raised
+frame .t.m -bd 2 -relief raised -width 100 -height 30
+testmenubar window .t .t.m
+update
+destroy .t
+update
+puts "  ok: no fault"
+flush stdout
+
+# The ordinary way a program sets a menubar is "$w configure -menu .m",
+# and tkUnixMenu.c then hands TkUnixSetMenubar the MENU WIDGET -- which
+# is a SIBLING, not a child. Nothing destroys it with the toplevel, so
+# this is the ordering where the menubar can outlive the WmInfo it
+# points at. Upstream's TkWmDeadWindow destroys it explicitly.
+step "5b. menubar is NOT a child of the toplevel"
+destroy .t .m
+toplevel .t -width 300 -height 200
+frame .m -bd 2 -relief raised -width 100 -height 30
+testmenubar window .t .m
+update
+destroy .t
+update
+check "menubar went with its toplevel" [winfo exists .m] 0
+
+step "5c. what unixWm.test does next: withdraw . and build a toplevel"
+destroy .t
+wm geom . +700+700
+wm withdraw .
+toplevel .t -width 200 -height 200 -bg green
+update
+destroy .t
+wm deiconify .
+update
+puts "  ok: no fault"
+flush stdout
+
+# ------------------------------------------------------------------
+step "6. KNOWN WRONG, recorded rather than asserted"
 
 # There are no wrapper windows in this port, so a menubar stays an
 # ordinary child of its toplevel instead of sitting above it in a

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -1545,6 +1545,37 @@ TkWmDeadWindow(TkWindow *winPtr)
 
     if (wmPtr == NULL)
 	return;
+
+    /*
+     * THE MENUBAR HOLDS A POINTER TO THIS WmInfo AND MUST NOT OUTLIVE IT.
+     * Upstream's TkWmDeadWindow opens with exactly this line, and the
+     * reason is not obvious from unixWm.test, where the menubar happens
+     * to be a CHILD of its toplevel (.t.menu) and so is already gone by
+     * the time this runs -- generic Tk destroys the whole childList
+     * before reaching here (tkWindow.c:1485).
+     *
+     * The case it is for is "$w configure -menu .menubar", which is the
+     * ordinary way a program sets one: tkUnixMenu.c hands us the MENU
+     * WIDGET, which is usually a sibling rather than a child. Nothing
+     * then destroys it with the toplevel, so without this the ckfree
+     * below leaves menubarPtr->wmInfoPtr pointing at freed memory, and
+     * MenubarDestroyProc later writes wmPtr->menubar through it and
+     * reads wmPtr->winPtr back out to schedule an update.
+     *
+     * Same shape as the icon relationship below, and the same reason it
+     * is worth the line: on this allocator a freed WmInfo stays readable
+     * and writable, so nothing fails until the garbage read out of it is
+     * dereferenced, somewhere else entirely.
+     */
+    if (wmPtr->menubar != NULL) {
+	TkWindow *menubarPtr = wmPtr->menubar;
+
+	wmPtr->menubar = NULL;
+	wmPtr->menuHeight = 0;
+	menubarPtr->wmInfoPtr = NULL;
+	Tk_DestroyWindow((Tk_Window) menubarPtr);
+    }
+
     WmUnlink(winPtr->dispPtr, wmPtr);
     if (wmPtr->flags & WM_UPDATE_PENDING)
 	Tcl_CancelIdleCall(WmUpdateGeometry, winPtr);


### PR DESCRIPTION
…shed

Run 9 did not finish. The freeze is gone -- tk-menubar-test.tcl passes every case and unixWm-50.5 no longer hangs -- but the log ends

  ==== unixWm-49.2 FAILED
  tktest 17077: suicide: sys: trap: fault write addr=0x3a3a79007393 pc=0x2d1856

with no "Tests ended", no total, and no "tk-runall: every file ran" marker. visual, winfo, winWm, wm and xmfbox are still unmeasured. A fault returns to the shell prompt exactly as a clean finish does, which is why it read as a complete run; the marker is the discriminator and it is absent. 79174e01 was in the build, so this is ours.

Both menubar tests report exactly what was predicted (49.2 gives 52 7 12 32 against 52 7 12 62, the missing menuHeight offset), so the fault is after the result was printed. The faulting address is not a plausible heap or stack address -- its bytes read as text -- i.e. a pointer fetched out of a freed and reused block.

One hole found by reading upstream: TkWmDeadWindow there opens with Tk_DestroyWindow(wmPtr->menubar) and the port's did not. It is invisible from unixWm.test, where the menubar is a child and so is already destroyed with the childList, but "$w configure -menu .menubar" hands TkUnixSetMenubar a SIBLING, which nothing then destroys -- so the ckfree left menubarPtr->wmInfoPtr dangling.

That is fixed on its own merits and is NOT claimed to be this crash. tk-menubar-test.tcl grows a section 5 separating the orderings: child menubar, sibling menubar, and the deleteWindows / wm withdraw . / new-toplevel sequence unixWm.test runs right after 49.2.

The decisive step is still the pc, and it needs no rebuild:
  acid $home/APExp/sys/src/ape/cmd/wish/tktest
  acid: src(0x2d1856)


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs