### PR TITLE
fix(tk): wm manage and wm forget -- the wrapper was the only hard part

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ itself are `bool-test.c`, `bitfield-test.c`, `compound-assign-test.c`,
 `format-arg-test.c`, `unget-pipe-test.c`, `isatty-test.c`,
 `sincos-test.c`, `explog-test.c`, `fparith-test.c`,
 `float-overflow-test.c`, `malloc-reuse-test.c` and
-`stdio-test.c`. The twenty-four `tk-*.tcl` scripts there are Tcl, run
+`stdio-test.c`. The twenty-five `tk-*.tcl` scripts there are Tcl, run
 with `wish` -- except `tk-menubar-test.tcl`, which needs `tktest` and
 skips itself under `wish`, and `tk-transient-test.tcl`, whose last
 section alone does; see the Tk section below. `tk-runall.tcl` is the harness for
@@ -1736,20 +1736,20 @@ table below is the whole thing, and the list has been re-derived rather
 than extended.
 
 ```
-all.tcl:  Total 10027  Passed 8913  Skipped 924  Failed 190
+all.tcl:  Total 10027  Passed 8917  Skipped 924  Failed 186
 Sourced 97 Test Files.
 ```
 
-**That is run 14. Run 10 was the first complete run under `tktest`**,
+**That is run 15. Run 10 was the first complete run under `tktest`**,
 and is the one to read against run 7 -- the last complete `wish` run --
 one column at a time rather than by the total:
 
-| | run 7 (`wish`) | run 10 (`tktest`) | run 11 | run 12 | run 13 | run 14 |
-|---|---|---|---|---|---|---|
-| Total | 10027 | 10027 | 10027 | 10027 | 10027 | 10027 |
-| **Skipped** | 1429 | **924** | 924 | 924 | 924 | 924 |
-| **Passed** | 8427 | **8877** | **8888** | **8898** | **8902** | **8913** |
-| **Failed** | 171 | **226** | **215** | **205** | **201** | **190** |
+| | run 7 (`wish`) | run 10 (`tktest`) | run 11 | run 12 | run 13 | run 14 | run 15 |
+|---|---|---|---|---|---|---|---|
+| Total | 10027 | 10027 | 10027 | 10027 | 10027 | 10027 | 10027 |
+| **Skipped** | 1429 | **924** | 924 | 924 | 924 | 924 | 924 |
+| **Passed** | 8427 | **8877** | **8888** | **8898** | **8902** | **8913** | **8917** |
+| **Failed** | 171 | **226** | **215** | **205** | **201** | **190** | **186** |
 
 Run 10 -> 11 is the `testembed` work below: eleven moved from failed to
 passed, nothing else changed at all.
@@ -1990,7 +1990,7 @@ tests. `wm.test` had not been read since `tktest` arrived either:
 | | |
 |---|---|
 | **7** | `wm-transient-*` |
-| **7** | `wm-manage-*` and `wm-forget-2` -- the deliberate no-ops recorded above; real generic-Tk reparenting |
+| **7** | `wm-manage-*` and `wm-forget-2` -- deliberate no-ops when this was written; implemented in run 15's round, and three of them wanted the *refusal* rather than the action |
 | **4** | `wm-stackorder-*` |
 | **1** | `wm-colormapwindows-2.1` |
 
@@ -2336,14 +2336,62 @@ it, so the absence stays a decision on the record.
 
 **`wm manage`/`wm forget` are the next round's headline and were
 deliberately NOT batched here** -- eight tests (`wm-manage-1.*`,
-`wm-forget-2`, `winWm-9.2`), and upstream's `WmManageCmd` is mostly
-generic Tk: the X-specific half is `TK_HAS_WRAPPER` and
-`RemapWindows(winPtr, wmPtr->wrapperPtr)`, and with no wrappers here
-that reduces to reparenting the frame to the root, which
-`XReparentWindow` in `tkPlan9Init.c` already does. It is smaller than
-the note above it claims. But it turns a frame into a toplevel and so
+`wm-forget-2`, `winWm-9.2`). It turns a frame into a toplevel and so
 edits `dispPtr->firstWmPtr`, the list the last three rounds have all
 touched, and it wants a run of its own to read.
+
+#### Run 15: four fixed, nothing added, exactly as predicted
+
+**190 -> 186**, and the name diff is `unixWm-50.3`, `tk-2.3`,
+`winfo-5.4`, `winfo-5.5` removed with **no additions** -- so the
+deferred container destroy satisfies both `winfo-13.2` (which stayed
+fixed) and `unixWm-50.3`, and the app-name registry does what it was
+written for. Three rounds running now where the per-file check found
+nothing unexpected; the method is doing its job.
+
+#### wm manage / wm forget: the note above overstated the job
+
+**Both were `return TCL_OK`** -- silent no-ops -- on the grounds that
+they are "real generic-Tk reparenting" and that doing them wrongly is
+worse than not doing them. The second half of that is still true. The
+first was an overestimate, and **reading upstream rather than the note
+is what settled it**: `WmManageCmd` and `WmForgetCmd` are generic Tk
+with exactly one X-specific step, setting `TK_HAS_WRAPPER` and calling
+`RemapWindows(winPtr, wmPtr->wrapperPtr)` to reparent the frame into
+the wrapper just created for it.
+
+**There are no wrappers here**, so the flag is not set and the reparent
+target is the **root** -- which is what being a toplevel *means* in this
+port. Same reduction as embedding, stacking and the menubar: the
+wrapper is the thing upstream needs and this port does not have, and
+removing it usually removes the difficulty with it rather than adding
+to it. `XReparentWindow` in `tkPlan9Init.c` was already real.
+
+Everything else was already present and is called unchanged:
+`Tk_IsManageable`, `TkFocusSplit`/`TkFocusJoin`, `TkMapTopFrame`, and
+`TkWmDeadWindow` -- which upstream calls **on a window that is still
+alive**, and which this port's version is already right for: it
+unlinks from `firstWmPtr`, cancels the pending geometry update,
+destroys the menubar, forgets the transients and ends with
+`wmInfoPtr = NULL`, so a later `wm manage` takes the `TkWmNewWindow`
+branch and starts clean.
+
+**Three of the eight tests want the REFUSAL, not the action.**
+`wm-manage-1.4`, `1.5` and `1.6` call `wm manage` on a `ttk::frame`, a
+`text` and a `button` and require a **non-zero return code**; a silent
+no-op answers `TCL_OK` and so fails them in the same direction as doing
+nothing at all. `Tk_IsManageable` is the whole of it. Worth noticing
+because a count of "eight tests about reparenting" is wrong about three
+of them -- **read what each test compares**, the rule this file states
+twice already.
+
+`wm-manage-1.8` calls each command **twice** on purpose: the second must
+be a no-op, which is upstream's `if (Tk_IsTopLevel(...))` either way
+round.
+
+Covered by `sys/lib/tests/tk-manage-test.tcl`, which separates the
+manage, the refusal, the round trip and the "is the content still laid
+out" question (`winWm-9.2`) into their own sections.
 
 `focus-2.*` is deliberately untouched. It is `TkFocusFilterEvent`, and
 the warning three sections down stands: getting the mode and detail
@@ -2499,9 +2547,13 @@ rather than in `WmInfo`, as upstream does: generic Tk reads it there
 (menus and tooltips set it), so a private copy would be a second answer
 to the same question.
 
-`wm forget` and `wm manage` are still no-ops -- they are real
-generic-Tk reparenting operations, seven tests, and doing them wrongly
-is worse than not doing them.
+**Corrected:** this used to say `wm forget` and `wm manage` were still
+no-ops because they are "real generic-Tk reparenting operations" and
+doing them wrongly is worse than not doing them. They are implemented
+-- see the run-15 section above. The caution was right and the estimate
+was not: upstream's two commands are generic Tk with a single
+X-specific step, and that step is the wrapper, which this port does not
+have.
 
 **The remaining wm failures were not this**, as predicted -- `state`,
 `iconify`, `minsize`, `maxsize`, `resizable` and `geometry` were all

--- a/sys/lib/tests/tk-manage-test.tcl
+++ b/sys/lib/tests/tk-manage-test.tcl
@@ -1,0 +1,155 @@
+# tk-manage-test.tcl -- "wm manage" makes a widget a toplevel, and
+# "wm forget" turns it back.
+#
+# WHERE THIS CAME FROM: both were `return TCL_OK` -- silent no-ops --
+# under a note in CLAUDE.md saying they were "real generic-Tk
+# reparenting" and that doing them wrongly was worse than not doing
+# them. Eight tests: wm-manage-1.1, 1.3..1.8, wm-forget-2, winWm-9.2.
+#
+# THE NOTE OVERSTATED IT. Upstream's WmManageCmd and WmForgetCmd are
+# generic Tk with ONE X-specific step: they set TK_HAS_WRAPPER and
+# reparent the frame into the wrapper just made for it. There are no
+# wrappers in this port -- a toplevel IS its own window -- so the flag
+# is not set and the reparent target is the ROOT, which is what being a
+# toplevel means here. Same reduction as the embedding and stacking
+# work.
+#
+# Everything else is shared and was already present: Tk_IsManageable,
+# TkFocusSplit/TkFocusJoin, TkMapTopFrame, and TkWmDeadWindow ending
+# with wmInfoPtr = NULL so a later "wm manage" starts clean.
+#
+# Runs under wish.
+
+set failures 0
+
+proc step {msg} { puts "STEP: $msg"; flush stdout }
+proc check {name got want} {
+    global failures
+    if {$got eq $want} {
+	puts "  PASS $name: $got"
+    } else {
+	incr failures
+	puts "  FAIL $name: got '$got' want '$want'"
+    }
+    flush stdout
+}
+
+# ------------------------------------------------------------------
+step "1. manage a frame (wm-manage-1.1)"
+
+destroy .t
+toplevel .t
+frame .t.f
+pack [label .t.f.l -text hello]
+wm manage .t.f
+raise .t.f
+update
+check "manager is wm"   [winfo manage .t.f]   wm
+check "it is its own toplevel" [winfo toplevel .t.f] .t.f
+check "and its child agrees"   [winfo toplevel .t.f.l] .t.f
+
+# ------------------------------------------------------------------
+step "2. a labelframe too (wm-manage-1.3)"
+
+destroy .t2
+toplevel .t2
+labelframe .t2.f -text Labelframe
+pack [label .t2.f.l -text hello]
+wm manage .t2.f
+raise .t2.f
+update
+check "manager is wm" [winfo manage .t2.f] wm
+check "own toplevel"  [winfo toplevel .t2.f] .t2.f
+
+# ------------------------------------------------------------------
+step "3. WHAT MUST BE REFUSED (wm-manage-1.4, 1.5, 1.6)"
+
+# Tk_IsManageable is the whole test: a ttk::frame, a text and a button
+# are not frames, labelframes or toplevels, and "wm manage" on them has
+# to RAISE AN ERROR rather than quietly succeed. Three of the eight
+# failures were the refusal, not the action -- a silent no-op returns
+# TCL_OK and so fails them in the same direction as doing nothing.
+destroy .t3
+toplevel .t3
+text .t3.txt
+button .t3.b -text Button
+check "text is refused"   [catch {wm manage .t3.txt}] 1
+check "button is refused" [catch {wm manage .t3.b}]   1
+if {[catch {package require Tk::ttk}] && [catch {ttk::frame .t3.tf}]} {
+    puts "  SKIP: no ttk::frame here"
+} else {
+    check "ttk::frame is refused" [catch {wm manage .t3.tf}] 1
+}
+check "the message names the three kinds" \
+	[string match "*must be a frame, labelframe or toplevel*" \
+		[catch {wm manage .t3.b} m; set m]] 1
+
+# ------------------------------------------------------------------
+step "4. manage, then forget, and pack it again (wm-manage-1.7)"
+
+destroy .t4
+toplevel .t4
+frame .t4.f
+pack [label .t4.f.l -text Label]
+pack .t4.f
+update
+check "starts packed"      [winfo manage .t4.f]   pack
+wm manage .t4.f
+raise .t4.f
+update
+check "becomes wm"         [winfo manage .t4.f]   wm
+check "becomes a toplevel" [winfo toplevel .t4.f] .t4.f
+wm forget .t4.f
+pack .t4.f
+update
+check "packed again"       [winfo manage .t4.f]   pack
+check "a child again"      [winfo toplevel .t4.f] .t4
+
+# ------------------------------------------------------------------
+step "5. forget a REAL toplevel, and manage it back (wm-manage-1.8)"
+
+# Both commands are called twice on purpose: the second must be a
+# no-op, not an error and not a second teardown.
+destroy .t5
+toplevel .t5
+toplevel .t5.t
+pack [button .t5.t.b -text "Manage This"]
+update
+check "a toplevel to start"  [winfo manage .t5.t] wm
+check "child's toplevel"     [winfo toplevel .t5.t.b] .t5.t
+wm forget .t5.t
+wm forget .t5.t
+pack .t5.t
+update
+check "packs as a child now" [winfo manage .t5.t] pack
+check "child's toplevel is the outer one" [winfo toplevel .t5.t.b] .t5
+wm manage .t5.t
+wm manage .t5.t
+wm deiconify .t5.t
+update
+check "a toplevel again"     [winfo manage .t5.t] wm
+check "child's toplevel again" [winfo toplevel .t5.t.b] .t5.t
+
+# ------------------------------------------------------------------
+step "6. the contents are still laid out afterwards (winWm-9.2)"
+
+# winWm-9.2's real question: after manage/forget/repack, does a
+# grandchild still land somewhere sensible? It checks rooty != 0.
+destroy .t6
+toplevel .t6
+frame .t6.f
+pack [button .t6.f.x -text x]
+pack .t6.f
+update
+wm manage .t6.f
+update
+wm forget .t6.f
+pack .t6.f
+update
+check "grandchild is not at the top of the screen" \
+	[expr {[winfo rooty .t6.f.x] != 0}] 1
+
+destroy .t .t2 .t3 .t4 .t5 .t6
+puts ""
+puts "failures: $failures"
+exit $failures

--- a/sys/src/external/tk/plan9/tkPlan9Wm.c
+++ b/sys/src/external/tk/plan9/tkPlan9Wm.c
@@ -893,6 +893,30 @@ WmIsOverrideRedirect(WmInfo *p)
 	    && Tk_Attributes((Tk_Window) p->winPtr)->override_redirect;
 }
 
+/*
+ * Reparent one window, for "wm manage" and "wm forget" -- upstream's
+ * RemapWindows, which despite the plural moves only the window it is
+ * given. A NULL parent means the root, i.e. "make this a toplevel".
+ *
+ * Upstream reads the position back with XGetWindowAttributes; this uses
+ * winPtr->changes, which is Tk's own record and the one this port keeps
+ * in step (see the "no server sends ConfigureNotify" note above), so
+ * there is one fewer thing that has to agree.
+ */
+static void
+WmRemapWindow(TkWindow *winPtr, TkWindow *parentPtr)
+{
+    if (winPtr->window == None)
+	return;
+    if (parentPtr == NULL)
+	XReparentWindow(winPtr->display, winPtr->window,
+		XRootWindow(winPtr->display, winPtr->screenNum),
+		winPtr->changes.x, winPtr->changes.y);
+    else if (parentPtr->window != None)
+	XReparentWindow(winPtr->display, winPtr->window, parentPtr->window,
+		winPtr->changes.x, winPtr->changes.y);
+}
+
 static WmInfo *
 WmLast(TkDisplay *dispPtr)
 {
@@ -3905,16 +3929,91 @@ Tk_WmObjCmd(void *clientData, Tcl_Interp *interp,
             return TCL_OK;
         }
 
-    case OPT_FORGET:
-    case OPT_MANAGE:
-        /*
-         * Turning a toplevel into an ordinary child and back. Both are
-         * real generic-Tk operations and neither needs a window manager;
-         * they are left alone here because doing them wrongly is worse
-         * than not doing them, and wm-forget/wm-manage are seven tests.
-         * See the note in CLAUDE.md.
-         */
+    /*
+     * "wm manage" turns an ordinary widget into a toplevel and
+     * "wm forget" turns it back. Both are upstream's WmManageCmd and
+     * WmForgetCmd almost line for line -- they are generic Tk with one
+     * X-specific step, and it is the one that shrinks here.
+     *
+     * Upstream sets TK_HAS_WRAPPER and calls
+     * RemapWindows(winPtr, wmPtr->wrapperPtr), reparenting the frame
+     * into the wrapper it just made for it. **There are no wrappers in
+     * this port** -- a toplevel is its own window -- so the flag is not
+     * set and the reparent target is the ROOT, which is what being a
+     * toplevel means here. That is the same reduction as the embedding
+     * and stacking work above, and it is why this was smaller than the
+     * note that used to sit here claimed.
+     *
+     * Everything else is shared: Tk_IsManageable refuses anything that
+     * is not a frame, labelframe or toplevel (wm-manage-1.4, 1.5, 1.6
+     * want the *error*, for a ttk::frame, a text and a button);
+     * TkFocusSplit/TkFocusJoin move the focus record between the two
+     * focus domains; TkMapTopFrame makes the widget redraw itself as
+     * what it has become. A second "wm manage" on a toplevel, or a
+     * second "wm forget" on a child, is a no-op -- wm-manage-1.8 calls
+     * each twice on purpose.
+     */
+    case OPT_MANAGE: {
+        Tk_Window frameWin = (Tk_Window) winPtr;
+
+        if (objc != 3) {
+            Tcl_WrongNumArgs(interp, 2, objv, "window");
+            return TCL_ERROR;
+        }
+        if (Tk_IsTopLevel(frameWin))
+            return TCL_OK;
+        if (!Tk_IsManageable(frameWin)) {
+            Tcl_SetObjResult(interp, Tcl_ObjPrintf(
+                    "window \"%s\" is not manageable: must be a frame,"
+                    " labelframe or toplevel", Tk_PathName(frameWin)));
+            Tcl_SetErrorCode(interp, "TK", "WM", "MANAGE", (char *) NULL);
+            return TCL_ERROR;
+        }
+        TkFocusSplit(winPtr);
+        Tk_UnmapWindow(frameWin);
+        winPtr->flags |= TK_TOP_HIERARCHY|TK_TOP_LEVEL|TK_WIN_MANAGED;
+        if (winPtr->wmInfoPtr == NULL) {
+            TkWmNewWindow(winPtr);
+            TkWmMapWindow(winPtr);
+            Tk_UnmapWindow(frameWin);
+        }
+        winPtr->flags &= ~TK_MAPPED;
+        WmRemapWindow(winPtr, NULL);
+        TkMapTopFrame(frameWin);
         return TCL_OK;
+    }
+
+    case OPT_FORGET: {
+        Tk_Window frameWin = (Tk_Window) winPtr;
+
+        if (objc != 3) {
+            Tcl_WrongNumArgs(interp, 2, objv, "window");
+            return TCL_ERROR;
+        }
+        if (!Tk_IsTopLevel(frameWin))
+            return TCL_OK;
+        TkFocusJoin(winPtr);
+        Tk_UnmapWindow(frameWin);
+        /*
+         * TkWmDeadWindow on a window that is still alive is upstream's
+         * own call here, and it is what this port needs too: it unlinks
+         * the toplevel from firstWmPtr, cancels its pending geometry
+         * update, destroys its menubar, forgets its transients and ends
+         * with winPtr->wmInfoPtr = NULL -- so a later "wm manage" takes
+         * the TkWmNewWindow branch above and starts clean.
+         */
+        TkWmDeadWindow(winPtr);
+        winPtr->flags &= ~(TK_TOP_HIERARCHY|TK_TOP_LEVEL|TK_WIN_MANAGED);
+        WmRemapWindow(winPtr, winPtr->parentPtr);
+        /*
+         * The wm is no longer this window's geometry manager. Without
+         * this "winfo manager" still answers "wm" after the forget
+         * (wm-forget-2 reads it back at every step).
+         */
+        Tk_ManageGeometry(frameWin, NULL, NULL);
+        TkMapTopFrame(frameWin);
+        return TCL_OK;
+    }
 
     default:
         /*


### PR DESCRIPTION
Run 15 verified: 190 -> 186, four names removed and none added -- unixWm-50.3, tk-2.3, winfo-5.4, winfo-5.5 -- with winfo-13.2 staying fixed. Exactly the prediction, and the third round running where the per-file check found nothing unexpected.

Both commands were "return TCL_OK" -- silent no-ops -- under a note saying they were real generic-Tk reparenting and that doing them wrongly is worse than not doing them. The caution was right; the estimate was not, and reading upstream rather than the note settled it. WmManageCmd and WmForgetCmd are generic Tk with exactly one X-specific step: set TK_HAS_WRAPPER and reparent the frame into the wrapper just made for it.

There are no wrappers here, so the flag is not set and the reparent target is the ROOT -- which is what being a toplevel means in this port. Same reduction as embedding, stacking and the menubar. XReparentWindow in tkPlan9Init.c was already real.

Everything else was already present and is called unchanged: Tk_IsManageable, TkFocusSplit/TkFocusJoin, TkMapTopFrame, and TkWmDeadWindow -- which upstream calls on a window that is STILL ALIVE, and which this port's version is already right for: it unlinks from firstWmPtr, cancels the pending geometry update, destroys the menubar, forgets the transients, and ends with wmInfoPtr = NULL so a later wm manage takes the TkWmNewWindow branch and starts clean.

THREE OF THE EIGHT TESTS WANT THE REFUSAL, NOT THE ACTION. wm-manage-1.4, 1.5 and 1.6 call wm manage on a ttk::frame, a text and a button and require a non-zero return code; a silent no-op answers TCL_OK and fails them in the same direction as doing nothing. Tk_IsManageable is the whole of it. wm-manage-1.8 calls each command twice on purpose, so both are no-ops the second time.

New: sys/lib/tests/tk-manage-test.tcl.


Claude-Session: https://claude.ai/code/session_01WGAwvvTwDg2yknFkmZ3qzs