### PR TITLE
fix(tk): a transient tracks its container; wm group; override-redirec…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,10 @@ itself are `bool-test.c`, `bitfield-test.c`, `compound-assign-test.c`,
 `format-arg-test.c`, `unget-pipe-test.c`, `isatty-test.c`,
 `sincos-test.c`, `explog-test.c`, `fparith-test.c`,
 `float-overflow-test.c`, `malloc-reuse-test.c` and
-`stdio-test.c`. The twenty-one `tk-*.tcl` scripts there are Tcl, run
+`stdio-test.c`. The twenty-two `tk-*.tcl` scripts there are Tcl, run
 with `wish` -- except `tk-menubar-test.tcl`, which needs `tktest` and
-skips itself under `wish`; see the Tk section below. `tk-runall.tcl` is the harness for
+skips itself under `wish`, and `tk-transient-test.tcl`, whose last
+section alone does; see the Tk section below. `tk-runall.tcl` is the harness for
 Tk's own suite rather than a test of its own, and `tk-runtest.tcl` runs
 a single file from it. `sys/src/ape/lib/libressl/test/` is separate: it is
 upstream's own ML-KEM and SHA-3 vectors, run by `mk test` there.
@@ -1735,23 +1736,51 @@ table below is the whole thing, and the list has been re-derived rather
 than extended.
 
 ```
-all.tcl:  Total 10027  Passed 8888  Skipped 924  Failed 215
+all.tcl:  Total 10027  Passed 8898  Skipped 924  Failed 205
 Sourced 97 Test Files.
 ```
 
-**That is run 11. Run 10 was the first complete run under `tktest`**,
+**That is run 12. Run 10 was the first complete run under `tktest`**,
 and is the one to read against run 7 -- the last complete `wish` run --
 one column at a time rather than by the total:
 
-| | run 7 (`wish`) | run 10 (`tktest`) | run 11 |
-|---|---|---|---|
-| Total | 10027 | 10027 | 10027 |
-| **Skipped** | 1429 | **924** | 924 |
-| **Passed** | 8427 | **8877** | **8888** |
-| **Failed** | 171 | **226** | **215** |
+| | run 7 (`wish`) | run 10 (`tktest`) | run 11 | run 12 |
+|---|---|---|---|---|
+| Total | 10027 | 10027 | 10027 | 10027 |
+| **Skipped** | 1429 | **924** | 924 | 924 |
+| **Passed** | 8427 | **8877** | **8888** | **8898** |
+| **Failed** | 171 | **226** | **215** | **205** |
 
 Run 10 -> 11 is the `testembed` work below: eleven moved from failed to
 passed, nothing else changed at all.
+
+**Run 11 -> 12 is the `unixWm` and `wm.test` batch below, and the
+prediction written before it was exactly right**: "expect 215 -> roughly
+205, and the per-file check should move `unixWm` and `wm` and nothing
+else -- if a third file moves, that's the signal, since `TkWmMapWindow`
+is on every toplevel's path." The per-file table moves in exactly those
+two lines, `unixWm` 44 -> 39 and `wm` 14 -> 11.
+
+**Diff the failing test NAMES, not just the per-file counts.** One
+command, and it answers "what was fixed" and "what broke" in the same
+output, which a count cannot:
+
+```sh
+grep '^==== ' run.out | grep ' FAILED$' | sed 's/^==== //; s/ FAILED$//' |
+	awk '{print $1}' | sort -u > names
+```
+
+then `diff` the two. For run 11 -> 12 it is ten removals and **no
+additions**: `unixWm-8.4`, `-37.5`, `-40.2`, `-53.2`, `-54.2`,
+`wm-stackorder-4.3`, `-4.4`, `-5.3`, `wm-transient-3.1`, `-4.1`. Every
+one of them is a test the round was aimed at, except `unixWm-8.4` --
+which is one of the three `failsOnUbuntu failsOnXQuartz` tests written
+off above, and which the `TkpGetWrapperWindow` fix evidently carried
+along with it. **A constraint saying a test fails on Linux too is a
+reason not to chase it, not proof it cannot pass.**
+
+`unixWm-21.5` was expected to go with `-37.5` and did not; see the `wm
+group` note below, which is what it actually wanted.
 
 **The count rose by 55 and nothing regressed.** Of the 505 tests that
 had never run here, **450 pass**. That is the "expect the failure count
@@ -2041,6 +2070,60 @@ and the transient must follow -- which is the structure handler upstream
 registers and this port still does not; and `wm manage`/`wm forget`,
 seven tests, are generic-Tk reparenting.
 
+**The tracking is done now** -- see the run-12 section below. `wm
+manage`/`wm forget` are still the seven.
+
+#### Run 12's round: tracking a transient, and two smaller ones
+
+**`wm transient` now tracks the container instead of sampling it.** The
+note above (and the one further down) recorded this as deliberately not
+done, on the grounds that it is a larger change. It is about forty
+lines: upstream's `WmWaitMapProc` registered on the **container** with
+`StructureNotifyMask`, carrying the **transient** as client data, which
+maps or withdraws the transient as the container is mapped or
+unmapped. `wm-transient-3.3`, `4.3`, `5.1`, `6.2`, `8.1` -- five tests,
+and `6.2` is the one that decides whether the implementation is right.
+
+**A transient the caller withdrew itself must not be mapped again when
+the container comes back** (`6.2`), and `wmPtr->withdrawn` cannot say
+which of the two withdrew it. That is what upstream's `WM_WITHDRAWN`
+flag is for, and it is `withdrawnExplicit` here: set by `wm withdraw`
+and `wm state withdrawn`, cleared by `wm deiconify` and `wm state
+normal`, and read in exactly one place.
+
+**Registering on the toplevel is right here and would be wrong on X.**
+Upstream registers on the container's **wrapper**, because that is the
+window the server sends `MapNotify` for. There are no wrappers here --
+a toplevel is its window -- so the events arrive on the toplevel
+itself. Every place that assigns `wmPtr->container` goes through
+`WmTrackContainer`/`WmUntrackContainer`, including `TkWmDeadWindow` and
+`WmForgetTransientsOf`: a handler left registered after either end dies
+runs with a freed `TkWindow` as its client data, which is the
+use-after-free shape this port has now hit three times.
+
+**`wm group` has to create the leader's window** (`unixWm-21.5`, which
+the `TkpGetWrapperWindow` fix was expected to carry and did not).
+Upstream's `WmGroupCmd` does `Tk_MakeWindowExist` on the leader and
+then `CreateWrapper`, because the group hint has to name a window id
+and a never-mapped toplevel has none. The test asks `testwrapper` on
+the leader before and after and requires empty then non-empty. Only the
+first half of upstream's pair exists here, and it is the whole of it.
+The leader is also resolved to its nearest toplevel ancestor now, as
+`wm transient` already was.
+
+**An override-redirect toplevel stays on top** (`wm-stackorder-5.2`).
+On X the window manager keeps it there and an ordinary `raise` cannot
+get above one; there is no window manager here, so `TkWmRestackToplevel`
+holds the rule itself when raising to the top. **This is not only a
+test**: `TkpMakeMenuWindow` marks every posted menu override-redirect,
+so without it a `raise` on the window a menu belongs to buries the
+menu.
+
+Covered by `sys/lib/tests/tk-transient-test.tcl`, which separates the
+follow cases from the explicitly-withdrawn one and destroys each end in
+turn; its last section needs `tktest` for `testwrapper` and says so
+under `wish`.
+
 `focus-2.*` is deliberately untouched. It is `TkFocusFilterEvent`, and
 the warning three sections down stands: getting the mode and detail
 wrong there is how `bind.test` went from 3 failures to 116.
@@ -2235,10 +2318,12 @@ missing:
 - a transient made transient to an **iconic or withdrawn** master is
   withdrawn at once.
 
-Only the state *at the moment of the call* is honoured. Upstream also
-tracks the master afterwards through a structure handler on it; that is
-a larger change and its tests are separate, so it is deliberately not
-done here.
+**Corrected:** this used to say that only the state *at the moment of
+the call* is honoured, and that upstream's structure handler on the
+master was "a larger change" left undone. It was about forty lines, and
+it is done -- see the run-12 section above. The rule stated here is
+still the one that applies at the moment of the call; the handler keeps
+it true afterwards.
 
 The eleven that were already implemented:
 `geometry`, `minsize`, `maxsize`, `withdraw`, `deiconify`, `state`,

--- a/sys/lib/tests/tk-transient-test.tcl
+++ b/sys/lib/tests/tk-transient-test.tcl
@@ -1,0 +1,173 @@
+# tk-transient-test.tcl -- a transient follows its container's state.
+#
+# WHERE THIS CAME FROM: "wm transient" in plan9/tkPlan9Wm.c honoured the
+# container's state only at the MOMENT OF THE CALL. Upstream also tracks
+# it afterwards, with a StructureNotify handler registered on the
+# container (tkUnixWm.c's WmWaitMapProc), so withdrawing the container
+# withdraws the dialog and deiconifying it brings the dialog back. Five
+# tests wanted that: wm-transient-3.3, 4.3, 5.1, 6.2 and 8.1.
+#
+# The one case that is NOT simply "follow the container" is 6.2: a
+# transient the caller withdrew ITSELF must stay withdrawn when the
+# container comes back. wmPtr->withdrawn cannot say which of the two
+# withdrew it, so there is a second flag (withdrawnExplicit, upstream's
+# WM_WITHDRAWN). Section 4 is that case, and it is the one a naive
+# implementation gets wrong.
+#
+# Runs under wish. Section 6 needs tktest ("testwrapper") and says so
+# rather than failing.
+#
+# Every marker is printed and flushed BEFORE the statement it names.
+
+set failures 0
+
+proc step {msg} { puts "STEP: $msg"; flush stdout }
+proc check {name got want} {
+    global failures
+    if {$got eq $want} {
+	puts "  PASS $name: $got"
+    } else {
+	incr failures
+	puts "  FAIL $name: got '$got' want '$want'"
+    }
+    flush stdout
+}
+proc note {name got} { puts "  note $name: $got"; flush stdout }
+
+proc fresh {} {
+    destroy .top .subject
+    toplevel .top
+    toplevel .subject
+    update
+    wm transient .subject .top
+    update
+}
+
+# ------------------------------------------------------------------
+step "1. withdraw/deiconify the container (wm-transient-3.3)"
+fresh
+wm withdraw .top
+update
+check "state after container withdraw"   [wm state .subject]      withdrawn
+check "ismapped after container withdraw" [winfo ismapped .subject] 0
+wm deiconify .top
+update
+check "state after container deiconify"   [wm state .subject]      normal
+check "ismapped after container deiconify" [winfo ismapped .subject] 1
+
+# ------------------------------------------------------------------
+step "2. iconify/deiconify the container (wm-transient-4.3)"
+
+# The transient goes WITHDRAWN, not iconic -- it is not the thing that
+# was iconified.
+fresh
+wm iconify .top
+update
+check "state after container iconify"   [wm state .subject]      withdrawn
+check "ismapped after container iconify" [winfo ismapped .subject] 0
+wm deiconify .top
+update
+check "state after container deiconify"  [wm state .subject]      normal
+
+# ------------------------------------------------------------------
+step "3. a failed 'wm transient' must not lose the tracking (5.1)"
+
+# "wm transient .subject .bad" is an error, and the handler registered
+# for the GOOD container has to survive it -- which it does only if the
+# error returns before anything is unregistered.
+fresh
+check "bad container is an error" [catch {wm transient .subject .bad}] 1
+wm withdraw .top
+update
+check "still tracking after the error" [wm state .subject] withdrawn
+wm deiconify .top
+update
+check "still tracking, the other way"  [wm state .subject] normal
+
+# ------------------------------------------------------------------
+step "4. a transient withdrawn BY THE CALLER does not track (6.2)"
+fresh
+wm withdraw .subject
+wm withdraw .top
+wm deiconify .top
+update
+check "container back, transient stays withdrawn" [wm state .subject] withdrawn
+wm deiconify .subject
+check "deiconified by hand"                       [wm state .subject] normal
+wm withdraw .top
+update
+check "and tracks again once it is normal"        [wm state .subject] withdrawn
+wm deiconify .top
+update
+check "back with its container"                   [wm state .subject] normal
+
+# ------------------------------------------------------------------
+step "5. transient of a container that is withdrawn already (8.1)"
+destroy .t1 .t2
+toplevel .t1; wm withdraw .t1; update
+toplevel .t2; wm transient .t2 .t1; update
+check "neither mapped" \
+	[list [winfo ismapped .t1] [winfo ismapped .t2]] {0 0}
+wm deiconify .t1
+update
+check "both mapped once the container is shown" \
+	[list [winfo ismapped .t1] [winfo ismapped .t2]] {1 1}
+check "both in the stacking order" \
+	[lsearch -all -inline -glob [wm stackorder .] ".t?"] {.t1 .t2}
+
+# ------------------------------------------------------------------
+step "6. destroy the container while it is being tracked"
+
+# The handler holds the TRANSIENT as its client data and is registered
+# on the CONTAINER, so destroying either end has to unregister it --
+# otherwise the next map or unmap runs with a freed TkWindow, the
+# use-after-free shape this port has hit three times (TkpDeleteFont,
+# TkpFreeColor, the menubar).
+fresh
+destroy .top
+update
+check "transient forgets a destroyed container" [wm transient .subject] {}
+step "6a. map and unmap the survivor, which is what would touch it"
+wm withdraw .subject
+update
+wm deiconify .subject
+update
+puts "  ok: no fault"
+flush stdout
+
+step "6b. the other order: destroy the TRANSIENT first"
+fresh
+destroy .subject
+update
+wm withdraw .top
+update
+wm deiconify .top
+update
+puts "  ok: no fault"
+flush stdout
+
+# ------------------------------------------------------------------
+step "7. wm group creates the leader's window (unixWm-21.5)"
+
+# Upstream's WmGroupCmd calls Tk_MakeWindowExist on the leader and then
+# creates its wrapper, because the group hint has to name a window id.
+# There are no wrappers here -- a toplevel IS its window -- so the first
+# half alone is the whole of it, and "testwrapper" is how the suite
+# looks at it.
+destroy .t2 .t3
+toplevel .t2 -width 120 -height 300
+toplevel .t3 -width 120 -height 300
+if {[catch {testwrapper .t2} before]} {
+    puts "  SKIP: no testwrapper command -- run this with tktest for section 7"
+} else {
+    check "leader has no window before" $before {}
+    wm group .t3 .t2
+    check "leader has a window after"   [expr {[testwrapper .t2] ne ""}] 1
+    check "group reads back"            [wm group .t3] .t2
+}
+destroy .t2 .t3
+
+destroy .top .subject .t1 .t2
+puts ""
+puts "failures: $failures"
+exit $failures

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -55,6 +55,15 @@ typedef struct TkWmInfo {
     int maxWidth, maxHeight;	/* 0 means unlimited. */
     int withdrawn;
     int iconified;		/* "wm iconify"; distinct from withdrawn */
+    /*
+     * withdrawnExplicit is upstream's WM_WITHDRAWN flag, and it exists
+     * only for transients: a transient follows its container's map
+     * state (WmWaitMapProc below), UNLESS the caller withdrew it
+     * itself, in which case the container coming back must not map it
+     * again (wm-transient-6.2). "withdrawn" alone cannot say which of
+     * the two withdrew it.
+     */
+    int withdrawnExplicit;
     int flags;
     char *title;		/* "wm title", or NULL for the default. */
     /*
@@ -784,6 +793,8 @@ WmScreenPosition(WmInfo *wmPtr, int width, int height, int *xPtr, int *yPtr)
  * and the stored pointer would otherwise dangle. dispPtr->firstWmPtr is
  * every toplevel, so this is the whole search space.
  */
+static void	WmUntrackContainer(TkWindow *winPtr, TkWindow *container);
+
 static void
 WmForgetTransientsOf(TkWindow *winPtr)
 {
@@ -791,6 +802,7 @@ WmForgetTransientsOf(TkWindow *winPtr)
 
     for (p = winPtr->dispPtr->firstWmPtr; p != NULL; p = p->nextPtr) {
 	if (p->container == winPtr) {
+	    WmUntrackContainer(p->winPtr, winPtr);
 	    p->container = NULL;
 	    WmSetString(&p->transient, NULL);
 	}
@@ -807,6 +819,79 @@ WmTransientOf(TkWindow *winPtr)
     if (winPtr == NULL || winPtr->wmInfoPtr == NULL)
 	return NULL;
     return winPtr->wmInfoPtr->container;
+}
+
+/*
+ * A TRANSIENT TRACKS ITS CONTAINER'S MAP STATE, not just the state the
+ * container happened to be in when "wm transient" was called. Upstream
+ * registers this on the CONTAINER with StructureNotifyMask and passes
+ * the TRANSIENT as client data (tkUnixWm.c's WmWaitMapProc); withdraw
+ * the container and the dialog goes with it, deiconify it and the
+ * dialog comes back. wm-transient-3.3, 4.3, 5.1, 6.2 and 8.1.
+ *
+ * The one exception is a transient the caller withdrew itself: the
+ * container reappearing must not undo that (6.2), which is what
+ * withdrawnExplicit is for.
+ *
+ * This port has no wrapper windows, so the events arrive on the
+ * container's own window rather than on a wrapper -- which is exactly
+ * why registering on the toplevel is right here and would not be on X.
+ */
+static void
+WmWaitMapProc(void *clientData, XEvent *eventPtr)
+{
+    TkWindow *winPtr = (TkWindow *) clientData;
+    WmInfo *wmPtr;
+
+    if (winPtr == NULL || (wmPtr = winPtr->wmInfoPtr) == NULL)
+	return;
+    if (wmPtr->container == NULL)
+	return;
+
+    if (eventPtr->type == MapNotify) {
+	if (wmPtr->withdrawnExplicit)
+	    return;
+	wmPtr->withdrawn = 0;
+	wmPtr->iconified = 0;
+	TkpWmSetState(winPtr, NormalState);
+    } else if (eventPtr->type == UnmapNotify) {
+	wmPtr->withdrawn = 1;
+	TkpWmSetState(winPtr, WithdrawnState);
+    }
+}
+
+/*
+ * Attach or detach the tracking handler. Every place that changes
+ * wmPtr->container goes through these two, so the handler and the
+ * pointer cannot get out of step -- a stale handler would run with a
+ * freed TkWindow as its client data.
+ */
+static void
+WmTrackContainer(TkWindow *winPtr, TkWindow *container)
+{
+    Tk_CreateEventHandler((Tk_Window) container, StructureNotifyMask,
+	    WmWaitMapProc, winPtr);
+}
+
+static void
+WmUntrackContainer(TkWindow *winPtr, TkWindow *container)
+{
+    if (container == NULL)
+	return;
+    Tk_DeleteEventHandler((Tk_Window) container, StructureNotifyMask,
+	    WmWaitMapProc, winPtr);
+}
+
+/*
+ * Override-redirect lives in Tk_Attributes rather than in WmInfo -- see
+ * the "wm overrideredirect" note -- so there is one answer to the
+ * question and this is where to ask it.
+ */
+static int
+WmIsOverrideRedirect(WmInfo *p)
+{
+    return p != NULL && p->winPtr != NULL
+	    && Tk_Attributes((Tk_Window) p->winPtr)->override_redirect;
 }
 
 static WmInfo *
@@ -1783,6 +1868,7 @@ TkWmDeadWindow(TkWindow *winPtr)
      */
     WmReleaseIcon(wmPtr);
     WmForgetTransientsOf(winPtr);
+    WmUntrackContainer(winPtr, wmPtr->container);
     wmPtr->container = NULL;
     if (wmPtr->iconFor != NULL && wmPtr->iconFor->wmInfoPtr != NULL) {
 	wmPtr->iconFor->wmInfoPtr->icon = NULL;
@@ -1845,6 +1931,23 @@ TkWmRestackToplevel(TkWindow *winPtr, int aboveBelow, TkWindow *otherPtr)
     WmUnlink(dispPtr, wmPtr);
     if (otherWmPtr == NULL) {
 	afterPtr = (aboveBelow == Above) ? WmLast(dispPtr) : NULL;
+	/*
+	 * AN OVERRIDE-REDIRECT TOPLEVEL STAYS ON TOP. On X the window
+	 * manager keeps them there and an ordinary "raise" cannot get
+	 * above one (wm-stackorder-5.2). There is no window manager
+	 * here, so this port has to hold the rule itself -- and it is
+	 * not only a test: TkpMakeMenuWindow marks every posted menu
+	 * override-redirect, so without this a "raise" on the window a
+	 * menu belongs to buries the menu under it.
+	 */
+	if (afterPtr != NULL && !WmIsOverrideRedirect(wmPtr)) {
+	    WmInfo *p, *below = NULL;
+
+	    for (p = dispPtr->firstWmPtr; p != NULL; p = p->nextPtr)
+		if (!WmIsOverrideRedirect(p))
+		    below = p;
+	    afterPtr = below;
+	}
     } else if (aboveBelow == Above) {
 	afterPtr = otherWmPtr;
     } else {
@@ -2658,6 +2761,7 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
             return WmIconForError(interp, "withdraw", "WITHDRAW", objv[2],
                     wmPtr);
         wmPtr->withdrawn = 1;
+        wmPtr->withdrawnExplicit = 1;
         TkpWmSetState(winPtr, WithdrawnState);
         return TCL_OK;
 
@@ -2685,6 +2789,7 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
          * wm-state-2.15, 2.17.
          */
         wmPtr->withdrawn = 0;
+        wmPtr->withdrawnExplicit = 0;
         wmPtr->iconified = 0;
         TkpWmSetState(winPtr, NormalState);
         return TCL_OK;
@@ -2726,6 +2831,7 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
                     sizeof(char *), "argument", 0, &st) != TCL_OK)
                 return TCL_ERROR;
             wmPtr->withdrawn = (st == ST_WITHDRAWN);
+            wmPtr->withdrawnExplicit = (st == ST_WITHDRAWN);
             wmPtr->iconified = (st == ST_ICONIC);
             TkpWmSetState(winPtr, st == ST_NORMAL ? NormalState :
                     st == ST_ICONIC ? IconicState : WithdrawnState);
@@ -3223,13 +3329,39 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
             return WmReturnString(interp, wmPtr->leaderName);
         {
             const char *s = Tcl_GetString(objv[3]);
+            Tk_Window leader;
 
             if (*s == '\0') {
                 WmSetString(&wmPtr->leaderName, NULL);
                 return TCL_OK;
             }
-            if (Tk_NameToWindow(interp, s, (Tk_Window) clientData) == NULL)
+            leader = Tk_NameToWindow(interp, s, (Tk_Window) clientData);
+            if (leader == NULL)
                 return TCL_ERROR;
+            /*
+             * The leader is resolved to its nearest TOPLEVEL ancestor,
+             * as with "wm transient" above and for the same reason.
+             */
+            while (leader != NULL && !Tk_TopWinHierarchy((TkWindow *) leader))
+                leader = (Tk_Window) ((TkWindow *) leader)->parentPtr;
+            if (leader == NULL) {
+                Tcl_SetObjResult(interp, Tcl_ObjPrintf(
+                        "can't find a toplevel for \"%s\"", s));
+                Tcl_SetErrorCode(interp, "TK", "WM", "GROUP", (char *) NULL);
+                return TCL_ERROR;
+            }
+            /*
+             * THE LEADER'S WINDOW IS CREATED HERE, and that is not
+             * bookkeeping. Upstream's WmGroupCmd does Tk_MakeWindowExist
+             * on the leader and then CreateWrapper if it has no wrapper
+             * yet, because the group hint has to name a window id and a
+             * never-mapped toplevel has none. There are no wrappers in
+             * this port -- a toplevel IS its window -- so the first half
+             * alone is the whole of it, and unixWm-21.5 tests exactly
+             * that: testwrapper on the leader is empty before the "wm
+             * group" and must be a real id after it.
+             */
+            Tk_MakeWindowExist(leader);
             WmSetString(&wmPtr->leaderName, s);
         }
         return TCL_OK;
@@ -3249,6 +3381,7 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
 
             if (*s == '\0') {
                 WmSetString(&wmPtr->transient, NULL);
+                WmUntrackContainer(winPtr, wmPtr->container);
                 wmPtr->container = NULL;
                 return TCL_OK;
             }
@@ -3325,7 +3458,16 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
             }
             Tk_MakeWindowExist(master);
             WmSetString(&wmPtr->transient, Tk_PathName(master));
-            wmPtr->container = (TkWindow *) master;
+            /*
+             * The handler moves with the pointer, and only when the
+             * container actually changes -- re-registering would give
+             * the window two handlers and every state change twice.
+             */
+            if (wmPtr->container != (TkWindow *) master) {
+                WmUntrackContainer(winPtr, wmPtr->container);
+                WmTrackContainer(winPtr, (TkWindow *) master);
+                wmPtr->container = (TkWindow *) master;
+            }
 
             /*
              * A transient follows its master's state: while the master
@@ -3335,10 +3477,8 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
              * exactly this, and it is the one part of "transient" that
              * is behaviour rather than bookkeeping.
              *
-             * Only the state at the moment of the call is honoured
-             * here. Upstream also *tracks* the master afterwards, with
-             * a structure handler on it; that is a larger change and
-             * the tests for it are separate.
+             * This is the state at the moment of the call; WmWaitMapProc
+             * above keeps it in step afterwards.
              */
             {
                 WmInfo *mPtr = ((TkWindow *) master)->wmInfoPtr;


### PR DESCRIPTION
…t stays on top

Run 12 verified first: marker, tcltest's own total (205), and the per-file diff -- ten test names removed, none added, exactly the two files the previous round touched.

wm transient now registers upstream's WmWaitMapProc on the container (StructureNotifyMask, the transient as client data) instead of sampling the container's state once at the call. Withdraw or iconify the container and the dialog follows; deiconify it and the dialog comes back. wm-transient-3.3, 4.3, 5.1, 6.2, 8.1.

6.2 is the case that decides whether this is right: a transient the caller withdrew ITSELF must stay withdrawn when the container returns, and wmPtr->withdrawn cannot say which of the two withdrew it. That is upstream's WM_WITHDRAWN, here withdrawnExplicit.

Registering on the toplevel is correct here only because there are no wrapper windows -- upstream registers on the wrapper. Every assignment to wmPtr->container goes through WmTrackContainer/WmUntrackContainer, including TkWmDeadWindow and WmForgetTransientsOf: a handler surviving either end is a freed TkWindow as client data.

wm group calls Tk_MakeWindowExist on the leader, as upstream does before creating its wrapper -- the group hint has to name a window id, and unixWm-21.5 asks for exactly that. The leader is resolved to its nearest toplevel ancestor, as wm transient already was.

TkWmRestackToplevel keeps override-redirect toplevels above an ordinary raise (wm-stackorder-5.2). Not only a test: TkpMakeMenuWindow marks every posted menu override-redirect, so without this a raise on the window a menu belongs to buries the menu.

New: sys/lib/tests/tk-transient-test.tcl.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs